### PR TITLE
PwParser: parse the standard output even if xml file is missing

### DIFF
--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -83,10 +83,12 @@ class PwParser(Parser):
         # The xml file is required for parsing
         if not self._calc._DATAFILE_XML_BASENAME in list_of_files:
             self.logger.error("The xml output file '{}' was not found but is required".format(self._calc._DATAFILE_XML_BASENAME))
-            return False, ()
+            successful = False
+            xml_file = None
+        else:
+            xml_file = os.path.join(out_folder.get_abs_path('.'), self._calc._DATAFILE_XML_BASENAME)
 
         out_file = os.path.join(out_folder.get_abs_path('.'), self._calc._OUTPUT_FILE_NAME)
-        xml_file = os.path.join(out_folder.get_abs_path('.'), self._calc._DATAFILE_XML_BASENAME)
 
         # Call the raw parsing function
         parsing_args = [out_file, parameters, parser_opts, xml_file, dir_with_bands]


### PR DESCRIPTION
Fixes #132 

The standard output will still contain useful information and if we
return straight away after detecting the missing the xml file, the
returned output parameters will be empty and useless to the user.