### PR TITLE
Add an explicit shebang to computer setup input on Travis

### DIFF
--- a/.travis-data/computer-setup-input.txt
+++ b/.travis-data/computer-setup-input.txt
@@ -4,6 +4,7 @@ localhost
 True
 ssh
 torque
+#!/bin/bash
 /scratch/{username}/aiida_run
 mpirun -np {tot_num_mpiprocs}
 1


### PR DESCRIPTION
The latest release of `aiida-core v0.11.0` saw a change to
the `verdi computer setup` command and now expects the user
to explicitly specify the shebang. Add this to the setup
input for the Travis build