### PR TITLE
fixing symlink problem in pw plugin

### DIFF
--- a/aiida_quantumespresso/calculations/__init__.py
+++ b/aiida_quantumespresso/calculations/__init__.py
@@ -109,19 +109,19 @@ class BasePwCpInputGenerator(CalcJob):
         # operations for restart
         symlink = settings_dict.pop('PARENT_FOLDER_SYMLINK', self._default_symlink_usage)  # a boolean
         if symlink:
-            if 'parent_calc_folder' in self.inputs:
+            if 'parent_folder' in self.inputs:
                 # I put the symlink to the old parent ./out folder
                 remote_symlink_list.append((
-                    self.inputs.parent_calc_folder.get_computer().uuid,
-                    os.path.join(self.inputs.parent_calc_folder.get_remote_path(), self._restart_copy_from),
+                    self.inputs.parent_folder.computer.uuid,
+                    os.path.join(self.inputs.parent_folder.get_remote_path(), self._restart_copy_from),
                     self._restart_copy_to
                 ))
         else:
             # copy remote output dir, if specified
-            if 'parent_calc_folder' in self.inputs:
+            if 'parent_folder' in self.inputs:
                 remote_copy_list.append((
-                    self.inputs.parent_calc_folder.get_computer().uuid,
-                    os.path.join(self.inputs.parent_calc_folder.get_remote_path(), self._restart_copy_from),
+                    self.inputs.parent_folder.computer.uuid,
+                    os.path.join(self.inputs.parent_folder.get_remote_path(), self._restart_copy_from),
                     self._restart_copy_to
                 ))
 

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -50,6 +50,9 @@ class PwCalculation(BasePwCpInputGenerator):
     _DEFAULT_INPUT_FILE = 'aiida.in'
     _DEFAULT_OUTPUT_FILE = 'aiida.out'
 
+    #not using symlink in pw to allow multiple nscf to run on top of the same scf
+    _default_symlink_usage = False
+
     @classmethod
     def define(cls, spec):
         super(PwCalculation, cls).define(spec)


### PR DESCRIPTION
by default quantum espresso uses symlink but it doesn't work,
moreover restarts weren't working because uses the wrong link name for the parent folder