### PR TITLE
PwRelaxWorkChain: fix small bug with Node not being unwrapped

### DIFF
--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -116,7 +116,7 @@ class PwRelaxWorkChain(WorkChain):
         if 'automatic_parallelization' in self.inputs:
             self.ctx.inputs.automatic_parallelization = self.inputs.automatic_parallelization
 
-        self.ctx.inputs.parameters['CONTROL']['calculation'] = self.inputs.relaxation_scheme
+        self.ctx.inputs.parameters['CONTROL']['calculation'] = self.inputs.relaxation_scheme.value
 
         return
 


### PR DESCRIPTION
This was fixed in `workflows` but not in `develop` and crashes when running `SqlAlchemy`