### PR TITLE
Fix a bug causing cmdline args to be ignored in namelists.py

### DIFF
--- a/aiida_quantumespresso/calculations/namelists.py
+++ b/aiida_quantumespresso/calculations/namelists.py
@@ -257,12 +257,6 @@ class NamelistsCalculation(JobCalculation):
         
         calcinfo.retrieve_singlefile_list = self._retrieve_singlefile_list
 
-        codeinfo = CodeInfo()
-        codeinfo.stdin_name = self._INPUT_FILE_NAME
-        codeinfo.stdout_name = self._OUTPUT_FILE_NAME
-        codeinfo.code_uuid = code.uuid
-        calcinfo.codes_info = [codeinfo]
-
         if settings_dict:
             try:
                 Parserclass = self.get_parserclass()


### PR DESCRIPTION
Hi,

I removed redundant lines of code from `namelists.py` that overwrite `calcinfo.codes_info`. 

`calcinfo.codes_info` was set couple of lines before (line 249) with a correct `CodeInfo()` instance, that had also the commandline parameters specified. 