### PR TITLE
Use updated seekpath wrappers in aiida-core for PwBandsWorkChain

### DIFF
--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -13,7 +13,6 @@ from aiida.orm.utils import WorkflowFactory
 from aiida.work.run import submit
 from aiida.work.workchain import WorkChain, ToContext, if_
 from aiida.work.workfunction import workfunction
-from seekpath.aiidawrappers import get_path, get_explicit_k_path
 
 PwBaseWorkChain = WorkflowFactory('quantumespresso.pw.base')
 PwRelaxWorkChain = WorkflowFactory('quantumespresso.pw.relax')
@@ -152,7 +151,7 @@ class PwBandsWorkChain(WorkChain):
         result = seekpath_structure_analysis(structure)
 
         self.ctx.structure_relaxed_primitive = result['primitive_structure']
-        self.ctx.kpoints_path = result['explicit_kpoints_path']
+        self.ctx.kpoints_path = result['explicit_kpoints']
 
         self.out('primitive_structure', result['primitive_structure'])
         self.out('seekpath_parameters', result['parameters'])
@@ -245,18 +244,5 @@ def seekpath_structure_analysis(structure):
     Note that the returned primitive cell may differ from the original structure in
     which case the k-points are only congruent with the primitive cell.
     """
-    seekpath_info = get_path(structure)
-    explicit_path = get_explicit_k_path(structure)
-
-    primitive_structure = seekpath_info.pop('primitive_structure')
-    conv_structure = seekpath_info.pop('conv_structure')
-    parameters = ParameterData(dict=seekpath_info)
-
-    result = {
-        'parameters': parameters,
-        'conv_structure': conv_structure,
-        'primitive_structure': primitive_structure,
-        'explicit_kpoints_path': explicit_path['explicit_kpoints'],
-    }
-
-    return result
+    from aiida.tools import get_explicit_kpoints_path
+    return get_explicit_kpoints_path(structure)

--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -30,6 +30,8 @@ class PwBandsWorkChain(WorkChain):
         spec.input('structure', valid_type=StructureData)
         spec.input('pseudo_family', valid_type=Str)
         spec.input('kpoints_distance', valid_type=Float, default=Float(0.2))
+        spec.input('kpoints_distance_bands', valid_type=Float, default=Float(0.2))
+        spec.input('kpoinst_mesh', valid_type=KpointsData, required=False)
         spec.input('vdw_table', valid_type=SinglefileData, required=False)
         spec.input('parameters', valid_type=ParameterData)
         spec.input('settings', valid_type=ParameterData, required=False)
@@ -140,7 +142,7 @@ class PwBandsWorkChain(WorkChain):
                 return
 
         seekpath_parameters = ParameterData(dict={
-            'reference_distance': self.inputs.kpoints_distance.value
+            'reference_distance': self.inputs.kpoints_distance_bands.value
         })
 
         result = seekpath_structure_analysis(structure, seekpath_parameters)
@@ -199,8 +201,12 @@ class PwBandsWorkChain(WorkChain):
         inputs.parameters['CONTROL']['restart_mode'] = restart_mode
         inputs.parameters['CONTROL']['calculation'] = calculation_mode
 
+        if 'kpoints_mesh' in self.inputs:
+            inputs.kpoints = self.inputs.kpoints_mesh
+        else:
+            inputs.kpoints = self.ctx.kpoints_path
+
         # Final input preparation, wrapping dictionaries in ParameterData nodes
-        inputs.kpoints = self.ctx.kpoints_path
         inputs.structure = self.ctx.structure
         inputs.parent_folder = remote_folder
         inputs.parameters = ParameterData(dict=inputs.parameters)

--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -31,7 +31,7 @@ class PwBandsWorkChain(WorkChain):
         spec.input('pseudo_family', valid_type=Str)
         spec.input('kpoints_distance', valid_type=Float, default=Float(0.2))
         spec.input('kpoints_distance_bands', valid_type=Float, default=Float(0.2))
-        spec.input('kpoinst_mesh', valid_type=KpointsData, required=False)
+        spec.input('kpoints', valid_type=KpointsData, required=False)
         spec.input('vdw_table', valid_type=SinglefileData, required=False)
         spec.input('parameters', valid_type=ParameterData)
         spec.input('settings', valid_type=ParameterData, required=False)
@@ -201,8 +201,8 @@ class PwBandsWorkChain(WorkChain):
         inputs.parameters['CONTROL']['restart_mode'] = restart_mode
         inputs.parameters['CONTROL']['calculation'] = calculation_mode
 
-        if 'kpoints_mesh' in self.inputs:
-            inputs.kpoints = self.inputs.kpoints_mesh
+        if 'kpoints' in self.inputs:
+            inputs.kpoints = self.inputs.kpoints
         else:
             inputs.kpoints = self.ctx.kpoints_path
 


### PR DESCRIPTION
Fixes #83 

The kpoints_distance value was used to generate a kpoints mesh for the
scf step, when specified, but it did so on the input structure. However,
the structure that was actually used for the calculation, was the one
returned by Seekpath, which may have changed, since Seekpath tries to
reduce the structure to the primitive cell. To ensure that both the
kpoints mesh for the scf and the kpoints path (determined by Seekpath)
for the bands calculation are commensurate with the structure that is
used, we use the primitive structure returned by the Seekpath analysis