### PR TITLE
Properly use the options dictionary in the context proxy

### DIFF
--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -137,8 +137,8 @@ class PwBaseWorkChain(WorkChain):
 
         # If automatic parallelization is not enabled, we better make sure that the options satisfy minimum requirements
         if 'automatic_parallelization' not in self.inputs:
-            num_machines = self.inputs['options'].get('resources', {}).get('num_machines', None)
-            max_wallclock_seconds = self.inputs['options'].get('max_wallclock_seconds', None)
+            num_machines = self.ctx.inputs['_options'].get('resources', {}).get('num_machines', None)
+            max_wallclock_seconds = self.ctx.inputs['_options'].get('max_wallclock_seconds', None)
 
             if num_machines is None or max_wallclock_seconds is None:
                 self.abort_nowait("no automatic_parallelization requested, but the options do not specify both '{}' and '{}'"


### PR DESCRIPTION
Fixes #47 

Before it was trying to access the options from the inputs
as a dictionary, but since that was still a ParameterData
the get method was excepting.