### PR TITLE
Make structure relaxation optional in PwBandsWorkChain

### DIFF
--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from aiida.orm import Code
-from aiida.orm.data.base import Str, Float
+from aiida.orm.data.base import Str, Float, Bool
 from aiida.orm.data.parameter import ParameterData
 from aiida.orm.data.structure import StructureData
 from aiida.orm.data.array.bands import BandsData
@@ -12,7 +12,7 @@ from aiida.common.links import LinkType
 from aiida.common.exceptions import AiidaException, NotExistent
 from aiida.common.datastructures import calc_states
 from aiida.work.run import submit
-from aiida.work.workchain import WorkChain, ToContext, while_, append_
+from aiida.work.workchain import WorkChain, ToContext, while_, append_, if_
 from aiida.work.workfunction import workfunction
 from seekpath.aiidawrappers import get_path, get_explicit_k_path
 
@@ -37,13 +37,16 @@ class PwBandsWorkChain(WorkChain):
         spec.input('parameters', valid_type=ParameterData)
         spec.input('settings', valid_type=ParameterData)
         spec.input('options', valid_type=ParameterData, required=False)
+        spec.input('skip_relax', valid_type=Bool, default=Bool(False))
         spec.input('automatic_parallelization', valid_type=ParameterData, required=False)
         spec.input('group', valid_type=Str, required=False)
         spec.input_group('relax')
         spec.outline(
             cls.validate_inputs,
             cls.setup,
-            cls.run_relax,
+            if_(cls.should_do_relax)(
+                cls.run_relax,
+            ),
             cls.run_seekpath,
             cls.run_scf,
             cls.run_bands,
@@ -97,6 +100,12 @@ class PwBandsWorkChain(WorkChain):
             self.abort_nowait('you have to specify either the options or automatic_parallelization input')
             return
 
+    def should_do_relax(self):
+        """
+        If the skip_relax input is set to True we do not perform the relax calculation on the input structure
+        """
+        return not self.inputs.skip_relax.value
+
     def run_relax(self):
         """
         Run the PwRelaxWorkChain to run a relax PwCalculation
@@ -127,11 +136,14 @@ class PwBandsWorkChain(WorkChain):
         Run the relaxed structure through SeeKPath to get the new primitive structure, just in case
         the symmetry of the cell changed in the cell relaxation step
         """
-        try:
-            structure = self.ctx.workchain_relax.out.output_structure
-        except:
-            self.abort_nowait('the relax workchain did not output a output_structure node')
-            return
+        if self.inputs.skip_relax:
+            structure = self.inputs.structure
+        else:
+            try:
+                structure = self.ctx.workchain_relax.out.output_structure
+            except:
+                self.abort_nowait('the relax workchain did not output a output_structure node')
+                return
 
         result = seekpath_structure_analysis(structure)
 


### PR DESCRIPTION
Fixes #45 

With the new input skip_relax, users can set it to True
to skip the structure relaxation part and go straight to
the scf+bands calculation.