### PR TITLE
Add new 'parser_options' option to parse atomic occupations

### DIFF
--- a/aiida_quantumespresso/calculations/__init__.py
+++ b/aiida_quantumespresso/calculations/__init__.py
@@ -702,7 +702,7 @@ class BasePwCpInputGenerator(object):
         try:
             Parserclass = self.get_parserclass()
             parser = Parserclass(self)
-            parser_opts = parser.get_parser_settings_key()
+            parser_opts = parser.get_parser_settings_key().upper()
             settings_dict.pop(parser_opts)
         except (KeyError, AttributeError):
             # the key parser_opts isn't inside the dictionary

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -45,13 +45,14 @@ class PwParser(Parser):
         successful = True
 
         # Load the input dictionary
-        settings = self._calc.inp.settings.get_dict()
         parameters = self._calc.inp.parameters.get_dict()
 
-        # Look for eventual flags of the parser
+        # Look for optional settings input node and potential 'parser_options' dictionary within it
         try:
+            settings = self._calc.inp.settings.get_dict()
             parser_opts = settings[self.get_parser_settings_key()]
         except (AttributeError, KeyError):
+            settings = {}
             parser_opts = {}
 
         # Check that the retrieved folder is there

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -191,6 +191,13 @@ class PwParser(Parser):
                 new_nodes_list += [('output_band', the_bands_data)]
                 out_dict['linknames_band'] = ['output_band']
 
+        # Separate the atomic_occupations dictionary in its own node if it is present
+        atomic_occupations = out_dict.get('atomic_occupations', {})
+        if atomic_occupations:
+            out_dict.pop('atomic_occupations')
+            atomic_occupations_node = ParameterData(dict=atomic_occupations)
+            new_nodes_list.append(('output_atomic_occupations', atomic_occupations_node))
+
         output_params = ParameterData(dict=out_dict)
         new_nodes_list.append((self.get_linkname_outparams(), output_params))
 

