### PR TITLE
Properly detect which kpoints to use in PwBandsWorkChain

### DIFF
--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -153,12 +153,12 @@ class PwBandsWorkChain(WorkChain):
         inputs['parameters']['CONTROL']['calculation'] = calculation_mode
 
         # Construct a new kpoint mesh on the current structure or pass the static mesh
-        if 'kpoints_distance' in self.inputs:
+        if 'kpoints_mesh' in self.inputs:
+            kpoints_mesh = self.inputs.kpoints_mesh
+        else:
             kpoints_mesh = KpointsData()
             kpoints_mesh.set_cell_from_structure(structure)
             kpoints_mesh.set_kpoints_mesh_from_density(self.inputs.kpoints_distance.value)
-        else:
-            kpoints_mesh = self.inputs.kpoints_mesh
 
         # Final input preparation, wrapping dictionaries in ParameterData nodes
         inputs['kpoints'] = kpoints_mesh

--- a/tests/workflows/pw/bands.py
+++ b/tests/workflows/pw/bands.py
@@ -105,7 +105,7 @@ def execute(args):
         code=code,
         structure=structure,
         pseudo_family=Str(args.pseudo_family),
-        kpoints=kpoints,
+        kpoints_mesh=kpoints,
         parameters=ParameterData(dict=parameters),
         settings=ParameterData(dict=settings),
         options=ParameterData(dict=options),


### PR DESCRIPTION
Fixes #44 

The logic to use explicitly passes kpoints mesh in the inputs
or one generated from a kpoints distance was inverted, causing
the workchain to always create a mesh and ignore any explicit
kpoints meshes in the inputs