### PR TITLE
Adapt usage of get_outputs to function signature change

### DIFF
--- a/aiida_quantumespresso/calculations/__init__.py
+++ b/aiida_quantumespresso/calculations/__init__.py
@@ -873,7 +873,7 @@ class BasePwCpInputGenerator(object):
             old_inp_dict['CONTROL']['restart_mode'] = 'restart'
             inp_dict = ParameterData(dict=old_inp_dict)
 
-        remote_folders = self.get_outputs(type=RemoteData)
+        remote_folders = self.get_outputs(node_type=RemoteData)
         if len(remote_folders) != 1:
             raise InputValidationError("More than one output RemoteData found "
                                        "in calculation {}".format(self.pk))

--- a/aiida_quantumespresso/calculations/neb.py
+++ b/aiida_quantumespresso/calculations/neb.py
@@ -513,7 +513,7 @@ class NebCalculation(BasePwCpInputGenerator,JobCalculation):
         old_inp_dict['PATH']['restart_mode'] = 'restart'
         inp_dict = ParameterData(dict=old_inp_dict)
 
-        remote_folders = self.get_outputs(type=RemoteData)
+        remote_folders = self.get_outputs(node_type=RemoteData)
         if len(remote_folders) != 1:
             raise InputValidationError("More than one output RemoteData found "
                                        "in calculation {}".format(self.pk))

--- a/aiida_quantumespresso/calculations/ph.py
+++ b/aiida_quantumespresso/calculations/ph.py
@@ -478,7 +478,7 @@ class PhCalculation(JobCalculation):
         
         self._check_valid_parent(calc)
         
-        remotedatas = calc.get_outputs(type=RemoteData)
+        remotedatas = calc.get_outputs(node_type=RemoteData)
         if not remotedatas:
             raise NotExistent("No output remotedata found in "
                                   "the parent")
@@ -553,7 +553,7 @@ class PhCalculation(JobCalculation):
         old_inp_dict['INPUTPH']['recover'] = True
         inp_dict = ParameterData(dict=old_inp_dict) 
         
-        remote_folders = self.get_outputs(type=RemoteData)
+        remote_folders = self.get_outputs(node_type=RemoteData)
         if len(remote_folders)!=1:
             raise InputValidationError("More than one output RemoteData found "
                                        "in calculation {}".format(self.pk))


### PR DESCRIPTION
Fixes #142 

The signature was fixed and the wrong use of the keyword argument
`type` was replaced by `node_type`.