### PR TITLE
Improve kpoint mesh selection algorithm in `create_kpoints_from_distance`

### DIFF
--- a/aiida_quantumespresso/workflows/workfunctions.py
+++ b/aiida_quantumespresso/workflows/workfunctions.py
@@ -13,10 +13,24 @@ def create_kpoints_from_distance(structure, distance, force_parity):
     :param force_parity: a Bool to specify whether the generated mesh should maintain parity
     :returns: a KpointsData with the generated mesh
     """
+    from numpy import linalg
     from aiida.orm.data.array.kpoints import KpointsData
+
+    epsilon = 1E-5
 
     kpoints = KpointsData()
     kpoints.set_cell_from_structure(structure)
     kpoints.set_kpoints_mesh_from_density(distance.value, force_parity=force_parity.value)
+
+    lengths_vector = [linalg.norm(vector) for vector in structure.cell]
+    lengths_kpoint = kpoints.get_kpoints_mesh()[0]
+
+    is_symmetric_cell = all(abs(length - lengths_vector[0]) < epsilon for length in lengths_vector)
+    is_symmetric_mesh = all(length == lengths_kpoint[0] for length in lengths_kpoint)
+
+    # If the vectors of the cell all have the same length, the kpoint mesh should be isotropic as well
+    if is_symmetric_cell and not is_symmetric_mesh:
+        nk = max(lengths_kpoint)
+        kpoints.set_kpoints_mesh([nk, nk, nk])
 
     return kpoints


### PR DESCRIPTION
Fixes #202 

The `create_kpoints_from_distance` workfunction is used by among others
the pw.x workchains to generate a suitable kpoint mesh for a given
structure with a minimal kpoint distance. However, for certain oddly
defined cell structures, this can generate meshes that result into
problems in pw.x. For example for certain cells with equal length
vectors in real space, the cell in reciprocal space can be non isotropic
causing a non-isotropic mesh to be generated. This leads to problems with
the symmetry operations leading to more kpoints being calculation than
necessary. We solve this particular problem by comparing the proposed
kpoint mesh to the real space cell. If the real space cell has vectors of
equal length but the mesh is non-isotropic, the mesh is made to be isotropic
by taking the highest number of kpoints and choosing that in all directions.