### PR TITLE
 Do not use deepcopy on inputs dictionaries in workchains 

### DIFF
--- a/aiida_quantumespresso/cli/calculations/pw/base.py
+++ b/aiida_quantumespresso/cli/calculations/pw/base.py
@@ -11,11 +11,12 @@ from aiida_quantumespresso.utils.click import options
 @options.kpoint_mesh()
 @options.max_num_machines()
 @options.max_wallclock_seconds()
+@options.daemon()
 @click.option(
     '-z', '--calculation-mode', 'mode', type=click.Choice(['scf', 'vc-relax']), default='scf', show_default=True,
     help='select the calculation mode'
 )
-def launch(code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds, mode):
+def launch(code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds, daemon, mode):
     """
     Run a PwCalculation for a given input structure
     """
@@ -23,7 +24,7 @@ def launch(code, structure, pseudo_family, kpoints, max_num_machines, max_wallcl
     from aiida.orm.data.parameter import ParameterData
     from aiida.orm.data.upf import get_pseudos_from_structure
     from aiida.orm.utils import CalculationFactory
-    from aiida.work.run import run
+    from aiida.work.run import run, submit
     from aiida_quantumespresso.utils.resources import get_default_options
 
     PwCalculation = CalculationFactory('quantumespresso.pw')
@@ -48,14 +49,18 @@ def launch(code, structure, pseudo_family, kpoints, max_num_machines, max_wallcl
         '_options': get_default_options(max_num_machines, max_wallclock_seconds),
     }
 
-    click.echo('Running a pw.x calculation in the {} mode... '.format(mode))
-
     process = PwCalculation.process()
-    results, pk = run(process, _return_pid=True, **inputs)
-    calculation = load_node(pk)
 
-    click.echo('PwCalculation<{}> terminated with state: {}'.format(pk, calculation.get_state()))
-    click.echo('\n{link:25s} {node}'.format(link='Output link', node='Node pk and type'))
-    click.echo('{s}'.format(s='-'*60))
-    for link, node in sorted(calculation.get_outputs(also_labels=True)):
-        click.echo('{:25s} <{}> {}'.format(link, node.pk, node.__class__.__name__))
+    if daemon:
+        calculation = submit(process, **inputs)
+        click.echo('Submitted {}<{}> to the daemon'.format(PwCalculation.__name__, calculation.pid))
+    else:
+        click.echo('Running a PwCalculation in the {} mode... '.format(mode))
+        results, pk = run(process, _return_pid=True, **inputs)
+        calculation = load_node(pk)
+
+        click.echo('PwCalculation<{}> terminated with state: {}'.format(pk, calculation.get_state()))
+        click.echo('\n{link:25s} {node}'.format(link='Output link', node='Node pk and type'))
+        click.echo('{s}'.format(s='-'*60))
+        for link, node in sorted(calculation.get_outputs(also_labels=True)):
+            click.echo('{:25s} <{}> {}'.format(link, node.pk, node.__class__.__name__))

--- a/aiida_quantumespresso/cli/workflows/matdyn/base.py
+++ b/aiida_quantumespresso/cli/workflows/matdyn/base.py
@@ -10,14 +10,15 @@ from aiida_quantumespresso.utils.click import options
 @options.kpoint_mesh()
 @options.max_num_machines()
 @options.max_wallclock_seconds()
+@options.daemon()
 def launch(
-    code, parent_calc, kpoints, max_num_machines, max_wallclock_seconds):
+    code, parent_calc, kpoints, max_num_machines, max_wallclock_seconds, daemon):
     """
     Run the MatdynBaseWorkChain for a previously completed Q2rCalculation
     """
     from aiida.orm.data.parameter import ParameterData
     from aiida.orm.utils import CalculationFactory, WorkflowFactory
-    from aiida.work.run import run
+    from aiida.work.run import run, submit
     from aiida_quantumespresso.utils.resources import get_default_options
 
     MatdynBaseWorkChain = WorkflowFactory('quantumespresso.matdyn.base')
@@ -31,4 +32,8 @@ def launch(
         'options': ParameterData(dict=options),
     }
 
-    run(MatdynBaseWorkChain, **inputs)
+    if daemon:
+        workchain = submit(MatdynBaseWorkChain, **inputs)
+        click.echo('Submitted {}<{}> to the daemon'.format(MatdynBaseWorkChain.__name__, workchain.pid))
+    else:
+        run(MatdynBaseWorkChain, **inputs)

--- a/aiida_quantumespresso/cli/workflows/ph/base.py
+++ b/aiida_quantumespresso/cli/workflows/ph/base.py
@@ -6,18 +6,19 @@ from aiida_quantumespresso.utils.click import options
 
 @command()
 @options.code()
-@options.parent_calc()
+@options.parent_calc(callback_kwargs={'entry_point': 'quantumespresso.pw'})
 @options.kpoint_mesh()
 @options.max_num_machines()
 @options.max_wallclock_seconds()
