### PR TITLE
Ensure a handler_report was defined before returning its exit code

### DIFF
--- a/aiida_quantumespresso/common/workchain/base/restart.py
+++ b/aiida_quantumespresso/common/workchain/base/restart.py
@@ -312,7 +312,11 @@ class BaseRestartWorkChain(WorkChain):
         if not is_handled:
             raise UnexpectedCalculationFailure('calculation failure was not handled')
 
-        return handler_report.exit_code
+        # The last called error handler may not necessarily have returned a handler report
+        if handler_report:
+            return handler_report.exit_code
+
+        return
 
     def _prepare_process_inputs(self, process, inputs):
         """


### PR DESCRIPTION
Fixes #189 

The last called error handler in BaseRestartWorkChain._handle_calculation_failure
may not necessarily have returned an ErrorHandlerReport. Before returning
its exit code, it should be verified that it is not None.