### PR TITLE
 Add support for Hubbard V extension to PwCalculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This is the official Quantum ESPRESSO plugin for AiiDA.
 The version 3.x series ot the AiiDA-Quantum ESPRESSO plugins are compatible with the AiiDA 1.x series.
 For the plugin that supports AiiDA 0.9-0.12, check the earlier version of this plugin (versions 1.x and 2.x).
 
+The plugin versions 1.x and 2.x support AiiDA-core in the 0.9-0.12 range.
+For the plugins compatible with AiiDA-core 1.x, check the pre-releases for version 3.x (branch `release-v3.0.0`).
+
 # Documentation
 The documentation for this package can be found on Read the Docs at 
 http://aiida-quantumespresso.readthedocs.io/en/latest/

--- a/aiida_quantumespresso/calculations/__init__.py
+++ b/aiida_quantumespresso/calculations/__init__.py
@@ -548,6 +548,11 @@ class BasePwCpInputGenerator(object):
                 raise InputValidationError("vdw_table, if specified, "
                                            "must be of type SinglefileData")
 
+        hubbard_file = inputdict.pop(self.get_linkname('hubbard_file'), None)
+        if hubbard_file is not None:
+            if not isinstance(hubbard_file, SinglefileData):
+                raise InputValidationError('hubbard_file, if specified, must be of type SinglefileData')
+
         try:
             code = inputdict.pop(self.get_linkname('code'))
         except KeyError:
@@ -579,13 +584,14 @@ class BasePwCpInputGenerator(object):
         # Note that the name of the table is not checked but should be the
         # one expected by QE.
         if vdw_table:
-            local_copy_list.append(
-                (
-                vdw_table.get_file_abs_path(),
-                os.path.join(self._PSEUDO_SUBFOLDER,
-                    os.path.split(vdw_table.get_file_abs_path())[1])
-                )
-                )
+            src_path = vdw_table.get_file_abs_path()
+            dst_path = os.path.join(self._PSEUDO_SUBFOLDER, os.path.split(vdw_table.get_file_abs_path())[1])
+            local_copy_list.append((src_path, dst_path))
+
+        if hubbard_file:
+            src_path = hubbard_file.get_file_abs_path()
+            dst_path = self.input_file_name_hubbard_file
+            local_copy_list.append((src_path, dst_path))
 
         input_filecontent, local_copy_pseudo_list = self._generate_PWCPinputdata(parameters,settings_dict,pseudos,
                                                                                  structure,kpoints)

--- a/aiida_quantumespresso/utils/cli/options.py
+++ b/aiida_quantumespresso/utils/cli/options.py
@@ -15,15 +15,25 @@ clean_workdir = overridable_option(
 
 ecutwfc = overridable_option(
     '-W', '--ecutwfc', type=click.FLOAT, default=30., show_default=True,
-    help='The plane wave cutoff energy in Ry'
+    help='the plane wave cutoff energy in Ry'
 )
 
 ecutrho = overridable_option(
     '-R', '--ecutrho', type=click.FLOAT, default=240., show_default=True,
-    help='The charge density cutoff energy in Ry'
+    help='the charge density cutoff energy in Ry'
 )
 
 hubbard_u = overridable_option(
-    '-U', '--hubbard-u', nargs=2, multiple=True, type=click.Tuple([unicode, float]),
-    help='Add a Hubbard U term to a specific kind'
+    '-U', '--hubbard-u', nargs=2, multiple=True, type=click.Tuple([unicode, float]), metavar='KIND MAGNITUDE',
+    help='add a Hubbard U term to a specific kind'
+)
+
+hubbard_v = overridable_option(
+    '-V', '--hubbard-v', nargs=4, multiple=True, type=click.Tuple([int, int, int, float]), metavar='SITE SITE TYPE MAGNITUDE',
+    help='add a Hubbard V interaction between two sites'
+)
+
+starting_magnetization = overridable_option(
+    '-M', '--starting-magnetization', nargs=2, multiple=True, type=click.Tuple([unicode, float]),
+    help='add a starting magnetization to a specific kind'
 )

--- a/aiida_quantumespresso/utils/cli/validate.py
+++ b/aiida_quantumespresso/utils/cli/validate.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.common.exceptions import NotExistent
+
+
+@with_dbenv()
+def validate_hubbard_parameters(structure, parameters, hubbard_u=None, hubbard_v=None, hubbard_file_pk=None):
+    """
+    Validate Hubbard input parameters and update the parameters input node accordingly. If a valid hubbard_file_pk
+    is provided, the node will be loaded and returned
+
+    :param structure: the StructureData node that will be used in the inputs
+    :param parameters: the ParameterData node that will be used in the inputs
+    :param hubbard_u: the Hubbard U inputs values from the cli
+    :param hubbard_v: the Hubbard V inputs values from the cli
+    :param hubbard_file_pk: a pk referencing a SinglefileData with Hubbard parameters
+    :returns: the loaded SinglefileData node with Hubbard parameters if valid pk was defined, None otherwise
+    """
+    from aiida.orm import load_node
+    from aiida.orm.data.singlefile import SinglefileData
+
+    if [v is None for v in [hubbard_u, hubbard_v, hubbard_file_pk]].count(True) > 1:
+        raise ValueError('the hubbard_u, hubbard_v and hubbard_file_pk options are mutually exclusive')
+
+    hubbard_file = None
+
+    if hubbard_file_pk:
+
+        try:
+            hubbard_file = load_node(pk=hubbard_file_pk)
+        except NotExistent:
+            ValueError('{} is not a valid pk'.format(hubbard_file_pk))
+        else:
+            if not isinstance(hubbard_file, SinglefileData):
+                ValueError('Node<{}> is not a SinglefileData but {}'.format())
+
+        parameters['SYSTEM']['lda_plus_u'] = True
+        parameters['SYSTEM']['lda_plus_u_kind'] = 2
+        parameters['SYSTEM']['hubbard_parameters'] = 'file'
+
+    elif hubbard_v:
+
+        parameters['SYSTEM']['lda_plus_u'] = True
+        parameters['SYSTEM']['lda_plus_u_kind'] = 2
+        parameters['SYSTEM']['hubbard_parameters'] = 'input'
+        parameters['SYSTEM']['hubbard_v'] = []
+
+        for value in hubbard_v:
+            parameters['SYSTEM']['hubbard_v'].append(value)
+
+    elif hubbard_u:
+
+        structure_kinds = structure.get_kind_names()
+        hubbard_kinds = [value[0] for value in hubbard_u]
+
+        if not set(hubbard_kinds).issubset(structure_kinds):
+            raise ValueError('the kinds in the specified starting Hubbard values is not a strict subset of the kinds in the structure')
+
+        parameters['SYSTEM']['lda_plus_u'] = True
+        parameters['SYSTEM']['lda_plus_u_kind'] = 0
+        parameters['SYSTEM']['hubbard_u'] = {}
+
+        for kind, value in hubbard_u:
+            parameters['SYSTEM']['hubbard_u'][kind] = value
+
+    return hubbard_file


### PR DESCRIPTION
Fixes #155 

This change required the addition of an optional input for the
`PwCalculation class`, `hubbard_file`, through the use methods.
It can be used to pass in a single file produced by a `hp.x` calculation
for a +U+V calculation, which can be used to read the parameters
for a restart instead of having to define all Hubbard V parameters
manually in the input parameters.

The launch script for a `PwCalculation` has also been updated with
options to pass defined Hubbard parameters, either manually or through
the use of a Hubbard `SinglefileData` node, including validation of
these inputs