### PR TITLE
Do not set attributes or properties in WorkChain constructors

### DIFF
--- a/aiida_quantumespresso/workflows/matdyn/base.py
+++ b/aiida_quantumespresso/workflows/matdyn/base.py
@@ -24,9 +24,6 @@ class MatdynBaseWorkChain(BaseRestartWorkChain):
     _verbose = True
     _calculation_class = MatdynCalculation
 
-    def __init__(self, *args, **kwargs):
-        super(MatdynBaseWorkChain, self).__init__(*args, **kwargs)
-
     @classmethod
     def define(cls, spec):
         super(MatdynBaseWorkChain, cls).define(spec)

--- a/aiida_quantumespresso/workflows/ph/base.py
+++ b/aiida_quantumespresso/workflows/ph/base.py
@@ -25,13 +25,10 @@ class PhBaseWorkChain(BaseRestartWorkChain):
     _verbose = True
     _calculation_class = PhCalculation
 
-    def __init__(self, *args, **kwargs):
-        super(PhBaseWorkChain, self).__init__(*args, **kwargs)
-
-        self.defaults = AttributeDict({
-            'delta_factor_max_seconds': 0.95,
-            'alpha_mix': 0.70,
-        })
+    defaults = AttributeDict({
+        'delta_factor_max_seconds': 0.95,
+        'alpha_mix': 0.70,
+    })
 
     @classmethod
     def define(cls, spec):

--- a/aiida_quantumespresso/workflows/pw/band_structure.py
+++ b/aiida_quantumespresso/workflows/pw/band_structure.py
@@ -16,8 +16,6 @@ class PwBandStructureWorkChain(WorkChain):
     Workchain to relax and compute the band structure for a given input structure
     using Quantum ESPRESSO's pw.x
     """
-    def __init__(self, *args, **kwargs):
-        super(PwBandStructureWorkChain, self).__init__(*args, **kwargs)
 
     @classmethod
     def define(cls, spec):

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -36,16 +36,13 @@ class PwBaseWorkChain(BaseRestartWorkChain):
     _calculation_class = PwCalculation
     _error_handler_entry_point = 'aiida_quantumespresso.workflow_error_handlers.pw.base'
 
-    def __init__(self, *args, **kwargs):
-        super(PwBaseWorkChain, self).__init__(*args, **kwargs)
-
-        self.defaults = AttributeDict({
-            'qe': qe_defaults,
-            'delta_threshold_degauss': 30,
-            'delta_factor_degauss': 0.1,
-            'delta_factor_mixing_beta': 0.8,
-            'delta_factor_max_seconds': 0.95,
-        })
+    defaults = AttributeDict({
+        'qe': qe_defaults,
+        'delta_threshold_degauss': 30,
+        'delta_factor_degauss': 0.1,
+        'delta_factor_mixing_beta': 0.8,
+        'delta_factor_max_seconds': 0.95,
+    })
 
     @classmethod
     def define(cls, spec):

--- a/aiida_quantumespresso/workflows/q2r/base.py
+++ b/aiida_quantumespresso/workflows/q2r/base.py
@@ -21,9 +21,6 @@ class Q2rBaseWorkChain(BaseRestartWorkChain):
     _verbose = True
     _calculation_class = Q2rCalculation
 
-    def __init__(self, *args, **kwargs):
-        super(Q2rBaseWorkChain, self).__init__(*args, **kwargs)
-
     @classmethod
     def define(cls, spec):
         super(Q2rBaseWorkChain, cls).define(spec)


### PR DESCRIPTION
Fixes #109 

Attributes and properties defined in the constructor of a WorkChain will
not be persisted and therefore cannot be guaranteed to persist between
outline steps.