### PR TITLE
Fix update aiida core requirement to v1.0.0a1

### DIFF
--- a/.travis-data/before_script.sh
+++ b/.travis-data/before_script.sh
@@ -8,9 +8,7 @@ then
     # Refresh the entrypoint cache through reentry
     reentry scan
 
-    # start the daemon for the correct profile
-    # (actually, for the way it works now, the -p probably does not
-    #  have any effect...)
+    # Start the daemon for the correct profile
     verdi -p $TEST_AIIDA_BACKEND daemon start
     
     # Setup the torquessh computer

--- a/.travis-data/setup_profiles.sh
+++ b/.travis-data/setup_profiles.sh
@@ -5,6 +5,7 @@ if [[ "$TEST_TYPE" != "pre-commit" ]]
 then
     # Here I create the actual DB for submission
     psql -c "CREATE DATABASE $TEST_AIIDA_BACKEND;" -U postgres
+
     # Here I create the test DB
     psql -c "CREATE DATABASE test_$TEST_AIIDA_BACKEND;" -U postgres
 
@@ -14,7 +15,6 @@ then
     # Here I setup the test AiiDA profile, non-interactively
     verdi -p test_$TEST_AIIDA_BACKEND setup --non-interactive --backend=$TEST_AIIDA_BACKEND --email="aiida@localhost" --db_host="localhost" --db_port=5432 --db_name="test_$TEST_AIIDA_BACKEND" --db_user=postgres --db_pass='' --repo="/tmp/test_repository_test_${TEST_AIIDA_BACKEND}/" --first-name=AiiDA --last-name=test --institution="AiiDA Team" --no-password
 
-    # Maybe not needed, but set this profile to be the default one for (at least) the daemon
-    verdi profile setdefault daemon $TEST_AIIDA_BACKEND
-    verdi profile setdefault verdi $TEST_AIIDA_BACKEND
+    # Maybe not needed, but set this profile to be the default one
+    verdi profile setdefault $TEST_AIIDA_BACKEND
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: required
+
 language: python
 
 python:
@@ -6,6 +9,7 @@ python:
 cache: pip
 
 services:
+    - rabbitmq
     - postgresql
     - docker
 

--- a/setup.json
+++ b/setup.json
@@ -78,7 +78,7 @@
         ]
     }, 
     "install_requires": [
-        "aiida_core>=0.12.0[atomic_tools]", 
+        "aiida_core>=1.0.0a1[atomic_tools]", 
         "click"
     ], 
     "license": "MIT License", 


### PR DESCRIPTION
This branch will become `aiida-quantumespresso v3.0.0` which will rely on
`aiida-core v1.0.0`, so here we update the requirement to the just released alpha version