### PR TITLE
Fix bug when passing both final_scf and clean_workdir to PwRelaxWorkDir

### DIFF
--- a/aiida_quantumespresso/utils/defaults/calculation/__init__.py
+++ b/aiida_quantumespresso/utils/defaults/calculation/__init__.py
@@ -2,6 +2,7 @@
 from aiida.common.extendeddicts import AttributeDict
 
 pw = AttributeDict({
+    'conv_thr': 1e-6,
     'degauss': 0.,
     'diagonalization': 'david',
     'electron_maxstep': 100,

--- a/tests/workflows/pw/base.py
+++ b/tests/workflows/pw/base.py
@@ -44,7 +44,7 @@ def parser_setup():
         help='the maximum wallclock time in seconds to set for the calculations. (default: %(default)d)'
     )
     parser.add_argument(
-        '-x', '--clean-workdir', action="store_true", dest='clean_workdir',
+        '-x', '--clean-workdir', action='store_true', dest='clean_workdir',
         help='clean the remote folder of all the launched calculations after completion of the workchain'
     )
 

--- a/tests/workflows/pw/relax.py
+++ b/tests/workflows/pw/relax.py
@@ -44,7 +44,7 @@ def parser_setup():
         help='the maximum wallclock time in seconds to set for the calculations. (default: %(default)d)'
     )
     parser.add_argument(
-        '-x', '--clean-workdir', action="store_true", dest='clean_workdir',
+        '-x', '--clean-workdir', action='store_true', dest='clean_workdir',
         help='clean the remote folder of all the launched calculations after completion of the workchain'
     )
 
@@ -96,7 +96,8 @@ def execute(args):
         'pseudo_family': Str(args.pseudo_family),
         'kpoints': kpoints,
         'parameters': ParameterData(dict=parameters),
-        'automatic_parallelization': ParameterData(dict=automatic_parallelization)
+        'automatic_parallelization': ParameterData(dict=automatic_parallelization),
+        'final_scf': Bool(True)
     }
 
     if args.clean_workdir:


### PR DESCRIPTION
Fixes #58 

When one passes both `final_scf` and `clean_workdir` to the `PwRelaxWorkChain`
the final scf calculation would fail. This is because the `clean_workdir`
input was just funneled to the `PwBaseWorkChain`, each one of which would
therefore be cleaned as soon as it was finished, but the workchain that
would run the final scf calculation would depend on the remote data of
the previous workchain, which would already have been cleaned.

To fix this, the `clean_workdir` option should not be passed to the
`PwBaseWorkChain` but the `PwRelaxWorkChain` itself should take care of
cleaning all the calculations of its sub workchains at the end and
only at the end of its own execution