### PR TITLE
Return result of automatic parallelization as output node

### DIFF
--- a/aiida_quantumespresso/workflows/ph/base.py
+++ b/aiida_quantumespresso/workflows/ph/base.py
@@ -41,8 +41,8 @@ class PhBaseWorkChain(BaseRestartWorkChain):
         super(PhBaseWorkChain, cls).define(spec)
         spec.input('code', valid_type=Code)
         spec.input('qpoints', valid_type=KpointsData)
-        spec.input('parameters', valid_type=ParameterData)
         spec.input('parent_calc', valid_type=PwCalculation)
+        spec.input('parameters', valid_type=ParameterData, required=False)
         spec.input('settings', valid_type=ParameterData, required=False)
         spec.input('options', valid_type=ParameterData, required=False)
         spec.outline(
@@ -68,8 +68,12 @@ class PhBaseWorkChain(BaseRestartWorkChain):
         self.ctx.inputs_raw = AttributeDict({
             'code': self.inputs.code,
             'qpoints': self.inputs.qpoints,
-            'parameters': self.inputs.parameters.get_dict(),
         })
+
+        if 'parameters' in self.inputs:
+            self.ctx.inputs_raw.parameters = self.inputs.parameters.get_dict()
+        else:
+            self.ctx.inputs_raw.parameters = {}
 
         if 'INPUTPH' not in self.ctx.inputs_raw.parameters:
             self.ctx.inputs_raw.parameters['INPUTPH'] = {}

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -227,8 +227,9 @@ class PwBaseWorkChain(BaseRestartWorkChain):
         # Get automated parallelization settings
         parallelization = get_pw_parallelization_parameters(calculation, **self.ctx.automatic_parallelization)
 
-        self.report('Determined the following resource settings from automatic_parallelization input: {}'
-            .format(parallelization))
+        node = ParameterData(dict=parallelization)
+        self.out('automatic_parallelization', node)
+        self.report('results of automatic parallelization in {}<{}>'.format(node.__class__.__name__, node.pk))
 
         options = self.ctx.inputs_raw._options
         base_resources = options.get('resources', {})

--- a/tests/workflows/pw/band_structure.py
+++ b/tests/workflows/pw/band_structure.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env runaiida
 # -*- coding: utf-8 -*-
-
 import argparse
 from aiida.common.exceptions import NotExistent
 from aiida.orm.data.base import Str
@@ -10,6 +9,7 @@ from aiida.orm.data.structure import StructureData
 from aiida.orm.data.array.kpoints import KpointsData
 from aiida.orm.utils import WorkflowFactory
 from aiida.work.run import run
+from aiida_quantumespresso.utils.resources import get_default_options
 
 PwBandStructureWorkChain = WorkflowFactory('quantumespresso.pw.band_structure')
 
@@ -30,7 +30,7 @@ def parser_setup():
     )
     parser.add_argument(
         '-p', type=str, required=True, dest='pseudo_family',
-        help='the name of pseudo family to use'
+        help='the name of the pseudo family to use'
     )
     parser.add_argument(
         '-s', type=int, required=True, dest='structure',
@@ -74,13 +74,14 @@ def execute(args):
         print "The provided pk {} for the structure does not correspond to StructureData, aborting...".format(args.parent_calc)
         return
 
-    run(
-        PwBandStructureWorkChain,
-        code=code,
-        structure=structure,
-        pseudo_family=Str(args.pseudo_family),
-        protocol=Str(args.protocol)
-    )
+    inputs = {
+        'code': code,
+        'structure': structure,
+        'pseudo_family': Str(args.pseudo_family),
+        'protocol': Str(args.protocol),
+    }
+
+    run(PwBandStructureWorkChain, **inputs)
 
 
 def main():
@@ -88,7 +89,7 @@ def main():
     Setup the parser to retrieve the command line arguments and pass them to the main execution function.
     """
     parser = parser_setup()
-    args   = parser.parse_args()
+    args = parser.parse_args()
     result = execute(args)
 
 

--- a/tests/workflows/pw/bands.py
+++ b/tests/workflows/pw/bands.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env runaiida
 # -*- coding: utf-8 -*-
-
 import argparse
 from aiida.common.exceptions import NotExistent
 from aiida.orm.data.base import Str, Float
@@ -9,6 +8,7 @@ from aiida.orm.data.structure import StructureData
 from aiida.orm.data.array.kpoints import KpointsData
 from aiida.orm.utils import WorkflowFactory
 from aiida.work.run import run
+from aiida_quantumespresso.utils.resources import get_default_options
 
 PwBandsWorkChain = WorkflowFactory('quantumespresso.pw.bands')
 
@@ -21,24 +21,32 @@ def parser_setup():
         description='Run the PwBandsWorkChain for a given input structure',
     )
     parser.add_argument(
-        '-k', nargs=3, type=int, default=[2, 2, 2], dest='kpoints', metavar='Q',
-        help='define the q-points mesh. (default: %(default)s)'
-    )
-    parser.add_argument(
         '-c', type=str, required=True, dest='codename',
         help='the name of the AiiDA code that references QE pw.x'
     )
     parser.add_argument(
+        '-k', nargs=3, type=int, default=[2, 2, 2], dest='kpoints', metavar='K',
+        help='define the k-points mesh. (default: %(default)s)'
+    )
+    parser.add_argument(
         '-p', type=str, required=True, dest='pseudo_family',
-        help='the name of pseudo family to use'
+        help='the name of the pseudo family to use'
     )
     parser.add_argument(
         '-s', type=int, required=True, dest='structure',
         help='the node id of the structure'
     )
     parser.add_argument(
+        '-m', type=int, default=1, dest='max_num_machines',
+        help='the maximum number of machines (nodes) to use for the calculations. (default: %(default)d)'
+    )
+    parser.add_argument(
         '-w', type=int, default=1800, dest='max_wallclock_seconds',
         help='the maximum wallclock time in seconds to set for the calculations. (default: %(default)d)'
+    )
+    parser.add_argument(
+        '-a', '--automatic-parallelization', action='store_true', dest='automatic_parallelization',
+        help='enable the automatic parallelization option of the workchain'
     )
 
     return parser
@@ -71,47 +79,38 @@ def execute(args):
     kpoints.set_kpoints_mesh(args.kpoints)
 
     parameters = {
-        'CONTROL': {
-            'restart_mode': 'from_scratch',
-        },
         'SYSTEM': {
             'ecutwfc': 30.,
             'ecutrho': 240.,
         },
     }
-    settings = {}
-    options  = {
-        'resources': {
-            'num_machines': 1,
-        },
-        'max_wallclock_seconds': args.max_wallclock_seconds,
-    }
 
     relax_inputs = {
         'kpoints_distance': Float(0.2),
         'parameters': ParameterData(dict=parameters),
-        'settings': ParameterData(dict=settings),
-        'options': ParameterData(dict=options)
-    }
-    
-    automatic_parallelization = {
-        'max_num_machines': 1,
-        'target_time_seconds': 1800,
-        'max_wallclock_seconds': 4 * 3600
     }
 
-    run(
-        PwBandsWorkChain,
-        code=code,
-        structure=structure,
-        pseudo_family=Str(args.pseudo_family),
-        kpoints_mesh=kpoints,
-        parameters=ParameterData(dict=parameters),
-        settings=ParameterData(dict=settings),
-        options=ParameterData(dict=options),
-        automatic_parallelization=ParameterData(dict=automatic_parallelization),
-        relax=relax_inputs
-    )
+    inputs = {
+        'code': code,
+        'structure': structure,
+        'pseudo_family': Str(args.pseudo_family),
+        'kpoints_mesh': kpoints,
+        'parameters': ParameterData(dict=parameters),
+        'relax': relax_inputs
+    }
+
+    if args.automatic_parallelization:
+        automatic_parallelization = {
+            'max_num_machines': args.max_num_machines,
+            'target_time_seconds': 0.5 * args.max_wallclock_seconds,
+            'max_wallclock_seconds': args.max_wallclock_seconds
+        }
+        inputs['automatic_parallelization'] = ParameterData(dict=automatic_parallelization)
+    else:
+        options = get_default_options(args.max_num_machines, args.max_wallclock_seconds)
+        inputs['options'] = ParameterData(dict=options)
+
+    run(PwBandsWorkChain, **inputs)
 
 
 def main():
@@ -119,7 +118,7 @@ def main():
     Setup the parser to retrieve the command line arguments and pass them to the main execution function.
     """
     parser = parser_setup()
-    args   = parser.parse_args()
+    args = parser.parse_args()
     result = execute(args)
 
 

--- a/tests/workflows/pw/relax.py
+++ b/tests/workflows/pw/relax.py
@@ -8,6 +8,7 @@ from aiida.orm.data.structure import StructureData
 from aiida.orm.data.array.kpoints import KpointsData
 from aiida.orm.utils import WorkflowFactory
 from aiida.work.run import run
+from aiida_quantumespresso.utils.resources import get_default_options
 
 PwRelaxWorkChain = WorkflowFactory('quantumespresso.pw.relax')
 
@@ -24,12 +25,12 @@ def parser_setup():
         help='the name of the AiiDA code that references QE pw.x'
     )
     parser.add_argument(
-        '-k', nargs=3, type=int, default=[2, 2, 2], dest='kpoints', metavar='Q',
-        help='define the q-points mesh. (default: %(default)s)'
+        '-k', nargs=3, type=int, default=[2, 2, 2], dest='kpoints', metavar='K',
+        help='define the k-points mesh. (default: %(default)s)'
     )
     parser.add_argument(
         '-p', type=str, required=True, dest='pseudo_family',
-        help='the name of pseudo family to use'
+        help='the name of the pseudo family to use'
     )
     parser.add_argument(
         '-s', type=int, required=True, dest='structure',
@@ -40,8 +41,12 @@ def parser_setup():
         help='the maximum number of machines (nodes) to use for the calculations. (default: %(default)d)'
     )
     parser.add_argument(
-        '-w', type=int, default=3600, dest='max_wallclock_seconds',
+        '-w', type=int, default=1800, dest='max_wallclock_seconds',
         help='the maximum wallclock time in seconds to set for the calculations. (default: %(default)d)'
+    )
+    parser.add_argument(
+        '-a', '--automatic-parallelization', action='store_true', dest='automatic_parallelization',
+        help='enable the automatic parallelization option of the workchain'
     )
     parser.add_argument(
         '-x', '--clean-workdir', action='store_true', dest='clean_workdir',
@@ -83,12 +88,6 @@ def execute(args):
             'ecutrho': 240.,
         },
     }
