### PR TITLE
Add a 'group' overridable option for cli scripts

### DIFF
--- a/aiida_quantumespresso/utils/click/options.py
+++ b/aiida_quantumespresso/utils/click/options.py
@@ -17,13 +17,19 @@ class overridable_option(object):
         self.args = args
         self.kwargs = kwargs
 
-    def __call__(self, **kwargs):
+    def __call__(self, *args, **kwargs):
         """
         Override kwargs (no name changes) and return option
         """
+        if not args:
+            args_copy = self.args
+        else:
+            args_copy = args
+
         kw_copy = self.kwargs.copy()
         kw_copy.update(kwargs)
-        return click.option(*self.args, **kw_copy)
+
+        return click.option(*args_copy, **kw_copy)
 
 code = overridable_option(
     '-c', '--code', type=click.STRING, required=True,

--- a/aiida_quantumespresso/utils/click/options.py
+++ b/aiida_quantumespresso/utils/click/options.py
@@ -80,3 +80,9 @@ clean_workdir = overridable_option(
     '-x', '--clean-workdir', is_flag=True, default=False, show_default=True,
     help='clean the remote folder of all the launched calculations after completion of the workchain'
 )
+
+group = overridable_option(
+    '-g', '--group', type=click.STRING, required=True,
+    callback=validators.validate_group,
+    help='the name or pk of a Group'
+)

--- a/aiida_quantumespresso/utils/click/validators.py
+++ b/aiida_quantumespresso/utils/click/validators.py
@@ -105,3 +105,28 @@ def validate_parent_calc(ctx, param, value):
         raise click.BadParameter('node<{}> is not of type JobCalculation'.format(value))
 
     return parent_calc
+
+def validate_group(ctx, param, value):
+    """
+    Command line option validator for an AiiDA Group. It expects a string for the value
+    that corresponds to the label or a pk of an AiiDA group.
+
+    :param value: a Group label or pk
+    :returns: a Group instance
+    """
+    from aiida.common.exceptions import NotExistent
+    from aiida.orm import Group
+
+    try:
+        group = Group.get_from_string(value)
+    except NotExistent as exception:
+        pass
+    else:
+        return group
+
+    try:
+        group = Group.get(pk=int(value))
+    except NotExistent as exception:
+        raise click.BadParameter("failed to load the Group with the label or pk '{}'\n{}".format(value, exception))
+    else:
+        return group


### PR DESCRIPTION
Fixes #88 

Define a customizable `overridable_option` for AiiDA Group entities.
This also required a change in the `overridable_option` class.

Certain predefined cli options are general enough that they can
be used multiple times for the same cli entry point. However, this
means then that the argument flags that are used should be different.
To allow this, the `*args` of the overridable_option should be also
overridable in the `__call__`. For example one can take the 'code'
`overridable_option` which defines:

    code = overridable_option(
        '-c', '--code', type=click.STRING, required=True,
        callback=validators.validate_code,
        help='the label of the AiiDA code object to use'
    )

One can imagine a cli script, however, that requires two different
codes as input. It would then be impossible to use the option. By
allowing the `args` to be overwritten this is made possible. e.g.:

	@options.code('--ph', 'code_ph', help='code label referencing ph.x')
	@options.code('--pw', 'code_pw', help='code label referencing pw.x')