### PR TITLE
Implement the new expose port functionality in workchains

### DIFF
--- a/aiida_quantumespresso/cli/workflows/pw/bands.py
+++ b/aiida_quantumespresso/cli/workflows/pw/bands.py
@@ -3,6 +3,7 @@ import click
 from aiida.utils.cli import command
 from aiida.utils.cli import options
 from aiida_quantumespresso.utils.cli import options as options_qe
+from aiida_quantumespresso.utils.cli import validate
 
 
 @command()
@@ -13,11 +14,18 @@ from aiida_quantumespresso.utils.cli import options as options_qe
 @options.max_num_machines()
 @options.max_wallclock_seconds()
 @options.daemon()
+@options_qe.ecutwfc()
+@options_qe.ecutrho()
+@options_qe.hubbard_u()
+@options_qe.hubbard_v()
+@options_qe.hubbard_file()
+@options_qe.starting_magnetization()
+@options_qe.smearing()
 @options_qe.automatic_parallelization()
 @options_qe.clean_workdir()
 def launch(
-    code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds, daemon,
-    automatic_parallelization, clean_workdir):
+    code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds, daemon, ecutwfc, ecutrho,
+    hubbard_u, hubbard_v, hubbard_file_pk, starting_magnetization, smearing, automatic_parallelization, clean_workdir):
     """
     Run the PwBandsWorkChain for a given input structure
     """
@@ -25,41 +33,71 @@ def launch(
     from aiida.orm.data.parameter import ParameterData
     from aiida.orm.utils import WorkflowFactory
     from aiida.work.launch import run, submit
-    from aiida_quantumespresso.utils.resources import get_default_options
+    from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     PwBandsWorkChain = WorkflowFactory('quantumespresso.pw.bands')
 
     parameters = {
         'SYSTEM': {
-            'ecutwfc': 30.,
-            'ecutrho': 240.,
+            'ecutwfc': ecutwfc,
+            'ecutrho': ecutrho,
         },
     }
 
-    relax_inputs = {
-        'kpoints_distance': Float(0.2),
-        'parameters': ParameterData(dict=parameters),
-    }
+    try:
+        hubbard_file = validate.validate_hubbard_parameters(structure, parameters, hubbard_u, hubbard_v, hubbard_file_pk)
+    except ValueError as exception:
+        raise click.BadParameter(exception.message)
+
+    try:
+        validate.validate_starting_magnetization(structure, parameters, starting_magnetization)
+    except ValueError as exception:
+        raise click.BadParameter(exception.message)
+
+    try:
+        validate.validate_smearing(parameters, smearing)
+    except ValueError as exception:
+        raise click.BadParameter(exception.message)
+
+    pseudo_family = Str(pseudo_family)
+    parameters = ParameterData(dict=parameters)
 
     inputs = {
-        'code': code,
         'structure': structure,
-        'pseudo_family': Str(pseudo_family),
-        'kpoints': kpoints,
-        'parameters': ParameterData(dict=parameters),
-        'relax': relax_inputs,
+        'relax': {
+            'base': {
+                'code': code,
+                'pseudo_family': pseudo_family,
+                'kpoints_distance': Float(1.0),
+                'parameters': parameters,
+                'meta_convergence': Bool(False),
+            }
+        },
+        'scf': {
+            'code': code,
+            'pseudo_family': pseudo_family,
+            'kpoints_distance': Float(1.0),
+            'parameters': parameters,
+        },
+        'bands': {
+            'code': code,
+            'pseudo_family': pseudo_family,
+            'kpoints_distance': Float(1.0),
+            'kpoints': kpoints,
+            'parameters': parameters,
+        }
     }
 
     if automatic_parallelization:
-        parallelization = {
-            'max_num_machines': max_num_machines,
-            'target_time_seconds': 0.5 * max_wallclock_seconds,
-            'max_wallclock_seconds': max_wallclock_seconds
-        }
-        inputs['automatic_parallelization'] = ParameterData(dict=parallelization)
+        auto_para = ParameterData(dict=get_automatic_parallelization_options(max_num_machines, max_wallclock_seconds))
+        inputs['relax']['base']['automatic_parallelization'] = auto_para
+        inputs['scf']['automatic_parallelization'] = auto_para
+        inputs['bands']['automatic_parallelization'] = auto_para
     else:
-        options = get_default_options(max_num_machines, max_wallclock_seconds)
-        inputs['options'] = ParameterData(dict=options)
+        options = ParameterData(dict=get_default_options(max_num_machines, max_wallclock_seconds))
+        inputs['relax']['base']['options'] = options
+        inputs['scf']['options'] = options
+        inputs['bands']['options'] = options
 
     if clean_workdir:
         inputs['clean_workdir'] = Bool(True)

--- a/aiida_quantumespresso/cli/workflows/pw/base.py
+++ b/aiida_quantumespresso/cli/workflows/pw/base.py
@@ -3,7 +3,7 @@ import click
 from aiida.utils.cli import command
 from aiida.utils.cli import options
 from aiida_quantumespresso.utils.cli import options as options_qe
-
+from aiida_quantumespresso.utils.cli import validate
 
 
 @command()
@@ -14,11 +14,18 @@ from aiida_quantumespresso.utils.cli import options as options_qe
 @options.max_num_machines()
 @options.max_wallclock_seconds()
 @options.daemon()
+@options_qe.ecutwfc()
+@options_qe.ecutrho()
+@options_qe.hubbard_u()
+@options_qe.hubbard_v()
+@options_qe.hubbard_file()
+@options_qe.starting_magnetization()
+@options_qe.smearing()
 @options_qe.automatic_parallelization()
 @options_qe.clean_workdir()
 def launch(
-    code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds, daemon,
-    automatic_parallelization, clean_workdir):
+    code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds, daemon, ecutwfc, ecutrho,
+    hubbard_u, hubbard_v, hubbard_file_pk, starting_magnetization, smearing, automatic_parallelization, clean_workdir):
     """
     Run the PwBaseWorkChain for a given input structure
     """
