### PR TITLE
PW parser: correctly parse forces and stresses from QE 6.1

### DIFF
--- a/aiida_quantumespresso/parsers/raw_parser_pw.py
+++ b/aiida_quantumespresso/parsers/raw_parser_pw.py
@@ -1642,7 +1642,7 @@ def parse_pw_text_output(data, xml_data={}, structure_data={}, input_dict={}):
                     parsed_data['warnings'].append('Error while parsing Fermi energy from the output file.')
 
 
-            elif 'Forces acting on atoms (Ry/au):' in line:
+            elif ('Forces acting on atoms (Ry/au):' in line) or ('Forces acting on atoms (cartesian axes, Ry/au):' in line):
                 try:
                     forces = []
                     j = 0
@@ -1678,7 +1678,7 @@ def parse_pw_text_output(data, xml_data={}, structure_data={}, input_dict={}):
                 except Exception:
                     parsed_data['warnings'].append('Error while parsing total force.')
 
-            elif 'entering subroutine stress ...' in line:
+            elif ('entering subroutine stress ...' in line) or ('Computing stress (Cartesian axis) and pressure' in line):
                 try:
                     stress = []
                     for k in range (10+5*vdw_correction):


### PR DESCRIPTION
This should fix issue #1.

These are the strictest changes possible that appear to work with my version of QE 6.1. The change can be made simpler (and a bit more general) by parsing only for `Forces acting on atoms` and `Computing stress` respectively. Given that the capitalization of `Cartesian` has changed in between the commits referenced from #1, I would be in favor of this.

I'll add a further commit to implement this if requested.