### PR TITLE
Fix `PwCalculation` and `PwParser` to changes in `aiida-core==1.0.0`

### DIFF
--- a/aiida_quantumespresso/calculations/__init__.py
+++ b/aiida_quantumespresso/calculations/__init__.py
@@ -306,7 +306,7 @@ class BasePwCpInputGenerator(CalcJob):
                 pseudo_filenames[ps.pk] = filename
                 # I add this pseudo file to the list of files to copy
                 filepath = os.path.join(ps._repository._get_base_folder().abspath, ps.filename)
-                local_copy_list_to_append.append((filepath, os.path.join(self._PSEUDO_SUBFOLDER, filename)))
+                local_copy_list_to_append.append((ps.uuid, ps.filename, os.path.join(self._PSEUDO_SUBFOLDER, filename)))
 
             kind_names.append(kind.name)
             atomic_species_card_list.append("{} {} {}\n".format(kind.name.ljust(6), kind.mass, filename))

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -57,7 +57,7 @@ class PwCalculation(BasePwCpInputGenerator):
         spec.input('metadata.options.parser_name', valid_type=six.string_types, default='quantumespresso.pw', non_db=True)
         spec.input('kpoints', valid_type=orm.KpointsData,
             help='kpoint mesh or kpoint path')
-        spec.input('hubbard_file', valid_type=orm.SinglefileData,
+        spec.input('hubbard_file', valid_type=orm.SinglefileData, required=False,
             help='SinglefileData node containing the output Hubbard parameters from a HpCalculation')
         spec.exit_code(
             100, 'ERROR_NO_RETRIEVED_FOLDER', message='The retrieved folder data node could not be accessed.')

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -30,11 +30,11 @@ class PwParser(Parser):
         except exceptions.NotExistent:
             return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
 
-        parameters = self.node.inp.parameters.get_dict()
+        parameters = self.node.inputs.parameters.get_dict()
 
         # Look for optional settings input node and potential 'parser_options' dictionary within it
         try:
-            settings = self.node.inp.settings.get_dict()
+            settings = self.node.inputs.settings.get_dict()
             parser_options = settings[self.get_parser_settings_key()]
         except (AttributeError, KeyError):
             settings = {}
@@ -195,7 +195,7 @@ class PwParser(Parser):
             kpoints_from_output = orm.KpointsData()
             kpoints_from_output.set_cell_from_structure(struc)
             kpoints_from_output.set_kpoints(k_points_list, cartesian=True, weights=k_points_weights_list)
-            kpoints_from_input = self.node.inp.kpoints
+            kpoints_from_input = self.node.inputs.kpoints
 
             if not bands_data:
                 try:


### PR DESCRIPTION
The format of the `local_copy_list` has been changed and the `inp`
property on the `Node` has been renamed to `inputs`.
Also, the optional `hubbard_file` input was not properly marked as such.