### PR TITLE
Do not set restart_calc when error handler sets is_handled to True

### DIFF
--- a/aiida_quantumespresso/common/workchain/base/restart.py
+++ b/aiida_quantumespresso/common/workchain/base/restart.py
@@ -301,7 +301,6 @@ class BaseRestartWorkChain(WorkChain):
 
             # If at least one error is handled, we consider the calculation failure handled
             if handler_report and handler_report.is_handled:
-                self.ctx.restart_calc = calculation
                 is_handled = True
 
             # After certain error handlers, we may want to skip all other error handling


### PR DESCRIPTION
Fixes #190 

Some error handlers that are called in _handle_calculation_failure
may return an ErrorHandlerReport with is_handled = True, but the
failed calculation may be unusable and should not be used for a
restart. The responsibility of setting the restart_calc is that of
the error handlers.