### PR TITLE
Remove the `_error_handlers` list attribute from BaseRestartWorkChain

### DIFF
--- a/aiida_quantumespresso/common/workchain/base/restart.py
+++ b/aiida_quantumespresso/common/workchain/base/restart.py
@@ -52,7 +52,6 @@ class BaseRestartWorkChain(WorkChain):
     before the next calculation will be run with those inputs.
     """
     _verbose = False
-    _error_handlers = []
     _calculation_class = None
     _error_handler_entry_point = None
     _expected_calculation_states = [calc_states.FINISHED, calc_states.FAILED, calc_states.SUBMISSIONFAILED]
@@ -148,7 +147,7 @@ class BaseRestartWorkChain(WorkChain):
 
         # Abort: exceeded maximum number of retries
         elif self.ctx.iteration >= self.inputs.max_iterations.value:
-            self.abort_nowait('reached the maximumm number of iterations {}\nlast ran {}<{}>'
+            self.abort_nowait('reached the maximumm number of iterations {}: last ran {}<{}>'
                 .format(self.inputs.max_iterations.value, self._calculation_class.__name__, calculation.pk))
 
         # Abort: unexpected state of last calculation

--- a/aiida_quantumespresso/common/workchain/utils.py
+++ b/aiida_quantumespresso/common/workchain/utils.py
@@ -56,12 +56,19 @@ def register_error_handler(cls, priority):
         during the handling of a failed calculation. Higher priorities will be handled first
     """
     def error_handler_decorator(handler):
+
         @wraps(handler)
         def error_handler(self, calculation):
             if hasattr(cls, '_verbose') and cls._verbose:
                 self.report('({}){}'.format(priority, handler.__name__))
             return handler(self, calculation)
+
         setattr(cls, handler.__name__, error_handler)
+
+        if not hasattr(cls, '_error_handlers'):
+            cls._error_handlers = []
         cls._error_handlers.append(ErrorHandler(priority, error_handler))
+
         return error_handler
+
     return error_handler_decorator


### PR DESCRIPTION
Fixes #127 

Because it was defined as a class attribute for the BaseRestartWorkChain
each time the register_error_handler decorator was used, the method was
appended to the exact same list, regardless of the workchain class to
which it was supposed to be applied.