### PR TITLE
Minor cleanup to workchains related to clean_workdir

### DIFF
--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -110,6 +110,12 @@ class PwBaseWorkChain(WorkChain):
         """
         Validate inputs that may depend on each other
         """
+        if 'CONTROL'not in self.ctx.inputs.parameters:
+            self.ctx.inputs.parameters['CONTROL'] = {}
+
+        if 'calculation' not in self.ctx.inputs.parameters['CONTROL']:
+            self.ctx.inputs.parameters['CONTROL']['calculation'] = 'scf'
+
         if 'parent_folder' in self.inputs:
             self.ctx.inputs.parent_folder = self.inputs.parent_folder
             self.ctx.inputs.parameters['CONTROL']['restart_mode'] = 'restart'

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -32,7 +32,7 @@ class PwRelaxWorkChain(WorkChain):
         spec.input('kpoints_distance', valid_type=Float, default=Float(0.2))
         spec.input('vdw_table', valid_type=SinglefileData, required=False)
         spec.input('parameters', valid_type=ParameterData)
-        spec.input('settings', valid_type=ParameterData)
+        spec.input('settings', valid_type=ParameterData, required=False)
         spec.input('options', valid_type=ParameterData, required=False)
         spec.input('automatic_parallelization', valid_type=ParameterData, required=False)
         spec.input('final_scf', valid_type=Bool, default=Bool(False))
@@ -71,7 +71,6 @@ class PwRelaxWorkChain(WorkChain):
             'code': self.inputs.code,
             'structure': self.inputs.structure,
             'parameters': self.inputs.parameters.get_dict(),
-            'settings': self.inputs.settings,
             'clean_workdir': self.inputs.clean_workdir,
         }
 
@@ -96,6 +95,9 @@ class PwRelaxWorkChain(WorkChain):
         # Set the correct relaxation scheme in the input parameters
         if 'CONTROL' not in self.ctx.inputs['parameters']:
             self.ctx.inputs['parameters']['CONTROL'] = {}
