### PR TITLE
Implement the new exit code functionality in the workchains

### DIFF
--- a/aiida_quantumespresso/cli/workflows/ph/base.py
+++ b/aiida_quantumespresso/cli/workflows/ph/base.py
@@ -20,11 +20,10 @@ def launch(
     """
     from aiida.orm.data.base import Bool
     from aiida.orm.data.parameter import ParameterData
-    from aiida.orm.utils import CalculationFactory, WorkflowFactory
+    from aiida.orm.utils import WorkflowFactory
     from aiida.work.launch import run, submit
     from aiida_quantumespresso.utils.resources import get_default_options
 
-    PwCalculation = CalculationFactory('quantumespresso.pw')
     PhBaseWorkChain = WorkflowFactory('quantumespresso.ph.base')
 
     parameters = {

--- a/aiida_quantumespresso/common/workchain/utils.py
+++ b/aiida_quantumespresso/common/workchain/utils.py
@@ -2,6 +2,9 @@
 from collections import namedtuple
 from functools import wraps
 
+from aiida.work import ExitCode
+
+
 ErrorHandler = namedtuple('ErrorHandler', 'priority method')
 """
 A namedtuple to define an error handler for a :class:`~aiida.work.workchain.WorkChain`.
@@ -15,8 +18,9 @@ as its sole argument. If the condition of the error handler is met, it should re
 :param method: the workchain class method
 """
 
-ErrorHandlerReport = namedtuple('ErrorHandlerReport', 'is_handled do_break exit_status')
-ErrorHandlerReport.__new__.__defaults__ = (False, False, None)
+
+ErrorHandlerReport = namedtuple('ErrorHandlerReport', 'is_handled do_break exit_code')
+ErrorHandlerReport.__new__.__defaults__ = (False, False, ExitCode())
 """
 A namedtuple to define an error handler report for a :class:`~aiida.work.workchain.WorkChain`.
 
@@ -28,8 +32,9 @@ the 'do_break' field should be set to `True`
 
 :param is_handled: boolean, set to `True` when an error was handled, default is `False`
 :param do_break: boolean, set to `True` if no further error handling should be performed, default is `False`
-:param exit_status: set to non-zero integer to abort the workchain with this exit status, default is `None`
+:param exit_code: an instance of the :class:`~aiida.work.ExitCode` tuple
 """
+
 
 def register_error_handler(cls, priority):
     """

--- a/aiida_quantumespresso/utils/mapping.py
+++ b/aiida_quantumespresso/utils/mapping.py
@@ -50,6 +50,11 @@ def prepare_process_inputs(process, inputs):
     :param inputs: a dictionary of inputs intended for submission of the process
     :return: a dictionary with all bare dictionaries wrapped in ParameterData if dictated by process spec
     """
+    from aiida.orm.calculation.job import JobCalculation
+
+    if issubclass(process, JobCalculation):
+        process = process.process()
+
     prepared_inputs = AttributeDict()
 
     try:

--- a/aiida_quantumespresso/utils/pseudopotential.py
+++ b/aiida_quantumespresso/utils/pseudopotential.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from aiida.orm.data.upf import UpfData, get_pseudos_from_structure
 
+
 def get_pseudos_of_calc(calc):
     """
     Return a dictionary of pseudos used by a given (pw.x, cp.x) calculation.
@@ -24,6 +25,7 @@ def get_pseudos_of_calc(calc):
             pseudos[multiplekindstring] = inputs[linkname]
     return pseudos
 
+
 def validate_and_prepare_pseudos_inputs(structure, pseudos=None, pseudo_family=None):
     """
     Use the explicitly passed pseudos dictionary or use the pseudo_family in combination with
@@ -34,7 +36,7 @@ def validate_and_prepare_pseudos_inputs(structure, pseudos=None, pseudo_family=N
     but multiple links for the same input node are not allowed. Moreover, to couple the UPF nodes
     to the Calculation instance, we have to go through the use_pseudo method, which takes the kind
     name as an additional parameter. When creating a Calculation through a Process instance, one
-    cannot call the use methods directly but rather should pass them as keyword arguments. However, 
+    cannot call the use methods directly but rather should pass them as keyword arguments. However,
     we can pass the additional parameters by using them as the keys of a dictionary
 
     :param structure: StructureData node

--- a/aiida_quantumespresso/utils/resources.py
+++ b/aiida_quantumespresso/utils/resources.py
@@ -69,7 +69,6 @@ def get_default_options(max_num_machines=1, max_wallclock_seconds=1800):
             'num_machines': int(max_num_machines)
         },
         'max_wallclock_seconds': int(max_wallclock_seconds),
-        'withmpi': False
     }
 
 

--- a/aiida_quantumespresso/workflows/matdyn/base.py
+++ b/aiida_quantumespresso/workflows/matdyn/base.py
@@ -68,4 +68,3 @@ class MatdynBaseWorkChain(BaseRestartWorkChain):
             self.ctx.inputs.options = self.inputs.options.get_dict()
         else:
             self.ctx.inputs.options = get_default_options()
-

--- a/aiida_quantumespresso/workflows/ph/base.py
+++ b/aiida_quantumespresso/workflows/ph/base.py
@@ -30,8 +30,6 @@ class PhBaseWorkChain(BaseRestartWorkChain):
         'alpha_mix': 0.70,
     })
 
-    ERROR_CALCULATION_INVALID_INPUT_FILE = 7
-
     @classmethod
     def define(cls, spec):
         super(PhBaseWorkChain, cls).define(spec)
@@ -52,6 +50,8 @@ class PhBaseWorkChain(BaseRestartWorkChain):
             ),
             cls.results,
         )
+        spec.exit_code(402, 'ERROR_CALCULATION_INVALID_INPUT_FILE',
+            message='the calculation failed because it had an invalid input file')
         spec.output('output_parameters', valid_type=ParameterData)
         spec.output('remote_folder', valid_type=RemoteData)
         spec.output('retrieved', valid_type=FolderData)
@@ -118,7 +118,7 @@ def _handle_fatal_error_read_namelists(self, calculation):
     """
     if any(['reading inputph namelist' in w for w in calculation.res.warnings]):
         self.report('PhCalculation<{}> failed because of an invalid input file'.format(calculation.pk))
-        return ErrorHandlerReport(True, True, self.ERROR_CALCULATION_INVALID_INPUT_FILE)
+        return ErrorHandlerReport(True, True, self.exit_codes.ERROR_CALCULATION_INVALID_INPUT_FILE)
 
 
 @register_error_handler(PhBaseWorkChain, 300)


### PR DESCRIPTION
Fixes #173 

New functionality added in aiida-core now allows to define known exit
modes of a WorkChain through its ProcessSpec. They can be added in the
define method, through the exit_code method. Later they can be retrieved
through the exit_codes collection property for a given label