### PR TITLE
Remove calculation state check from parse_with_retrieved

### DIFF
--- a/aiida_quantumespresso/parsers/basicpw.py
+++ b/aiida_quantumespresso/parsers/basicpw.py
@@ -42,12 +42,6 @@ class BasicpwParser(Parser):
 
         successful = True
 
-        # check if I'm not to overwrite anything
-        #state = self._calc.get_state()
-        #if state != calc_states.PARSING:
-        #    raise InvalidOperation("Calculation not in {} state"
-        #                           .format(calc_states.PARSING) )
-
         # retrieve the input parameter
         calc_input = self._calc.inp.parameters
 

--- a/aiida_quantumespresso/parsers/cp.py
+++ b/aiida_quantumespresso/parsers/cp.py
@@ -41,12 +41,6 @@ class CpParser(Parser):
 
         successful = True
 
-        # check if I'm not to overwrite anything
-        state = self._calc.get_state()
-        if state != calc_states.PARSING:
-            raise InvalidOperation("Calculation not in {} state"
-                                   .format(calc_states.PARSING))
-
         # get the input structure
         input_structure = self._calc.inp.structure
 

--- a/aiida_quantumespresso/parsers/dos.py
+++ b/aiida_quantumespresso/parsers/dos.py
@@ -51,11 +51,6 @@ class DosParser(Parser):
         successful = True
         new_nodes_list = []
 
-        # check if I'm not to overwrite anything
-        state = self._calc.get_state()
-        if state != calc_states.PARSING:
-           raise InvalidOperation("Calculation not in {} state")
-
         try:
             out_folder = self._calc.get_retrieved_node()
         except KeyError:

--- a/aiida_quantumespresso/parsers/matdyn.py
+++ b/aiida_quantumespresso/parsers/matdyn.py
@@ -39,12 +39,6 @@ class MatdynParser(Parser):
         # suppose at the start that the job is successful
         successful = True
         new_nodes_list = []
-
-        # check if I'm not to overwrite anything
-        state = self._calc.get_state()
-        if state != calc_states.PARSING:
-            raise InvalidOperation("Calculation not in {} state"
-                                   .format(calc_states.PARSING) )
         
         # Check that the retrieved folder is there 
         try:

--- a/aiida_quantumespresso/parsers/neb.py
+++ b/aiida_quantumespresso/parsers/neb.py
@@ -45,12 +45,6 @@ class NebParser(Parser):
         import copy
         
         successful = True
-        
-        # check if I'm not to overwrite anything
-        #state = self._calc.get_state()
-        #if state != calc_states.PARSING:
-        #    raise InvalidOperation("Calculation not in {} state"
-        #                           .format(calc_states.PARSING) )
 
         # look for eventual flags of the parser
         try:

--- a/aiida_quantumespresso/parsers/ph.py
+++ b/aiida_quantumespresso/parsers/ph.py
@@ -34,12 +34,6 @@ class PhParser(Parser):
         
         successful = True
         
-        # check if I'm not to overwrite anything
-        state = self._calc.get_state()
-        if state != calc_states.PARSING:
-            raise InvalidOperation("Calculation not in {} state"
-                                   .format(calc_states.PARSING) )
-        
         # retrieve the whole list of input links
         calc_input_parameterdata = self._calc.get_inputs(node_type=ParameterData,
                                                          also_labels=True)

--- a/aiida_quantumespresso/parsers/projwfc.py
+++ b/aiida_quantumespresso/parsers/projwfc.py
@@ -287,12 +287,6 @@ class ProjwfcParser(Parser):
             successful = False
             new_nodes_list = []
 
-            # check if I'm not to overwrite anything
-            state = self._calc.get_state()
-            if state != calc_states.PARSING:
-               raise InvalidOperation("Calculation not in {} state"
-                                      .format(calc_states.PARSING))
-
             # Check that the retrieved folder is there
             try:
                 out_folder = self._calc.get_retrieved_node()

--- a/aiida_quantumespresso/parsers/q2r.py
+++ b/aiida_quantumespresso/parsers/q2r.py
@@ -32,12 +32,6 @@ class Q2rParser(Parser):
 
         # suppose at the start that the job is successful
         successful = True
-
-        # check if I'm not to overwrite anything
-        state = self._calc.get_state()
-        if state != calc_states.PARSING:
-            raise InvalidOperation("Calculation not in {} state"
-                                   .format(calc_states.PARSING) )
         
         # Check that the retrieved folder is there 
         try:


### PR DESCRIPTION
Fixes #70 

The parsing function does not store any nodes as this is
the responsability of the exec manager which also calls
this function and should therefore be responsible for
ensuring that the calculation is put in the correct state
prior to parsing. Removing the checks from the plugins
also allows for easier testing of the parse function.