### PR TITLE
Add parsing of electronic and ionic dipole for raw pw output

### DIFF
--- a/aiida_quantumespresso/parsers/raw_parser_pw.py
+++ b/aiida_quantumespresso/parsers/raw_parser_pw.py
@@ -1728,13 +1728,28 @@ def parse_pw_text_output(data, xml_data={}, structure_data={}, input_dict={}, pa
         if lelfield is True:
 
             # For every property only get the last entry if possible
-            ed_cell = trajectory_frame['electronic_dipole_cell_average'].pop()
-            ed_axes = trajectory_frame['electronic_dipole_cartesian_axes'].pop()
-            id_cell = trajectory_frame['ionic_dipole_cell_average'].pop()
-            id_axes = trajectory_frame['ionic_dipole_cartesian_axes'].pop()
+            try:
+                ed_cell = trajectory_frame['electronic_dipole_cell_average'].pop()
+            except IndexError:
+                ed_cell = None
+
+            try:
+                ed_axes = trajectory_frame['electronic_dipole_cartesian_axes'].pop()
+            except IndexError:
+                ed_axes = None
+
+            try:
+                id_cell = trajectory_frame['ionic_dipole_cell_average'].pop()
+            except IndexError:
+                id_cell = None
+
+            try:
+                id_axes = trajectory_frame['ionic_dipole_cartesian_axes'].pop()
+            except IndexError:
+                id_axes = None
 
             # Only add them if all four properties were successfully parsed
-            if all([ed_cell, ed_axes, id_cell, id_axes]):
+            if all([value is not None for value in [ed_cell, ed_axes, id_cell, id_axes]]):
                 trajectory_data.setdefault('electronic_dipole_cell_average', []).append(ed_cell)
                 trajectory_data.setdefault('electronic_dipole_cartesian_axes', []).append(ed_axes)
                 trajectory_data.setdefault('ionic_dipole_cell_average', []).append(id_cell)

--- a/aiida_quantumespresso/parsers/raw_parser_pw.py
+++ b/aiida_quantumespresso/parsers/raw_parser_pw.py
@@ -1123,6 +1123,9 @@ def parse_pw_text_output(data, xml_data={}, structure_data={}, input_dict={}, pa
 
     all_warnings = dict(critical_warnings.items() + minor_warnings.items())
 
+    # Determine whether the input switched on an electric field
+    lelfield = input_dict.get('CONTROL', {}).get('lelfield', False)
+
     # Find some useful quantities.
     if not xml_data.get('number_of_bands',None) and not structure_data:
         try:
@@ -1392,6 +1395,9 @@ def parse_pw_text_output(data, xml_data={}, structure_data={}, input_dict={}, pa
 
     # now I create a bunch of arrays for every step.
     for data_step in relax_steps:
+
+        trajectory_frame = {}
+
         for count,line in enumerate(data_step):
 
             if 'CELL_PARAMETERS' in line:
@@ -1697,6 +1703,42 @@ def parse_pw_text_output(data, xml_data={}, structure_data={}, input_dict={}, pa
                     parsed_data['stress'+units_suffix] = default_stress_units
                 except Exception:
                     parsed_data['warnings'].append('Error while parsing stress tensor.')
+
+            # Electronic and ionic dipoles when 'lelfield' was set to True in input parameters
+            elif lelfield is True:
+
+                if 'Electronic Dipole per cell' in line:
+                    electronic_dipole = float(line.split()[-1])
+                    trajectory_frame.setdefault('electronic_dipole_cell_average', []).append(electronic_dipole)
+
+                elif 'Ionic Dipole per cell' in line:
+                    ionic_dipole = float(line.split()[-1])
+                    trajectory_frame.setdefault('ionic_dipole_cell_average', []).append(ionic_dipole)
+
+                elif 'Electronic Dipole on Cartesian axes' in line:
+                    electronic_dipole = [float(data_step[count + i + 1].split()[1]) for i in range(3)]
+                    trajectory_frame.setdefault('electronic_dipole_cartesian_axes', []).append(electronic_dipole)
+
+                elif 'Ionic Dipole on Cartesian axes' in line:
+                    ionic_dipole = [float(data_step[count + i + 1].split()[1]) for i in range(3)]
+                    trajectory_frame.setdefault('ionic_dipole_cartesian_axes', []).append(ionic_dipole)
+
+
+        # End of trajectory frame, only keep last entries for dipole related values
+        if lelfield is True:
+
+            # For every property only get the last entry if possible
+            ed_cell = trajectory_frame['electronic_dipole_cell_average'].pop()
+            ed_axes = trajectory_frame['electronic_dipole_cartesian_axes'].pop()
+            id_cell = trajectory_frame['ionic_dipole_cell_average'].pop()
+            id_axes = trajectory_frame['ionic_dipole_cartesian_axes'].pop()
+
+            # Only add them if all four properties were successfully parsed
+            if all([ed_cell, ed_axes, id_cell, id_axes]):
+                trajectory_data.setdefault('electronic_dipole_cell_average', []).append(ed_cell)
+                trajectory_data.setdefault('electronic_dipole_cartesian_axes', []).append(ed_axes)
+                trajectory_data.setdefault('ionic_dipole_cell_average', []).append(id_cell)
+                trajectory_data.setdefault('ionic_dipole_cartesian_axes', []).append(id_axes)
 
 
     # If specified in the parser options, parse the atomic occupations


### PR DESCRIPTION
Fixes #56 

When the boolean switch `lelfield` is defined in the `CONTROL` card of
the input parameters of a `PwCalculation`, the electronic and ionic
dipoles will be printed at the end of every scf iteration, both the
average over the cell as well as projected on the cartesian axes.

Add the parsing of these values for the final scf iteration of each
trajectory step under the following keys:

  * `electronic_dipole_cell_average`
  * `electronic_dipole_cartesian_axes`
  * `ionic_dipole_cell_average`
  * `ionic_dipole_cartesian_axes`

Each of these fields will be a list with as many entries as there were
scf steps in the trajectory.