### PR TITLE
Include stacktrace of ImportError in LoadingPluginFailed exception of get_plugin

### DIFF
--- a/aiida_quantumespresso/common/pluginloader.py
+++ b/aiida_quantumespresso/common/pluginloader.py
@@ -36,7 +36,9 @@ def get_plugin(category, name):
 
     try:
         plugin = entrypoint.load()
-    except ImportError:
-        raise LoadingPluginFailed("Loading the plugin '{}' failed".format(name))
+    except ImportError as exception:
+        import traceback
+        raise LoadingPluginFailed("Loading the plugin '{}' failed:\n{}"
+            .format(name, traceback.format_exc()))
 
     return plugin

--- a/aiida_quantumespresso/common/workchain/base/restart.py
+++ b/aiida_quantumespresso/common/workchain/base/restart.py
@@ -67,6 +67,8 @@ class BaseRestartWorkChain(WorkChain):
             for plugin in get_plugins(self._error_handler_entry_point):
                 try:
                     get_plugin(self._error_handler_entry_point, plugin)
+                    self.logger.info("loaded the '{}' entry point for the '{}' error handlers category"
+                        .format(plugin, self._error_handler_entry_point, plugin))
                 except (LoadingPluginFailed, MissingPluginError):
                     self.logger.warning("failed to load the '{}' entry point for the '{}' error handlers"
                         .format(plugin, self._error_handler_entry_point))

--- a/aiida_quantumespresso/common/workchain/utils.py
+++ b/aiida_quantumespresso/common/workchain/utils.py
@@ -58,7 +58,7 @@ def register_error_handler(cls, priority):
     def error_handler_decorator(handler):
         @wraps(handler)
         def error_handler(self, calculation):
-            if hasattr(_verbose, cls) and cls._verbose:
+            if hasattr(cls, '_verbose') and cls._verbose:
                 self.report('({}){}'.format(priority, handler.__name__))
             return handler(self, calculation)
         setattr(cls, handler.__name__, error_handler)


### PR DESCRIPTION
Fixes #79 

Also fixed a bug in the recently added `register_error_handler` decorator and reordered the priorities of the error handlers for the `PwBaseWorkChain`