+@options.daemon()
 def launch(
-    code, parent_calc, kpoints, max_num_machines, max_wallclock_seconds):
+    code, parent_calc, kpoints, max_num_machines, max_wallclock_seconds, daemon):
     """
     Run the PhBaseWorkChain for a previously completed PwCalculation
     """
     from aiida.orm.data.parameter import ParameterData
     from aiida.orm.utils import CalculationFactory, WorkflowFactory
-    from aiida.work.run import run
+    from aiida.work.run import run, submit
     from aiida_quantumespresso.utils.resources import get_default_options
 
     PwCalculation = CalculationFactory('quantumespresso.pw')
@@ -38,4 +39,8 @@ def launch(
         'options': ParameterData(dict=options),
     }
 
-    run(PhBaseWorkChain, **inputs)
+    if daemon:
+        workchain = submit(PhBaseWorkChain, **inputs)
+        click.echo('Submitted {}<{}> to the daemon'.format(PhBaseWorkChain.__name__, workchain.pid))
+    else:
+        run(PhBaseWorkChain, **inputs)

--- a/aiida_quantumespresso/cli/workflows/pw/band_structure.py
+++ b/aiida_quantumespresso/cli/workflows/pw/band_structure.py
@@ -8,19 +8,20 @@ from aiida_quantumespresso.utils.click import options
 @options.code()
 @options.structure()
 @options.pseudo_family()
+@options.daemon()
 @click.option(
     '-z', '--protocol', type=click.Choice(['standard']), default='standard', show_default=True,
     help='the protocol to use for the workflow'
 )
 def launch(
-    code, structure, pseudo_family, protocol):
+    code, structure, pseudo_family, daemon, protocol):
     """
     Run the PwBandStructureWorkChain for a given input structure 
     to compute the band structure for the relaxed structure
     """
     from aiida.orm.data.base import Str
     from aiida.orm.utils import WorkflowFactory
-    from aiida.work.run import run
+    from aiida.work.run import run, submit
 
     PwBandStructureWorkChain = WorkflowFactory('quantumespresso.pw.band_structure')
 
@@ -31,4 +32,8 @@ def launch(
         'protocol': Str(protocol),
     }
 
-    run(PwBandStructureWorkChain, **inputs)
+    if daemon:
+        workchain = submit(PwBandStructureWorkChain, **inputs)
+        click.echo('Submitted {}<{}> to the daemon'.format(PwBandStructureWorkChain.__name__, workchain.pid))
+    else:
+        run(PwBandStructureWorkChain, **inputs)

--- a/aiida_quantumespresso/cli/workflows/pw/bands.py
+++ b/aiida_quantumespresso/cli/workflows/pw/bands.py
@@ -11,16 +11,18 @@ from aiida_quantumespresso.utils.click import options
 @options.kpoint_mesh()
 @options.max_num_machines()
 @options.max_wallclock_seconds()
+@options.daemon()
 @options.automatic_parallelization()
 def launch(
-    code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds, automatic_parallelization):
+    code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds, daemon,
+    automatic_parallelization):
     """
     Run the PwBandsWorkChain for a given input structure
     """
     from aiida.orm.data.base import Bool, Float, Str
     from aiida.orm.data.parameter import ParameterData
     from aiida.orm.utils import WorkflowFactory
-    from aiida.work.run import run
+    from aiida.work.run import run, submit
     from aiida_quantumespresso.utils.resources import get_default_options
 
     PwBandsWorkChain = WorkflowFactory('quantumespresso.pw.bands')
