### PR TITLE
Fix the requirements string for aiida-core and atomic_tools optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,15 @@ before_install:
 install:
     # Upgrade pip setuptools and wheel to be able to run the next command
     - pip install -U pip wheel setuptools reentry
-    # Install AiiDA with some optional dependencies
-    - pip install .[atomic_tools,docs,dev_precommit]
+
+    # Install the repository with some optional dependencies
+    - pip install .[docs,dev_precommit]
 
 env:
 - TEST_TYPE="pre-commit"
 - TEST_AIIDA_BACKEND=django TEST_TYPE="docs"
 - TEST_AIIDA_BACKEND=django TEST_TYPE="tests"
 - TEST_AIIDA_BACKEND=sqlalchemy TEST_TYPE="tests"
-
 
 before_script:
     - .travis-data/setup_profiles.sh

--- a/setup.json
+++ b/setup.json
@@ -78,7 +78,7 @@
         ]
     }, 
     "install_requires": [
-        "aiida_core>=0.12.0,<1.0.0[atomic_tools]", 
+        "aiida_core[atomic_tools]>=0.12.0,<1.0.0", 
         "click"
     ], 
     "license": "MIT License", 


### PR DESCRIPTION
Fixes #160 

The optional needs to directly follow the dependency name. I also
removed the `atomic_tools` option in `.travis.yml` when installing
the `aiida-quantumespresso` package, as it does not have this optional
requirement group