### PR TITLE
Fix the wrong parser option key for atomic occupations in PwParser

### DIFF
--- a/aiida_quantumespresso/parsers/raw_parser_pw.py
+++ b/aiida_quantumespresso/parsers/raw_parser_pw.py
@@ -1700,7 +1700,7 @@ def parse_pw_text_output(data, xml_data={}, structure_data={}, input_dict={}, pa
 
 
     # If specified in the parser options, parse the atomic occupations
-    parse_atomic_occupations = parser_opts.get('atomic_occupations', False)
+    parse_atomic_occupations = parser_opts.get('parse_atomic_occupations', False)
 
     if parse_atomic_occupations:
 

--- a/docs/source/user_guide/calculation_plugins/pw.rst
+++ b/docs/source/user_guide/calculation_plugins/pw.rst
@@ -266,9 +266,9 @@ the special key ``parser_options`` which has the options discussed below.
 
 Parsing atomic occupations
 ..........................
-For DFT+U calculations, pw.x will also print atomic electron occupations to the standard
+For DFT+U calculations, ``pw.x`` will also print atomic electron occupations to the standard
 output. This flag enables or disables the parsing of this information into a ``ParameterData``
-output node with the link name ``atomic_occupations``. The value should be a boolean, with
+output node with the link name ``output_atomic_occupations``. The value should be a boolean, with
 ``False`` being the default. Setting it to ``True`` will enable the parsing of the atomic
 occupations::
 
@@ -277,3 +277,6 @@ occupations::
             'parse_atomic_occupations': True,
         }
     }
+
+Note that for ``pw.x`` to print the required information, the flag ``lda_plus_u`` has to be
+set to ``True`` in the ``SYSTEM`` card of the input ``parameters`` node.


### PR DESCRIPTION
Fixes #106 

The code looked for 'atomic_occupations' but the key should be
'parse_atomic_occupations' instead