### PR TITLE
 PwRelaxWorkChain: fix bug when adding final PwCalculation to group

### DIFF
--- a/aiida_quantumespresso/cli/workflows/pw/relax.py
+++ b/aiida_quantumespresso/cli/workflows/pw/relax.py
@@ -13,11 +13,19 @@ from aiida_quantumespresso.utils.click import options
 @options.max_wallclock_seconds()
 @options.automatic_parallelization()
 @options.clean_workdir()
+@click.option(
+    '-f', '--final-scf', is_flag=True, default=False, show_default=True,
+    help='run a final scf calculation for the final relaxed structure'
+)
+@click.option(
+    '-g', '--group', type=click.STRING, required=False,
+    help='the label of a Group to add the final PwCalculation to in case of success'
+)
 def launch(
     code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds,
-    automatic_parallelization, clean_workdir):
+    automatic_parallelization, clean_workdir, final_scf, group):
     """
-    Run the PwBaseWorkChain for a given input structure
+    Run the PwRelaxWorkChain for a given input structure
     """
     from aiida.orm.data.base import Bool, Str
     from aiida.orm.data.parameter import ParameterData
@@ -55,5 +63,11 @@ def launch(
 
     if clean_workdir:
         inputs['clean_workdir'] = Bool(True)
+
+    if final_scf:
+        inputs['final_scf'] = Bool(True)
+
+    if group:
+        inputs['group'] = Str(group)
 
     run(PwRelaxWorkChain, **inputs)


### PR DESCRIPTION
Fixes #92 

When the `group` input is passed to the workchain, upon workchain
success, the last completed `PwCalculation` will be added to said group.
The `PwCalculation` was retrieved from the final `PwBaseWorkChain`, either
the from the last relax cycle or the final scf run, from its ouput
parameters node, from which in turn through the `.inp` method the
`PwCalculation` was returned. However, since the `PwBaseWorkChain` also
return the `output_parameters` `ParameterData` node, it will no longer
have just a single parent node with the link label `output_parameters`.
The `.inp` method will then randomly select one, which sometimes resulted
in the `WorkCalculation` node being returned instead of the desired
`PwCalculation` node. To fix this ambiguity we use the `get_inputs()`
method instead, explicitly stating that we want the parent node with
node type `PwCalculation`.