@@ -26,16 +33,31 @@ def launch(
     from aiida.orm.data.parameter import ParameterData
     from aiida.orm.utils import WorkflowFactory
     from aiida.work.launch import run, submit
-    from aiida_quantumespresso.utils.resources import get_default_options
+    from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     PwBaseWorkChain = WorkflowFactory('quantumespresso.pw.base')
 
     parameters = {
         'SYSTEM': {
-            'ecutwfc': 30.,
-            'ecutrho': 240.,
+            'ecutwfc': ecutwfc,
+            'ecutrho': ecutrho,
         },
     }
+
+    try:
+        hubbard_file = validate.validate_hubbard_parameters(structure, parameters, hubbard_u, hubbard_v, hubbard_file_pk)
+    except ValueError as exception:
+        raise click.BadParameter(exception.message)
+
+    try:
+        validate.validate_starting_magnetization(structure, parameters, starting_magnetization)
+    except ValueError as exception:
+        raise click.BadParameter(exception.message)
+
+    try:
+        validate.validate_smearing(parameters, smearing)
+    except ValueError as exception:
+        raise click.BadParameter(exception.message)
 
     inputs = {
         'code': code,
@@ -46,12 +68,8 @@ def launch(
     }
 
     if automatic_parallelization:
-        parallelization = {
-            'max_num_machines': max_num_machines,
-            'target_time_seconds': 0.5 * max_wallclock_seconds,
-            'max_wallclock_seconds': max_wallclock_seconds
-        }
-        inputs['automatic_parallelization'] = ParameterData(dict=parallelization)
+        automatic_parallelization = get_automatic_parallelization_options(max_num_machines, max_wallclock_seconds)
+        inputs['automatic_parallelization'] = ParameterData(dict=automatic_parallelization)
     else:
         options = get_default_options(max_num_machines, max_wallclock_seconds)
         inputs['options'] = ParameterData(dict=options)

--- a/aiida_quantumespresso/cli/workflows/pw/relax.py
+++ b/aiida_quantumespresso/cli/workflows/pw/relax.py
@@ -3,6 +3,7 @@ import click
 from aiida.utils.cli import command
 from aiida.utils.cli import options
 from aiida_quantumespresso.utils.cli import options as options_qe
+from aiida_quantumespresso.utils.cli import validate
 
 
 @command()
@@ -13,6 +14,13 @@ from aiida_quantumespresso.utils.cli import options as options_qe
 @options.max_num_machines()
 @options.max_wallclock_seconds()
 @options.daemon()
+@options_qe.ecutwfc()
+@options_qe.ecutrho()
+@options_qe.hubbard_u()
+@options_qe.hubbard_v()
+@options_qe.hubbard_file()
+@options_qe.starting_magnetization()
+@options_qe.smearing()
 @options_qe.automatic_parallelization()
 @options_qe.clean_workdir()
 @click.option(
@@ -24,8 +32,9 @@ from aiida_quantumespresso.utils.cli import options as options_qe
     help='the label of a Group to add the final PwCalculation to in case of success'
 )
 def launch(
-    code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds, daemon,
-    automatic_parallelization, clean_workdir, final_scf, group):
+    code, structure, pseudo_family, kpoints, max_num_machines, max_wallclock_seconds, daemon, ecutwfc, ecutrho,
+    hubbard_u, hubbard_v, hubbard_file_pk, starting_magnetization, smearing, automatic_parallelization, clean_workdir,
+    final_scf, group):
     """
     Run the PwRelaxWorkChain for a given input structure
     """
@@ -33,35 +42,48 @@ def launch(
     from aiida.orm.data.parameter import ParameterData
     from aiida.orm.utils import WorkflowFactory
     from aiida.work.launch import run, submit
-    from aiida_quantumespresso.utils.resources import get_default_options
+    from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     PwRelaxWorkChain = WorkflowFactory('quantumespresso.pw.relax')
 
     parameters = {
         'SYSTEM': {
-            'ecutwfc': 30.,
-            'ecutrho': 240.,
+            'ecutwfc': ecutwfc,
+            'ecutrho': ecutrho,
         },
     }
 
+    try:
+        hubbard_file = validate.validate_hubbard_parameters(structure, parameters, hubbard_u, hubbard_v, hubbard_file_pk)
+    except ValueError as exception:
+        raise click.BadParameter(exception.message)
+
+    try:
+        validate.validate_starting_magnetization(structure, parameters, starting_magnetization)
+    except ValueError as exception:
+        raise click.BadParameter(exception.message)
+
+    try:
+        validate.validate_smearing(parameters, smearing)
+    except ValueError as exception:
+        raise click.BadParameter(exception.message)
+
     inputs = {
-        'code': code,
         'structure': structure,
-        'pseudo_family': Str(pseudo_family),
-        'kpoints': kpoints,
-        'parameters': ParameterData(dict=parameters),
+        'base': {
+            'code': code,
+            'pseudo_family': Str(pseudo_family),
+            'kpoints': kpoints,
+            'parameters': ParameterData(dict=parameters),
+        }
     }
 
     if automatic_parallelization:
-        parallelization = {
-            'max_num_machines': max_num_machines,
-            'target_time_seconds': 0.5 * max_wallclock_seconds,
-            'max_wallclock_seconds': max_wallclock_seconds
-        }
-        inputs['automatic_parallelization'] = ParameterData(dict=parallelization)
+        automatic_parallelization = get_automatic_parallelization_options(max_num_machines, max_wallclock_seconds)
+        inputs['base']['automatic_parallelization'] = ParameterData(dict=automatic_parallelization)
     else:
         options = get_default_options(max_num_machines, max_wallclock_seconds)
-        inputs['options'] = ParameterData(dict=options)
+        inputs['base']['options'] = ParameterData(dict=options)
 
     if clean_workdir:
         inputs['clean_workdir'] = Bool(True)

--- a/aiida_quantumespresso/utils/cli/options.py
+++ b/aiida_quantumespresso/utils/cli/options.py
@@ -24,16 +24,26 @@ ecutrho = overridable_option(
 )
 
 hubbard_u = overridable_option(
-    '-U', '--hubbard-u', nargs=2, multiple=True, type=click.Tuple([unicode, float]), metavar='KIND MAGNITUDE',
-    help='add a Hubbard U term to a specific kind'
+    '-U', '--hubbard-u', nargs=2, multiple=True, type=click.Tuple([unicode, float]),
+    help='add a Hubbard U term to a specific kind', metavar='<KIND MAGNITUDE>...'
 )
 
 hubbard_v = overridable_option(
-    '-V', '--hubbard-v', nargs=4, multiple=True, type=click.Tuple([int, int, int, float]), metavar='SITE SITE TYPE MAGNITUDE',
-    help='add a Hubbard V interaction between two sites'
+    '-V', '--hubbard-v', nargs=4, multiple=True, type=click.Tuple([int, int, int, float]),
+    help='add a Hubbard V interaction between two sites', metavar='<SITE SITE TYPE MAGNITUDE>...'
+)
+
+hubbard_file = overridable_option(
+    '-H', '--hubbard-file', 'hubbard_file_pk', type=click.INT,
+    help='the pk of a SinglefileData containing Hubbard parameters from a HpCalculation to use as input for Hubbard V'
 )
 
 starting_magnetization = overridable_option(
     '-M', '--starting-magnetization', nargs=2, multiple=True, type=click.Tuple([unicode, float]),
-    help='add a starting magnetization to a specific kind'
+    help='add a starting magnetization to a specific kind', metavar='<KIND MAGNITUDE>...'
+)
+
+smearing = overridable_option(
+    '-S', '--smearing', nargs=2, default=(None, None), type=click.Tuple([unicode, float]),
+    help='add smeared occupations by specifying the type and amount of smearing', metavar='<TYPE DEGAUSS>'
 )

--- a/aiida_quantumespresso/utils/mapping.py
+++ b/aiida_quantumespresso/utils/mapping.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections import Mapping
 from aiida.common.extendeddicts import AttributeDict
-from aiida.orm.calculation.job import JobCalculation
 from aiida.orm.data.parameter import ParameterData
-from aiida.work.processes import Process
 
 
 def update_mapping(original, source):
@@ -27,9 +25,9 @@ def update_mapping(original, source):
 
     for key, value in source.iteritems():
         if (
-            key in original 
-            and (isinstance(value, Mapping) or isinstance(value, ParameterData))
-            and (isinstance(original[key], Mapping) or isinstance(original[key], ParameterData))
+            key in original and
+            (isinstance(value, Mapping) or isinstance(value, ParameterData)) and
+            (isinstance(original[key], Mapping) or isinstance(original[key], ParameterData))
         ):
             original[key] = update_mapping(original[key], value)
         else:

--- a/aiida_quantumespresso/utils/resources.py
+++ b/aiida_quantumespresso/utils/resources.py
@@ -3,6 +3,7 @@ import numpy as np
 from math import exp, ceil
 from aiida_quantumespresso.utils.defaults.calculation import pw as pw_defaults
 
+
 def create_scheduler_resources(scheduler, base, goal):
     """
     This function will take a dictionary 'base', which contains scheduler resource
@@ -36,6 +37,7 @@ def create_scheduler_resources(scheduler, base, goal):
 
     return {key: value for key, value in job_resource.iteritems() if value is not None}
 
+
 def cmdline_remove_npools(cmdline):
     """
     Remove all options related to npools in the list of command line options that is
@@ -50,24 +52,40 @@ def cmdline_remove_npools(cmdline):
     :param cmdline: the cmdline setting which is a list of string directives
     :return: the new cmdline setting
     """
-    return [e for i,e in enumerate(cmdline) 
-             if (e not in ('-npools','-npool','-nk') 
-                 and cmdline[i-1] not in ('-npools','-npool','-nk'))]
+    return [e for i, e in enumerate(cmdline) if (e not in ('-npools', '-npool', '-nk') and
+        cmdline[i - 1] not in ('-npools', '-npool', '-nk'))]
 
-def get_default_options(num_machines=1, max_wallclock_seconds=1800):
+
+def get_default_options(max_num_machines=1, max_wallclock_seconds=1800):
     """
     Return an instance of the options dictionary with the minimally required parameters
     for a JobCalculation and set to default values unless overriden
 
-    :param num_machines: set the number of nodes, default=1
+    :param max_num_machines: set the number of nodes, default=1
     :param max_wallclock_seconds: set the maximum number of wallclock seconds, default=1800
     """
     return {
         'resources': {
-            'num_machines': int(num_machines)
+            'num_machines': int(max_num_machines)
         },
         'max_wallclock_seconds': int(max_wallclock_seconds),
+        'withmpi': False
     }
+
+
+def get_automatic_parallelization_options(max_num_machines=1, max_wallclock_seconds=1800):
+    """
+    Return an instance of the automatic parallelization options dictionary
+
+    :param max_num_machines: set the number of nodes, default=1
+    :param max_wallclock_seconds: set the maximum number of wallclock seconds, default=1800
+    """
+    return {
+        'max_num_machines': max_num_machines,
+        'target_time_seconds': 0.5 * max_wallclock_seconds,
+        'max_wallclock_seconds': max_wallclock_seconds
+    }
+
 
 def get_pw_parallelization_parameters(calculation, max_num_machines, target_time_seconds, max_wallclock_seconds,
     calculation_mode='scf', round_interval=1800, scaling_law=(exp(-16.1951988), 1.22535849)):
@@ -84,13 +102,13 @@ def get_pw_parallelization_parameters(calculation, max_num_machines, target_time
         ('scf', 'nscf', 'bands', 'relax', 'md', 'vc-relax', 'vc-md')
     :param round_interval: the interval in seconds to which the estimated time in the results
         will be rounded up, to determine the max_wallclock_seconds that should be set
-    :param scaling_law: list or tuple with 2 numbers giving the 
-        fit parameters for a power law expressing the single-CPU time to do 
-        1 scf step, for 1 k-point, 1 spin and 1 small box of the fft grid, 
+    :param scaling_law: list or tuple with 2 numbers giving the
+        fit parameters for a power law expressing the single-CPU time to do
+        1 scf step, for 1 k-point, 1 spin and 1 small box of the fft grid,
         as a function of number of electrons, in the form:
             normalized_single_CPU_time = A*n_elec^B
         where A is the first number and B the second.
-        Default values were obtained on piz-dora (CSCS) in 2015, on a set of 
+        Default values were obtained on piz-dora (CSCS) in 2015, on a set of
         4370 calculations (with a very rough fit).
 
     :return: a dictionary with suggested parallelization parameters with the following keys
@@ -100,12 +118,12 @@ def get_pw_parallelization_parameters(calculation, max_num_machines, target_time
         * estimated_time: the estimated time the calculation should take in seconds
         * max_wallclock_seconds: the recommended max_wall_clock_seconds setting based on the
             estimated_time value and the round_interval argument
-        
+
     .. note:: If there was an out-of-memory problem during the initial
         calculation, the number of machines is increased.
     """
     from fractions import gcd
-    
+
     default_num_mpiprocs_per_machine = calculation.get_computer().get_default_mpiprocs_per_machine()
 
     input_parameters = calculation.inp.parameters.get_dict()
@@ -129,13 +147,17 @@ def get_pw_parallelization_parameters(calculation, max_num_machines, target_time
 
     # Compute an estimate single-CPU time
     time_single_cpu = np.prod(fft_grid) * nspin * nkpoints * niterations * scaling_law[0] * nbands ** scaling_law[1]
-    
+
     # The number of nodes is the maximum number we can use that is dividing nkpoints
     num_machines = max([m for m in range(1, max_num_machines + 1) if nkpoints % m == 0])
 
     # If possible try to make number of kpoints even by changing the number of machines
-    if (num_machines == 1 and nkpoints > 6 and max_num_machines > 1
-        and time_single_cpu / default_num_mpiprocs_per_machine > target_time):
+    if (
+        num_machines == 1 and
+        nkpoints > 6 and
+        max_num_machines > 1 and
+        time_single_cpu / default_num_mpiprocs_per_machine > target_time_seconds
+    ):
         num_machines = max([m for m in range(1, max_num_machines + 1) if (nkpoints + 1) % m == 0])
 
     # Now we will try to decrease the number of processes per machine (by not more than one fourth)
@@ -165,9 +187,9 @@ def get_pw_parallelization_parameters(calculation, max_num_machines, target_time
     if calculation.get_scheduler_error() and 'OOM' in calculation.get_scheduler_error():
         num_machines = max([i for i in range(num_machines, max_num_machines + 1) if i % num_machines == 0])
 
-    estimated_time = time_single_cpu/(num_mpiprocs_per_machine * num_machines)
+    estimated_time = time_single_cpu / (num_mpiprocs_per_machine * num_machines)
     max_wallclock_seconds = min(ceil(estimated_time / round_interval) * round_interval, max_wallclock_seconds)
-    
+
     result = {
         'resources': {
             'num_machines': num_machines,

--- a/aiida_quantumespresso/workflows/workfunctions.py
+++ b/aiida_quantumespresso/workflows/workfunctions.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from aiida.work.workfunctions import workfunction
+
+
+@workfunction
+def create_kpoints_from_distance(structure, distance, force_parity):
+    """
+    Generate a uniformly spaced kpoint mesh for a given structure where the spacing between kpoints in reciprocal
+    space is guaranteed to be at least the defined distance.
+
+    :param structure: the StructureData to which the mesh should apply
+    :param distance: a Float with the desired distance between kpoints in reciprocal space
+    :param force_parity: a Bool to specify whether the generated mesh should maintain parity
+    :returns: a KpointsData with the generated mesh
+    """
+    from aiida.orm.data.array.kpoints import KpointsData
+
+    kpoints = KpointsData()
+    kpoints.set_cell_from_structure(structure)
+    kpoints.set_kpoints_mesh_from_density(distance.value, force_parity=force_parity.value)
+
+    return kpoints


### PR DESCRIPTION
Fixes #164 

A recent update in aiida-core made it possible to properly expose
the input ports of a workchain in a wrapping workchain. The whole
exposed process class can now also be made to be optional, which
means that if that namespace is left empty when the workchain is
instantiated, the validation will not be triggered.

This mechanism is for example used in the PwBandsWorkChain, which
will expose the inputs of the PwRelaxWorkChain, but make the space
optional. This means that the presence of the `relax` namespace
in the inputs can now be used as a switch to determine whether the
user wants the structure to be relaxed.

Additionally, we provide support for defining smearing, starting
magnetization and Hubbard parameters through the command line
interface launch scripts, including the corresponding validation
functions.