@@ -57,4 +59,8 @@ def launch(
         options = get_default_options(max_num_machines, max_wallclock_seconds)
         inputs['options'] = ParameterData(dict=options)
 
-    run(PwBandsWorkChain, **inputs)
+    if daemon:
+        workchain = submit(PwBandsWorkChain, **inputs)
+        click.echo('Submitted {}<{}> to the daemon'.format(PwBandsWorkChain.__name__, workchain.pid))
+    else:
+        run(PwBandsWorkChain, **inputs)

--- a/aiida_quantumespresso/cli/workflows/pw/base.py
+++ b/aiida_quantumespresso/cli/workflows/pw/base.py
@@ -3,6 +3,7 @@ import click
 from aiida_quantumespresso.utils.click import command
 from aiida_quantumespresso.utils.click import options
 
+
 @command()
 @options.code()
 @options.structure()
@@ -10,10 +11,11 @@ from aiida_quantumespresso.utils.click import options
 @options.kpoint_mesh()
 @options.max_num_machines()
 @options.max_wallclock_seconds()
+@options.daemon()
 @options.automatic_parallelization()
 @options.clean_workdir()
 def launch(
-    code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds,
+    code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds, daemon,
     automatic_parallelization, clean_workdir):
     """
     Run the PwBaseWorkChain for a given input structure
@@ -21,7 +23,7 @@ def launch(
     from aiida.orm.data.base import Bool, Str
     from aiida.orm.data.parameter import ParameterData
     from aiida.orm.utils import WorkflowFactory
-    from aiida.work.run import run
+    from aiida.work.run import run, submit
     from aiida_quantumespresso.utils.resources import get_default_options
 
     PwBaseWorkChain = WorkflowFactory('quantumespresso.pw.base')
@@ -55,4 +57,8 @@ def launch(
     if clean_workdir:
         inputs['clean_workdir'] = Bool(True)
 
-    run(PwBaseWorkChain, **inputs)
+    if daemon:
+        workchain = submit(PwBaseWorkChain, **inputs)
+        click.echo('Submitted {}<{}> to the daemon'.format(PwBaseWorkChain.__name__, workchain.pid))
+    else:
+        run(PwBaseWorkChain, **inputs)

--- a/aiida_quantumespresso/cli/workflows/q2r/base.py
+++ b/aiida_quantumespresso/cli/workflows/q2r/base.py
@@ -3,19 +3,21 @@ import click
 from aiida_quantumespresso.utils.click import command
 from aiida_quantumespresso.utils.click import options
 
+
 @command()
 @options.code()
 @options.parent_calc(callback_kwargs={'entry_point': 'quantumespresso.ph'})
 @options.max_num_machines()
 @options.max_wallclock_seconds()
+@options.daemon()
 def launch(
-    code, parent_calc, max_num_machines, max_wallclock_seconds):
+    code, parent_calc, max_num_machines, max_wallclock_seconds, daemon):
     """
     Run the Q2rBaseWorkChain for a previously completed PhCalculation
     """
     from aiida.orm.data.parameter import ParameterData
     from aiida.orm.utils import CalculationFactory, WorkflowFactory
-    from aiida.work.run import run
+    from aiida.work.run import run, submit
     from aiida_quantumespresso.utils.resources import get_default_options
 
     Q2rBaseWorkChain = WorkflowFactory('quantumespresso.q2r.base')
@@ -28,4 +30,8 @@ def launch(
         'options': ParameterData(dict=options),
     }
 
-    run(Q2rBaseWorkChain, **inputs)
+    if daemon:
+        workchain = submit(Q2rBaseWorkChain, **inputs)
+        click.echo('Submitted {}<{}> to the daemon'.format(Q2rBaseWorkChain.__name__, workchain.pid))
+    else:
+        run(Q2rBaseWorkChain, **inputs)

--- a/aiida_quantumespresso/common/workchain/base/restart.py
+++ b/aiida_quantumespresso/common/workchain/base/restart.py
@@ -10,6 +10,7 @@ from aiida.work.run import submit
 from aiida_quantumespresso.common.exceptions import UnexpectedCalculationFailure
 from aiida_quantumespresso.common.pluginloader import get_plugin, get_plugins
 
+
 class BaseRestartWorkChain(WorkChain):
     """
     Base restart workchain
@@ -314,12 +315,5 @@ class BaseRestartWorkChain(WorkChain):
         This is the format used by input groups as in for example the explicit pseudo dictionary where the key is
         a tuple of kind to which the UpfData corresponds.
         """
-        prepared_inputs = {}
-
-        for key, val in inputs.iteritems():
-            if key != '_options' and isinstance(val, dict) and all([isinstance(k, (basestring)) for k in val.keys()]):
-                prepared_inputs[key] = ParameterData(dict=val)
-            else:
-                prepared_inputs[key] = val
-
-        return prepared_inputs
+        from aiida_quantumespresso.utils.mapping import prepare_process_inputs
+        return prepare_process_inputs(inputs)

--- a/aiida_quantumespresso/utils/click/options.py
+++ b/aiida_quantumespresso/utils/click/options.py
@@ -98,3 +98,8 @@ group = overridable_option(
     callback=validators.validate_group,
     help='the name or pk of a Group'
 )
+
+daemon = overridable_option(
+    '-d', '--daemon', is_flag=True, default=False, show_default=True,
+    help='submit the workchain to the daemon instead of running it locally'
+)

--- a/aiida_quantumespresso/utils/mapping.py
+++ b/aiida_quantumespresso/utils/mapping.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from collections import Mapping
+from aiida.common.extendeddicts import AttributeDict
 from aiida.orm.data.parameter import ParameterData
+
 
 def update_mapping(original, source):
     """
@@ -28,3 +30,22 @@ def update_mapping(original, source):
         original = ParameterData(dict=original)
 
     return original
+
+
+def prepare_process_inputs(inputs):
+    """
+    Prepare the inputs dictionary for a calculation process. Any remaining bare dictionaries in the inputs
+    dictionary will be wrapped in a ParameterData data node except for the '_options' key which should remain
+    a standard dictionary. Another exception are dictionaries whose keys are not strings but for example tuples.
+    This is the format used by input groups as in for example the explicit pseudo dictionary where the key is
+    a tuple of kind to which the UpfData corresponds.
+    """
+    prepared_inputs = AttributeDict()
+
+    for key, val in inputs.iteritems():
+        if key != '_options' and isinstance(val, dict) and all([isinstance(k, (basestring)) for k in val.keys()]):
+            prepared_inputs[key] = ParameterData(dict=val)
+        else:
+            prepared_inputs[key] = val
+
+    return prepared_inputs

--- a/aiida_quantumespresso/workflows/matdyn/base.py
+++ b/aiida_quantumespresso/workflows/matdyn/base.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from copy import deepcopy
 from aiida.common.extendeddicts import AttributeDict
 from aiida.orm import Code
 from aiida.orm.data.folder import FolderData
@@ -14,7 +13,9 @@ from aiida_quantumespresso.common.workchain.base.restart import BaseRestartWorkC
 from aiida_quantumespresso.data.forceconstants import ForceconstantsData
 from aiida_quantumespresso.utils.resources import get_default_options
 
+
 MatdynCalculation = CalculationFactory('quantumespresso.matdyn')
+
 
 class MatdynBaseWorkChain(BaseRestartWorkChain):
     """
@@ -49,31 +50,27 @@ class MatdynBaseWorkChain(BaseRestartWorkChain):
 
     def validate_inputs(self):
         """
-        Define context dictionary 'inputs_raw' with the inputs for the MatdynCalculations as they were at the beginning
-        of the workchain. Changes have to be made to a deep copy so this remains unchanged and we can always reset
-        the inputs to their initial state. Inputs that are not required by the workchain will be given a default value
-        if not specified or be validated otherwise.
+        Validate inputs that depend might depend on each other and cannot be validated by the spec. Also define
+        dictionary `inputs` in the context, that will contain the inputs for the calculation that will be launched
+        in the `run_calculation` step.
         """
-        self.ctx.inputs_raw = AttributeDict({
+        self.ctx.inputs = AttributeDict({
             'code': self.inputs.code,
             'kpoints': self.inputs.kpoints,
             'parent_folder': self.inputs.parent_folder,
         })
 
         if 'parameters' in self.inputs:
-            self.ctx.inputs_raw.parameters = self.inputs.parameters.get_dict()
+            self.ctx.inputs.parameters = self.inputs.parameters.get_dict()
         else:
-            self.ctx.inputs_raw.parameters = {'INPUT': {}}
+            self.ctx.inputs.parameters = {'INPUT': {}}
 
         if 'settings' in self.inputs:
-            self.ctx.inputs_raw.settings = self.inputs.settings.get_dict()
+            self.ctx.inputs.settings = self.inputs.settings.get_dict()
         else:
-            self.ctx.inputs_raw.settings = {}
+            self.ctx.inputs.settings = {}
 
         if 'options' in self.inputs:
-            self.ctx.inputs_raw._options = self.inputs.options.get_dict()
+            self.ctx.inputs._options = self.inputs.options.get_dict()
         else:
-            self.ctx.inputs_raw._options = get_default_options()
-
-        # Assign a deepcopy to self.ctx.inputs which will be used by the BaseRestartWorkChain
-        self.ctx.inputs = deepcopy(self.ctx.inputs_raw)
+            self.ctx.inputs._options = get_default_options()

--- a/aiida_quantumespresso/workflows/pw/band_structure.py
+++ b/aiida_quantumespresso/workflows/pw/band_structure.py
@@ -9,7 +9,9 @@ from aiida.orm.utils import WorkflowFactory
 from aiida.work.run import submit
 from aiida.work.workchain import WorkChain, ToContext
 
+
 PwBandsWorkChain = WorkflowFactory('quantumespresso.pw.bands')
+
 
 class PwBandStructureWorkChain(WorkChain):
     """

--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from copy import deepcopy
 from aiida.common.extendeddicts import AttributeDict
 from aiida.orm import Code
 from aiida.orm.data.base import Str, Float, Bool
@@ -13,9 +12,12 @@ from aiida.orm.utils import WorkflowFactory
 from aiida.work.run import submit
 from aiida.work.workchain import WorkChain, ToContext, if_
 from aiida.work.workfunction import workfunction
+from aiida_quantumespresso.utils.mapping import prepare_process_inputs
+
 
 PwBaseWorkChain = WorkflowFactory('quantumespresso.pw.base')
 PwRelaxWorkChain = WorkflowFactory('quantumespresso.pw.relax')
+
 
 class PwBandsWorkChain(WorkChain):
     """
@@ -60,7 +62,7 @@ class PwBandsWorkChain(WorkChain):
         """
         Initialize context variables that are used during the logical flow of the BaseRestartWorkChain
         """
-        self.ctx.inputs_raw = AttributeDict({
+        self.ctx.inputs = AttributeDict({
             'code': self.inputs.code,
             'pseudo_family': self.inputs.pseudo_family,
             'parameters': self.inputs.parameters.get_dict(),
@@ -76,23 +78,23 @@ class PwBandsWorkChain(WorkChain):
 
         # Add the van der Waals kernel table file if specified
         if 'vdw_table' in self.inputs:
-            self.ctx.inputs_raw.vdw_table = self.inputs.vdw_table
+            self.ctx.inputs.vdw_table = self.inputs.vdw_table
             self.inputs.relax['vdw_table'] = self.inputs.vdw_table
 
         # Set the correct relaxation scheme in the input parameters
-        if 'CONTROL' not in self.ctx.inputs_raw.parameters:
-            self.ctx.inputs_raw.parameters['CONTROL'] = {}
+        if 'CONTROL' not in self.ctx.inputs.parameters:
+            self.ctx.inputs.parameters['CONTROL'] = {}
 
         if 'settings' in self.inputs:
-            self.ctx.inputs_raw.settings = self.inputs.settings
+            self.ctx.inputs.settings = self.inputs.settings
 
         # If options set, add it to the default inputs
         if 'options' in self.inputs:
-            self.ctx.inputs_raw.options = self.inputs.options
+            self.ctx.inputs.options = self.inputs.options
 
         # If automatic parallelization was set, add it to the default inputs
         if 'automatic_parallelization' in self.inputs:
-            self.ctx.inputs_raw.automatic_parallelization = self.inputs.automatic_parallelization
+            self.ctx.inputs.automatic_parallelization = self.inputs.automatic_parallelization
 
         return
 
@@ -164,18 +166,15 @@ class PwBandsWorkChain(WorkChain):
         """
         Run the PwBaseWorkChain in scf mode on the primitive cell of (optionally relaxed) input structure
         """
-        inputs = deepcopy(self.ctx.inputs_raw)
-
+        inputs = self.ctx.inputs
         calculation_mode = 'scf'
 
         # Set the correct pw.x input parameters
         inputs.parameters['CONTROL']['calculation'] = calculation_mode
-
-        # Final input preparation, wrapping dictionaries in ParameterData nodes
         inputs.kpoints = self.ctx.kpoints_mesh
         inputs.structure = self.ctx.structure
-        inputs.parameters = ParameterData(dict=inputs.parameters)
 
+        inputs = prepare_process_inputs(inputs)
         running = submit(PwBaseWorkChain, **inputs)
 
         self.report('launching PwBaseWorkChain<{}> in {} mode'.format(running.pid, calculation_mode))
@@ -192,8 +191,7 @@ class PwBandsWorkChain(WorkChain):
             self.abort_nowait('the scf workchain did not output a remote_folder node')
             return
 
-        inputs = deepcopy(self.ctx.inputs_raw)
-
+        inputs = self.ctx.inputs
         restart_mode = 'restart'
         calculation_mode = 'bands'
 
@@ -206,11 +204,10 @@ class PwBandsWorkChain(WorkChain):
         else:
             inputs.kpoints = self.ctx.kpoints_path
 
-        # Final input preparation, wrapping dictionaries in ParameterData nodes
         inputs.structure = self.ctx.structure
         inputs.parent_folder = remote_folder
-        inputs.parameters = ParameterData(dict=inputs.parameters)
 
+        inputs = prepare_process_inputs(inputs)
         running = submit(PwBaseWorkChain, **inputs)
 
         self.report('launching PwBaseWorkChain<{}> in {} mode'.format(running.pid, calculation_mode))

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from copy import deepcopy
 from aiida.orm import Code
 from aiida.orm.data.base import Bool, Int, Str
 from aiida.orm.data.folder import FolderData
@@ -26,7 +25,9 @@ from aiida_quantumespresso.utils.resources import get_pw_parallelization_paramet
 from aiida_quantumespresso.utils.resources import cmdline_remove_npools
 from aiida_quantumespresso.utils.resources import create_scheduler_resources
 
+
 PwCalculation = CalculationFactory('quantumespresso.pw')
+
 
 class PwBaseWorkChain(BaseRestartWorkChain):
     """
@@ -82,43 +83,42 @@ class PwBaseWorkChain(BaseRestartWorkChain):
 
     def validate_inputs(self):
         """
-        Define context dictionary 'inputs_raw' with the inputs for the PwCalculations as they were at the beginning
-        of the workchain. Changes have to be made to a deep copy so this remains unchanged and we can always reset
-        the inputs to their initial state. Inputs that are not required by the workchain will be given a default value
-        if not specified or be validated otherwise.
+        Validate inputs that depend might depend on each other and cannot be validated by the spec. Also define
+        dictionary `inputs` in the context, that will contain the inputs for the calculation that will be launched
+        in the `run_calculation` step.
         """
-        self.ctx.inputs_raw = AttributeDict({
+        self.ctx.inputs = AttributeDict({
             'code': self.inputs.code,
             'structure': self.inputs.structure,
             'kpoints': self.inputs.kpoints,
             'parameters': self.inputs.parameters.get_dict()
         })
 
-        if 'CONTROL'not in self.ctx.inputs_raw.parameters:
-            self.ctx.inputs_raw.parameters['CONTROL'] = {}
+        if 'CONTROL'not in self.ctx.inputs.parameters:
+            self.ctx.inputs.parameters['CONTROL'] = {}
 
-        if 'calculation' not in self.ctx.inputs_raw.parameters['CONTROL']:
-            self.ctx.inputs_raw.parameters['CONTROL']['calculation'] = 'scf'
+        if 'calculation' not in self.ctx.inputs.parameters['CONTROL']:
+            self.ctx.inputs.parameters['CONTROL']['calculation'] = 'scf'
 
         if 'parent_folder' in self.inputs:
-            self.ctx.inputs_raw.parent_folder = self.inputs.parent_folder
-            self.ctx.inputs_raw.parameters['CONTROL']['restart_mode'] = 'restart'
+            self.ctx.inputs.parent_folder = self.inputs.parent_folder
+            self.ctx.inputs.parameters['CONTROL']['restart_mode'] = 'restart'
         else:
-            self.ctx.inputs_raw.parent_folder = None
-            self.ctx.inputs_raw.parameters['CONTROL']['restart_mode'] = 'from_scratch'
+            self.ctx.inputs.parent_folder = None
+            self.ctx.inputs.parameters['CONTROL']['restart_mode'] = 'from_scratch'
 
         if 'settings' in self.inputs:
-            self.ctx.inputs_raw.settings = self.inputs.settings.get_dict()
+            self.ctx.inputs.settings = self.inputs.settings.get_dict()
         else:
-            self.ctx.inputs_raw.settings = {}
+            self.ctx.inputs.settings = {}
 
         if 'options' in self.inputs:
-            self.ctx.inputs_raw._options = self.inputs.options.get_dict()
+            self.ctx.inputs._options = self.inputs.options.get_dict()
         else:
-            self.ctx.inputs_raw._options = {}
+            self.ctx.inputs._options = {}
 
         if 'vdw_table' in self.inputs:
-            self.ctx.inputs_raw.vdw_table = self.inputs.vdw_table
+            self.ctx.inputs.vdw_table = self.inputs.vdw_table
 
         # Either automatic_parallelization or options has to be specified
         if not any([key in self.inputs for key in ['options', 'automatic_parallelization']]):
@@ -127,8 +127,8 @@ class PwBaseWorkChain(BaseRestartWorkChain):
 
         # If automatic parallelization is not enabled, we better make sure that the options satisfy minimum requirements
         if 'automatic_parallelization' not in self.inputs:
-            num_machines = self.ctx.inputs_raw['_options'].get('resources', {}).get('num_machines', None)
-            max_wallclock_seconds = self.ctx.inputs_raw['_options'].get('max_wallclock_seconds', None)
+            num_machines = self.ctx.inputs['_options'].get('resources', {}).get('num_machines', None)
+            max_wallclock_seconds = self.ctx.inputs['_options'].get('max_wallclock_seconds', None)
 
             if num_machines is None or max_wallclock_seconds is None:
                 self.abort_nowait("no automatic_parallelization requested, but the options do not specify both '{}' and '{}'"
@@ -140,12 +140,9 @@ class PwBaseWorkChain(BaseRestartWorkChain):
         pseudo_family = self.inputs.get('pseudo_family', None)
 
         try:
-            self.ctx.inputs_raw.pseudo = validate_and_prepare_pseudos_inputs(structure, pseudos, pseudo_family)
+            self.ctx.inputs.pseudo = validate_and_prepare_pseudos_inputs(structure, pseudos, pseudo_family)
         except ValueError as exception:
             self.abort_nowait('{}'.format(exception))
-
-        # Assign a deepcopy to self.ctx.inputs which will be used by the BaseRestartWorkChain
-        self.ctx.inputs = deepcopy(self.ctx.inputs_raw)
 
     def should_run_init(self):
         """
@@ -185,11 +182,11 @@ class PwBaseWorkChain(BaseRestartWorkChain):
             'max_wallclock_seconds': parallelization['max_wallclock_seconds'],
             'target_time_seconds': parallelization['target_time_seconds'],
             'max_num_machines': parallelization['max_num_machines'],
-            'calculation_mode': self.ctx.inputs_raw.parameters['CONTROL']['calculation']
+            'calculation_mode': self.ctx.inputs.parameters['CONTROL']['calculation']
         }
 
-        self.ctx.inputs_raw._options.setdefault('resources', {})['num_machines'] = parallelization['max_num_machines']
-        self.ctx.inputs_raw._options['max_wallclock_seconds'] = parallelization['max_wallclock_seconds']
+        self.ctx.inputs._options.setdefault('resources', {})['num_machines'] = parallelization['max_num_machines']
+        self.ctx.inputs._options['max_wallclock_seconds'] = parallelization['max_wallclock_seconds']
 
     def run_init(self):
         """
@@ -197,7 +194,7 @@ class PwBaseWorkChain(BaseRestartWorkChain):
         point it will have generated some general output pertaining to the dimensions of the
         calculation which we can use to distribute available computational resources
         """
-        inputs = deepcopy(self.ctx.inputs)
+        inputs = self.ctx.inputs
 
         # Set the initialization flag and the initial default options
         inputs.settings['ONLY_INITIALIZATION'] = True
@@ -230,23 +227,23 @@ class PwBaseWorkChain(BaseRestartWorkChain):
         self.out('automatic_parallelization', node)
         self.report('results of automatic parallelization in {}<{}>'.format(node.__class__.__name__, node.pk))
 
-        options = self.ctx.inputs_raw._options
+        options = self.ctx.inputs._options
         base_resources = options.get('resources', {})
         goal_resources = parallelization['resources']
 
         scheduler = calculation.get_computer().get_scheduler()
         resources = create_scheduler_resources(scheduler, base_resources, goal_resources)
 
-        cmdline = self.ctx.inputs_raw.settings.get('cmdline', [])
+        cmdline = self.ctx.inputs.settings.get('cmdline', [])
         cmdline = cmdline_remove_npools(cmdline)
         cmdline.extend(['-nk', str(parallelization['npools'])])
 
         # Set the new cmdline setting and resource options
-        self.ctx.inputs_raw.settings['cmdline'] = cmdline
-        self.ctx.inputs_raw._options = update_mapping(options, {'resources': resources})
+        self.ctx.inputs.settings['cmdline'] = cmdline
+        self.ctx.inputs._options = update_mapping(options, {'resources': resources})
 
-        # Update the self.ctx.inputs which will be used by the BaseRestartWorkChain
-        self.ctx.inputs = deepcopy(self.ctx.inputs_raw)
+        # Remove the only initialization flag
+        self.ctx.inputs.settings.pop('ONLY_INITIALIZATION')
 
         return
 
@@ -272,7 +269,6 @@ class PwBaseWorkChain(BaseRestartWorkChain):
         return super(PwBaseWorkChain, self)._prepare_process_inputs(inputs)
 
 
-
 @register_error_handler(PwBaseWorkChain, 500)
 def _handle_error_read_namelists(self, calculation):
     """
@@ -281,6 +277,7 @@ def _handle_error_read_namelists(self, calculation):
     if any(['read_namelists' in w for w in calculation.res.warnings]):
         self.abort_nowait('PwCalculation<{}> failed because of an invalid input file'.format(calculation.pk))
         return ErrorHandlerReport(True, True)
+
 
 @register_error_handler(PwBaseWorkChain, 400)
 def _handle_error_exceeded_maximum_walltime(self, calculation):
@@ -292,6 +289,7 @@ def _handle_error_exceeded_maximum_walltime(self, calculation):
         self.report('PwCalculation<{}> terminated because maximum wall time was exceeded, restarting'
             .format(calculation.pk))
         return ErrorHandlerReport(True, True)
+
 
 @register_error_handler(PwBaseWorkChain, 300)
 def _handle_error_diagonalization(self, calculation):
@@ -315,6 +313,7 @@ def _handle_error_diagonalization(self, calculation):
         self.report('Restarting with diagonalization scheme "{}"'.format(new_diagonalization))
         return ErrorHandlerReport(True, True)
 
+
 @register_error_handler(PwBaseWorkChain, 200)
 def _handle_error_convergence_not_reached(self, calculation):
     """
@@ -325,6 +324,7 @@ def _handle_error_convergence_not_reached(self, calculation):
         self.ctx.restart_calc = calculation
         self.report('PwCalculation<{}> did not converge, restart from previous calculation'.format(calculation.pk))
         return ErrorHandlerReport(True, True)
+
 
 @register_error_handler(PwBaseWorkChain, 100)
 def _handle_error_unrecognized_by_parser(self, calculation):

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from copy import deepcopy
 from aiida.common.links import LinkType
 from aiida.orm import Code
 from aiida.orm.data.base import Bool, Float, Int, Str 
@@ -16,9 +15,12 @@ from aiida.common.exceptions import AiidaException, NotExistent
 from aiida.common.datastructures import calc_states
 from aiida.work.run import submit
 from aiida.work.workchain import WorkChain, ToContext, if_, while_, append_
+from aiida_quantumespresso.utils.mapping import prepare_process_inputs
+
 
 PwCalculation = CalculationFactory('quantumespresso.pw')
 PwBaseWorkChain = WorkflowFactory('quantumespresso.pw.base')
+
 
 class PwRelaxWorkChain(WorkChain):
     """
@@ -148,9 +150,8 @@ class PwRelaxWorkChain(WorkChain):
         """
         self.ctx.iteration += 1
 
-        inputs = deepcopy(self.ctx.inputs)
+        inputs = self.ctx.inputs
         inputs['structure'] = self.ctx.current_structure
-        inputs['parameters'] = ParameterData(dict=inputs['parameters'])
 
         # Construct a new kpoint mesh on the current structure or pass the static mesh
         if 'kpoints' not in self.inputs or self.inputs.kpoints == None:
@@ -164,6 +165,7 @@ class PwRelaxWorkChain(WorkChain):
         else:
             inputs['kpoints'] = self.inputs.kpoints
 
+        inputs = prepare_process_inputs(inputs)
         running = submit(PwBaseWorkChain, **inputs)
 
         self.report('launching PwBaseWorkChain<{}>'.format(running.pid))
@@ -226,12 +228,11 @@ class PwRelaxWorkChain(WorkChain):
         """
         Run the PwBaseWorkChain to run a final scf PwCalculation for the relaxed structure
         """
-        inputs = deepcopy(self.ctx.inputs)
+        inputs = self.ctx.inputs
         structure = self.ctx.current_structure
 
-        parameters = inputs['parameters']
-        parameters['CONTROL']['calculation'] = 'scf'
-        parameters['CONTROL']['restart_mode'] = 'restart'
+        inputs.parameters['CONTROL']['calculation'] = 'scf'
+        inputs.parameters['CONTROL']['restart_mode'] = 'restart'
 
         # Construct a new kpoint mesh on the current structure or pass the static mesh
         if 'kpoints' not in self.inputs or self.inputs.kpoints == None:
@@ -247,10 +248,10 @@ class PwRelaxWorkChain(WorkChain):
         inputs.update({
             'kpoints': kpoints,
             'structure': structure,
-            'parameters': ParameterData(dict=parameters),
             'parent_folder': self.ctx.current_parent_folder,
         })
 
+        inputs = prepare_process_inputs(inputs)
         running = submit(PwBaseWorkChain, **inputs)
 
         self.report('launching PwBaseWorkChain<{}> for final scf'.format(running.pid))

--- a/aiida_quantumespresso/workflows/q2r/base.py
+++ b/aiida_quantumespresso/workflows/q2r/base.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from copy import deepcopy
 from aiida.common.extendeddicts import AttributeDict
 from aiida.orm import Code
 from aiida.orm.data.folder import FolderData
@@ -11,7 +10,9 @@ from aiida_quantumespresso.common.workchain.base.restart import BaseRestartWorkC
 from aiida_quantumespresso.data.forceconstants import ForceconstantsData
 from aiida_quantumespresso.utils.resources import get_default_options
 
+
 Q2rCalculation = CalculationFactory('quantumespresso.q2r')
+
 
 class Q2rBaseWorkChain(BaseRestartWorkChain):
     """
@@ -44,30 +45,26 @@ class Q2rBaseWorkChain(BaseRestartWorkChain):
 
     def validate_inputs(self):
         """
-        Define context dictionary 'inputs_raw' with the inputs for the Q2rCalculations as they were at the beginning
-        of the workchain. Changes have to be made to a deep copy so this remains unchanged and we can always reset
-        the inputs to their initial state. Inputs that are not required by the workchain will be given a default value
-        if not specified or be validated otherwise.
+        Validate inputs that depend might depend on each other and cannot be validated by the spec. Also define
+        dictionary `inputs` in the context, that will contain the inputs for the calculation that will be launched
+        in the `run_calculation` step.
         """
-        self.ctx.inputs_raw = AttributeDict({
+        self.ctx.inputs = AttributeDict({
             'code': self.inputs.code,
             'parent_folder': self.inputs.parent_folder,
         })
 
         if 'parameters' in self.inputs:
-            self.ctx.inputs_raw.parameters = self.inputs.parameters.get_dict()
+            self.ctx.inputs.parameters = self.inputs.parameters.get_dict()
         else:
-            self.ctx.inputs_raw.parameters = {'INPUT': {}}
+            self.ctx.inputs.parameters = {'INPUT': {}}
 
         if 'settings' in self.inputs:
-            self.ctx.inputs_raw.settings = self.inputs.settings.get_dict()
+            self.ctx.inputs.settings = self.inputs.settings.get_dict()
         else:
-            self.ctx.inputs_raw.settings = {}
+            self.ctx.inputs.settings = {}
 
         if 'options' in self.inputs:
-            self.ctx.inputs_raw._options = self.inputs.options.get_dict()
+            self.ctx.inputs._options = self.inputs.options.get_dict()
         else:
-            self.ctx.inputs_raw._options = get_default_options()
-
-        # Assign a deepcopy to self.ctx.inputs which will be used by the BaseRestartWorkChain
-        self.ctx.inputs = deepcopy(self.ctx.inputs_raw)
+            self.ctx.inputs._options = get_default_options()


### PR DESCRIPTION
Fixes #117 

If the copy operators of Nodes were to be implemented correctly, this
usage would result in duplicated entries to be generated in the database
which is not the intended behavior. Instead we keep one dictionary of
inputs and simply pass it to `prepare_process_inputs` which will wrap
bare dictionaries that are intended to be ParameterData objects in the
ParameterData class. With this change, one does have to remember that
when reusing the inputs dictionary for reuse, that potential changes in
a previous iteration of the calculation or sub workchain will be have
to be removed if necessary