+
+        if 'settings' in self.inputs:
+            self.ctx.inputs['settings'] = self.inputs.settings
 
         # If options set, add it to the default inputs
         if 'options' in self.inputs:

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -141,7 +141,7 @@ class PwRelaxWorkChain(WorkChain):
         """
         self.ctx.iteration += 1
 
-        inputs = dict(self.ctx.inputs)
+        inputs = deepcopy(self.ctx.inputs)
         inputs['parameters'] = ParameterData(dict=inputs['parameters'])
 
         # Construct a new kpoint mesh on the current structure or pass the static mesh
@@ -215,7 +215,7 @@ class PwRelaxWorkChain(WorkChain):
         """
         Run the PwBaseWorkChain to run a final scf PwCalculation for the relaxed structure
         """
-        inputs = dict(self.ctx.inputs)
+        inputs = deepcopy(self.ctx.inputs)
 
         parameters = inputs['parameters']
         parameters['CONTROL']['calculation'] = 'scf'

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -40,6 +40,7 @@ class PwRelaxWorkChain(WorkChain):
         spec.input('meta_converge', valid_type=Bool, default=Bool(True))
         spec.input('relaxation_scheme', valid_type=Str, default=Str('vc-relax'))
         spec.input('volume_convergence', valid_type=Float, default=Float(0.01))
+        spec.input('clean_workdir', valid_type=Bool, default=Bool(False))
         spec.outline(
             cls.setup,
             cls.validate_inputs,
@@ -70,7 +71,8 @@ class PwRelaxWorkChain(WorkChain):
             'code': self.inputs.code,
             'structure': self.inputs.structure,
             'parameters': self.inputs.parameters.get_dict(),
-            'settings': self.inputs.settings
+            'settings': self.inputs.settings,
+            'clean_workdir': self.inputs.clean_workdir,
         }
 
         # We expect either a KpointsData with given mesh or a desired distance between k-points

--- a/tests/workflows/pw/base.py
+++ b/tests/workflows/pw/base.py
@@ -78,18 +78,10 @@ def execute(args):
     kpoints.set_kpoints_mesh(args.kpoints)
 
     parameters = {
-        'CONTROL': {
-            'restart_mode': 'from_scratch',
-            'calculation': 'scf',
-            'tstress': True,
-        },
         'SYSTEM': {
-            'ecutwfc': 40.,
-            'ecutrho': 320.,
+            'ecutwfc': 30.,
+            'ecutrho': 240.,
         },
-        'ELECTRONS': {
-            'conv_thr': 1.e-10,
-        }
     }
     
     automatic_parallelization = {

--- a/tests/workflows/pw/base.py
+++ b/tests/workflows/pw/base.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import argparse
 from aiida.common.exceptions import NotExistent
-from aiida.orm.data.base import Str
+from aiida.orm.data.base import Bool, Str
 from aiida.orm.data.parameter import ParameterData
 from aiida.orm.data.structure import StructureData
 from aiida.orm.data.array.kpoints import KpointsData
@@ -42,6 +42,10 @@ def parser_setup():
     parser.add_argument(
         '-w', type=int, default=1800, dest='max_wallclock_seconds',
         help='the maximum wallclock time in seconds to set for the calculations. (default: %(default)d)'
+    )
+    parser.add_argument(
+        '-x', '--clean-workdir', action="store_true", dest='clean_workdir',
+        help='clean the remote folder of all the launched calculations after completion of the workchain'
     )
 
     return parser
@@ -94,15 +98,19 @@ def execute(args):
         'max_wallclock_seconds': args.max_wallclock_seconds
     }
 
-    run(
-        PwBaseWorkChain,
-        code=code,
-        structure=structure,
-        pseudo_family=Str(args.pseudo_family),
-        kpoints=kpoints,
-        parameters=ParameterData(dict=parameters),
-        automatic_parallelization=ParameterData(dict=automatic_parallelization)
-    )
+    inputs = {
+        'code': code,
+        'structure': structure,
+        'pseudo_family': Str(args.pseudo_family),
+        'kpoints': kpoints,
+        'parameters': ParameterData(dict=parameters),
+        'automatic_parallelization': ParameterData(dict=automatic_parallelization),
+    }
+
+    if args.clean_workdir:
+        inputs['clean_workdir'] = Bool(True)
+
+    run(PwBaseWorkChain, **inputs)
 
 
 def main():

--- a/tests/workflows/pw/relax.py
+++ b/tests/workflows/pw/relax.py
@@ -78,20 +78,10 @@ def execute(args):
     kpoints.set_kpoints_mesh(args.kpoints)
 
     parameters = {
-        'CONTROL': {
-            'restart_mode': 'from_scratch',
-        },
         'SYSTEM': {
             'ecutwfc': 30.,
             'ecutrho': 240.,
         },
-    }
-    settings = {}
-    options  = {
-        'resources': {
-            'num_machines': 1,
-        },
-        'max_wallclock_seconds': args.max_wallclock_seconds,
     }
     
     automatic_parallelization = {
@@ -106,8 +96,6 @@ def execute(args):
         'pseudo_family': Str(args.pseudo_family),
         'kpoints': kpoints,
         'parameters': ParameterData(dict=parameters),
-        'settings': ParameterData(dict=settings),
-        'options': ParameterData(dict=options),
         'automatic_parallelization': ParameterData(dict=automatic_parallelization)
     }
 

--- a/tests/workflows/pw/relax.py
+++ b/tests/workflows/pw/relax.py
@@ -36,7 +36,11 @@ def parser_setup():
         help='the node id of the structure'
     )
     parser.add_argument(
-        '-w', type=int, default=1800, dest='max_wallclock_seconds',
+        '-m', type=int, default=1, dest='max_num_machines',
+        help='the maximum number of machines (nodes) to use for the calculations. (default: %(default)d)'
+    )
+    parser.add_argument(
+        '-w', type=int, default=3600, dest='max_wallclock_seconds',
         help='the maximum wallclock time in seconds to set for the calculations. (default: %(default)d)'
     )
     parser.add_argument(
@@ -91,9 +95,9 @@ def execute(args):
     }
     
     automatic_parallelization = {
-        'max_num_machines': 1,
-        'target_time_seconds': 1800,
-        'max_wallclock_seconds': 4 * 3600
+        'max_num_machines': args.max_num_machines,
+        'target_time_seconds': 0.5 * args.max_wallclock_seconds,
+        'max_wallclock_seconds': args.max_wallclock_seconds
     }
 
     inputs = {


### PR DESCRIPTION
Also took the opportunity to clean some of the interface of the `PwRelaxWorkChain` and the input validation, as well as that of the `PwBaseWorkChain`. As a result I could also cleanup the test scripts and add the option to toggle the `clean_workdir` input from the command line