### PR TITLE
Set upper bound for aiida-core requirement to <v1.0.0

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -78,7 +78,7 @@
         ]
     }, 
     "install_requires": [
-        "aiida_core>=0.12.0[atomic_tools]", 
+        "aiida_core<1.0.0[atomic_tools]", 
         "click"
     ], 
     "license": "MIT License", 

--- a/setup.json
+++ b/setup.json
@@ -78,7 +78,7 @@
         ]
     }, 
     "install_requires": [
-        "aiida_core<1.0.0[atomic_tools]", 
+        "aiida_core>=0.12.0,<1.0.0[atomic_tools]", 
         "click"
     ], 
     "license": "MIT License", 


### PR DESCRIPTION
This branch will not work with the planned release aiida-core v1.0.0
and so we have to put an upper bound for the requirement