-    
-    automatic_parallelization = {
-        'max_num_machines': args.max_num_machines,
-        'target_time_seconds': 0.5 * args.max_wallclock_seconds,
-        'max_wallclock_seconds': args.max_wallclock_seconds
-    }
 
     inputs = {
         'code': code,
@@ -96,9 +95,19 @@ def execute(args):
         'pseudo_family': Str(args.pseudo_family),
         'kpoints': kpoints,
         'parameters': ParameterData(dict=parameters),
-        'automatic_parallelization': ParameterData(dict=automatic_parallelization),
         'final_scf': Bool(True)
     }
+
+    if args.automatic_parallelization:
+        automatic_parallelization = {
+            'max_num_machines': args.max_num_machines,
+            'target_time_seconds': 0.5 * args.max_wallclock_seconds,
+            'max_wallclock_seconds': args.max_wallclock_seconds
+        }
+        inputs['automatic_parallelization'] = ParameterData(dict=automatic_parallelization)
+    else:
+        options = get_default_options(args.max_num_machines, args.max_wallclock_seconds)
+        inputs['options'] = ParameterData(dict=options)
 
     if args.clean_workdir:
         inputs['clean_workdir'] = Bool(True)


### PR DESCRIPTION
Fixes #76 

The automatic parallelization of the PwBaseWorkChain used to print
the resulting parallelization parameters to the report, but this
was cluttering the report too much and the results were not queryable.
Instead we add the results as a ParameterData node and report the
id of the output node

Besides this fix, I included some trivial changes and improvements to some
of the workchains and CLI of the tests scripts