### PR TITLE
Update aiida-core requirement and fix TcodExporter

### DIFF
--- a/aiida_quantumespresso/tests/tcodexporter.py
+++ b/aiida_quantumespresso/tests/tcodexporter.py
@@ -544,24 +544,24 @@ class TestTcodDbExporter(AiidaTestCase):
             '_cell_length_b',
             '_cell_length_c',
             '_chemical_formula_sum',
-            '_symmetry_Int_Tables_number',
             '_symmetry_equiv_pos_as_xyz',
-            '_symmetry_space_group_name_H-M',
-            '_symmetry_space_group_name_Hall'
+            '_symmetry_int_tables_number',
+            '_symmetry_space_group_name_h-m',
+            '_symmetry_space_group_name_hall'
         ]
 
         tcod_file_tags = [
             '_tcod_content_encoding_id',
             '_tcod_content_encoding_layer_id',
             '_tcod_content_encoding_layer_type',
-            '_tcod_file_URI',
             '_tcod_file_content_encoding',
             '_tcod_file_contents',
             '_tcod_file_id',
             '_tcod_file_md5sum',
             '_tcod_file_name',
             '_tcod_file_role',
-            '_tcod_file_sha1sum'
+            '_tcod_file_sha1sum',
+            '_tcod_file_uri'
         ]
 
         # Not stored and not to be stored:

--- a/setup.json
+++ b/setup.json
@@ -68,11 +68,6 @@
         ]
     }, 
     "extras_require": {
-        "atomic_tools": [
-            "ase", 
-            "PyCifRW==3.6.2.1", 
-            "spglib"
-        ], 
         "dev_precommit": [
             "pre-commit"
         ], 
@@ -83,7 +78,7 @@
         ]
     }, 
     "install_requires": [
-        "aiida_core>=0.10.0rc3", 
+        "aiida_core>=0.11.0[atomic_tools]", 
         "click"
     ], 
     "license": "MIT License", 


### PR DESCRIPTION
Fixes #103 

The new version of `aiida-core` updated the `PyCifRW` dependency to `4.2.1` which broke the `TcodExport`. We updated the order and format of the expected tags in the tests to fix this