--- a/aiida_quantumespresso/parsers/raw_parser_pw.py
+++ b/aiida_quantumespresso/parsers/raw_parser_pw.py
@@ -1698,6 +1698,38 @@ def parse_pw_text_output(data, xml_data={}, structure_data={}, input_dict={}, pa
                 except Exception:
                     parsed_data['warnings'].append('Error while parsing stress tensor.')
 
+
+    # If specified in the parser options, parse the atomic occupations
+    parse_atomic_occupations = parser_opts.get('atomic_occupations', False)
+
+    if parse_atomic_occupations:
+
+        atomic_occupations = {}
+        hubbard_blocks = split = data.split('LDA+U parameters')
+
+        for line in hubbard_blocks[-1].split('\n'):
+
+            if 'Tr[ns(na)]' in line:
+
+                values = line.split('=')
+                atomic_index = values[0].split()[1]
+                occupations = values[1].split()
+
+                if len(occupations) == 1:
+                    atomic_occupations[atomic_index] = {
+                        'total': occupations[0]
+                    }
+                elif len(occupations) == 3:
+                    atomic_occupations[atomic_index] = {
+                        'up': occupations[0],
+                        'down': occupations[1],
+                        'total': occupations[2]
+                    }
+                else:
+                    continue
+
+        parsed_data['atomic_occupations'] =  atomic_occupations
+
     return parsed_data, trajectory_data, critical_warnings.values()
 
 def parse_QE_errors(lines,count,warnings):

--- a/aiida_quantumespresso/parsers/raw_parser_pw.py
+++ b/aiida_quantumespresso/parsers/raw_parser_pw.py
@@ -105,7 +105,7 @@ def parse_raw_output(out_file, input_dict, parser_opts=None, xml_file=None, dir_
 
     # parse
     try:
-        out_data,trajectory_data,critical_messages = parse_pw_text_output(out_lines,xml_data,structure_data,input_dict)
+        out_data,trajectory_data,critical_messages = parse_pw_text_output(out_lines, xml_data, structure_data, input_dict, parser_opts)
     except QEOutputParsingError as e:
         if not finished_run: # I try to parse it as much as possible
             parser_info['parser_warnings'].append('Error while parsing the output file')
@@ -1080,7 +1080,7 @@ def parse_pw_xml_output(data,dir_with_bands=None):
 
     return parsed_data,structure_dict,bands_dict
 
-def parse_pw_text_output(data, xml_data={}, structure_data={}, input_dict={}):
+def parse_pw_text_output(data, xml_data={}, structure_data={}, input_dict={}, parser_opts={}):
     """
     Parses the text output of QE-PWscf.
 
@@ -1088,6 +1088,7 @@ def parse_pw_text_output(data, xml_data={}, structure_data={}, input_dict={}):
     :param xml_data: the dictionary with the keys read from xml.
     :param structure_data: dictionary, coming from the xml, with info on the structure
     :param input_dict: dictionary with the input parameters
+    :param parser_opts: the parser options from the settings input parameter node
 
     :return parsed_data: dictionary with key values, referring to quantities
                          at the last scf step.

--- a/docs/source/user_guide/calculation_plugins/pw.rst
+++ b/docs/source/user_guide/calculation_plugins/pw.rst
@@ -24,9 +24,15 @@ Inputs
   Input parameters of pw.x, as a nested dictionary, mapping the input of QE.
   Example::
     
-      {"CONTROL":{"calculation":"scf"},
-       "ELECTRONS":{"ecutwfc":30.,"ecutrho":100.},
-      }
+    {
+        "CONTROL":{
+            "calculation":"scf"
+        },
+        "ELECTRONS":{
+            "ecutwfc":30.,
+            "ecutrho":100.
+        },
+    }
 
   A full list of variables and their meaning is found in the `pw.x documentation`_.
 
@@ -34,19 +40,19 @@ Inputs
 
   Following keywords, related to the structure or to the file paths, are already taken care of by AiiDA::
     
-      'CONTROL', 'pseudo_dir': pseudopotential directory
-      'CONTROL', 'outdir': scratch directory
-      'CONTROL', 'prefix': file prefix
-      'SYSTEM', 'ibrav': cell shape
-      'SYSTEM', 'celldm': cell dm
-      'SYSTEM', 'nat': number of atoms
-      'SYSTEM', 'ntyp': number of species
-      'SYSTEM', 'a': cell parameters
-      'SYSTEM', 'b': cell parameters
-      'SYSTEM', 'c': cell parameters
-      'SYSTEM', 'cosab': cell parameters
-      'SYSTEM', 'cosac': cell parameters
-      'SYSTEM', 'cosbc': cell parameters
+    'CONTROL', 'pseudo_dir': pseudopotential directory
+    'CONTROL', 'outdir': scratch directory
+    'CONTROL', 'prefix': file prefix
+    'SYSTEM', 'ibrav': cell shape
+    'SYSTEM', 'celldm': cell dm
+    'SYSTEM', 'nat': number of atoms
+    'SYSTEM', 'ntyp': number of species
+    'SYSTEM', 'a': cell parameters
+    'SYSTEM', 'b': cell parameters
+    'SYSTEM', 'c': cell parameters
+    'SYSTEM', 'cosab': cell parameters
+    'SYSTEM', 'cosac': cell parameters
+    'SYSTEM', 'cosbc': cell parameters
 
   Those keywords should not be specified, otherwise the submission will fail.
      
@@ -119,7 +125,7 @@ Quantum Espresso namelists, additional parameters can be specified in the 'setti
 After having defined the content of ``settings_dict``, you can use
 it as input of a calculation ``calc`` by doing::
 
-  calc.use_settings(ParameterData(dict=settings_dict))
+    calc.use_settings(ParameterData(dict=settings_dict))
 
 The different options are described below.
 
@@ -134,9 +140,9 @@ parsing is completed. This parsing of bands is done by default, but if you are n
 in the output bands node and want to prevent the unnecessary download of the required files,
 you can switch the parsing of by setting the following parameter in the settings dictionary::
 
-  settings_dict = {
-      'no_bands': True
-  }
+    settings_dict = {
+        'no_bands': True
+    }
 
 Fixing some atom coordinates
 ............................
@@ -145,15 +151,15 @@ If you want to ask QE to keep some coordinates of some atoms fixed
 0 or 1 values after the atomic coordinates), you can specify the following
 list of lists::
 
-  settings_dict = {
-      'fixed_coords': [
-          [True,False,False],
-          [True,True,True],
-          [False,False,False],
-          [False,False,False],
-          [False,False,False],
-          ],
-  }
+    settings_dict = {
+        'fixed_coords': [
+            [True, False, False],
+            [True, True, True],
+            [False, False, False],
+            [False, False, False],
+            [False, False, False]
+        ],
+    }
 
 the list of lists (of booleans) must be of length N times 3, where N is the 
 number of sites (i.e., atoms) in the input structure. ``False`` means that
@@ -167,9 +173,9 @@ equivalent by symmetry). Instead of generating it manually, you can
 pass a usual KpointsData specifying a mesh, and then pass the following 
 variable::
 
-  settings_dict = {  
-      'force_kpoints_list': True,
-  }
+    settings_dict = {
+        'force_kpoints_list': True,
+    }
 
 Gamma-only calculation
 ......................
@@ -177,9 +183,9 @@ If you are using only the Gamma point (a grid of 1x1x1 without offset), you
 may want to use the following flag to tell QE to use the gamma-only routines
 (typically twice faster)::
 
-  settings_dict = {  
-      'gamma_only': False,
-  }
+    settings_dict = {
+        'gamma_only': False,
+    }
 
 Initialization only
 ...................
@@ -188,9 +194,9 @@ part (e.g. to parse the number of symmetries detected, the number of G vectors,
 of k-points, ...)
 In this case, by specifying::
 
-  settings_dict = {  
-      'only_initialization': True,
-  }
+    settings_dict = {
+        'only_initialization': True,
+    }
 
 a file named ``aiida.EXIT`` (where ``aiida`` is the prefix) will be also generated,
 asking QE to exit cleanly after the initialisation.
@@ -203,9 +209,9 @@ The QE plugin will automatically figure out which namelists should be specified
 If you want to override the automatic list, you can specify the list
 of namelists you want to produce as follows::
 
-  settings_dict = {  
-      'namelists': ['CONTROL', 'SYSTEM', 'ELECTRONS', 'IONS', 'CELL', 'OTHERNL'],
-  }
+    settings_dict = {
+        'namelists': ['CONTROL', 'SYSTEM', 'ELECTRONS', 'IONS', 'CELL', 'OTHERNL'],
+    }
 
 
 Adding command-line options
@@ -214,9 +220,9 @@ If you want to add command-line options to the executable (particularly
 relevant e.g. to tune the parallelization level), you can pass each option 
 as a string in a list, as follows::
 
-  settings_dict = {  
-      'cmdline': ['-nk', '4'],
-  }
+    settings_dict = {
+        'cmdline': ['-nk', '4'],
+    }
 
 Using symlinks for the restarts
 ...............................
@@ -231,9 +237,9 @@ scratch directory of your computing cluster. If you prefer to use symlinks,
 pass::
 
 
-  settings_dict = {  
-      'parent_folder_symlink': True,
-  }
+    settings_dict = {
+        'parent_folder_symlink': True,
+    }
 
 .. note:: Use this flag ONLY IF YOU KNOW WHAT YOU ARE DOING. In particular, 
   if you run a NSCF with this flag after a SCF calculation, the scratch directory
@@ -248,6 +254,26 @@ retrieve (and preserve in the AiiDA repository in the long term), you can add
 those files as a list as follows (here in the case of a file named
 ``testfile.txt``)::
 
-  settings_dict = {  
-    'additional_retrieve_list': ['testfile.txt'],
-  }
+    settings_dict = {
+        'additional_retrieve_list': ['testfile.txt'],
+    }
+
+
+Parser options
+--------------
+To customize the parsing, the ``settings`` input ``ParameterData`` node provides
+the special key ``parser_options`` which has the options discussed below.
+
+Parsing atomic occupations
+..........................
+For DFT+U calculations, pw.x will also print atomic electron occupations to the standard
+output. This flag enables or disables the parsing of this information into a ``ParameterData``
+output node with the link name ``atomic_occupations``. The value should be a boolean, with
+``False`` being the default. Setting it to ``True`` will enable the parsing of the atomic
+occupations::
+
+    settings_dict = {
+        'parser_options': {
+            'parse_atomic_occupations': True,
+        }
+    }


### PR DESCRIPTION
Fixes #54 

We provide a new key for the 'parser_options' key in the settings input.
When the user sets 'atomic_occupations' to True, the parser will attempt
to parse the atomic occupations which will be stored in a separate ouput
ParameterData node labeled 'output_atomic_occupations'. Note that this
information is only printed for DFT+U calculations.