### PR TITLE
Bare essentials to make `PwCalculation` run in py2 and py3

### DIFF
--- a/aiida_quantumespresso/cli/calculations/pw/base.py
+++ b/aiida_quantumespresso/cli/calculations/pw/base.py
@@ -93,8 +93,8 @@ def cli(code, structure, pseudo_family, kpoints_mesh, ecutwfc, ecutrho, hubbard_
     else:
         click.echo('Running a pw.x calculation in the {} mode... '.format(mode))
         _, calculation = launch.run_get_node(PwCalculation, **inputs)
-        click.echo('PwCalculation<{}> terminated with state: {}'.format(calculation.pk, calculation.get_state()))
+        click.echo('PwCalculation<{}> terminated with state: {}'.format(calculation.pk, calculation.process_state))
         click.echo('\n{link:25s} {node}'.format(link='Output link', node='Node pk and type'))
         click.echo('{s}'.format(s='-' * 60))
-        for triple in sorted(calculation.get_outgoing().all()):
+        for triple in sorted(calculation.get_outgoing().all(), key=lambda triple: triple.link_label):
             click.echo('{:25s} {}<{}> '.format(triple.link_label, triple.node.__class__.__name__, triple.node.pk))

--- a/aiida_quantumespresso/parsers/raw_parser_pw.py
+++ b/aiida_quantumespresso/parsers/raw_parser_pw.py
@@ -466,7 +466,7 @@ def xml_card_ions(parsed_data,dom,lattice_vectors,volume):
                 # If I can't parse the digit, it is probably not there: I add a None to the tagslist
                 tagslist.append(None)
             # I remove the symbols
-            chem_symbol = chem_symbol.translate(None, string.digits)
+            chem_symbol = ''.join(i for i in chem_symbol if not i.isdigit())
 
             tagname2='tau'
             b = a.getAttribute(tagname2)

--- a/aiida_quantumespresso/utils/convert.py
+++ b/aiida_quantumespresso/utils/convert.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
+from __future__ import print_function
 import numbers
 import six
 from six.moves import zip
@@ -172,14 +173,14 @@ def convert_input_to_namelist_entry(key, val, mapping=None):
             except KeyError:
                 raise ValueError("Unable to find the key '{}' in the mapping dictionary".format(elemk))
 
-            list_of_strings.append((idx, '  {0}({2}) = {1}\n'.format(key, conv_to_fortran(itemval), idx)))
+            list_of_strings.append((idx, u'  {0}({2}) = {1}\n'.format(key, conv_to_fortran(itemval), idx)))
 
         # I first have to resort, then to remove the index from the first column, finally to join the strings
         list_of_strings = list(zip(*sorted(list_of_strings)))[1]
         return ''.join(list_of_strings)
 
-    # A list/array/tuple of values
-    elif hasattr(val, '__iter__'):
+    # A list/tuple of values
+    elif isinstance(val, (list, tuple)):
 
         list_of_strings = []
 
@@ -211,10 +212,10 @@ def convert_input_to_namelist_entry(key, val, mapping=None):
             else:
                 idx_string = '{}'.format(idx + 1)
 
-            list_of_strings.append('  {0}({2}) = {1}\n'.format(key, conv_to_fortran(itemval), idx_string))
+            list_of_strings.append(u'  {0}({2}) = {1}\n'.format(key, conv_to_fortran(itemval), idx_string))
 
-        return ''.join(list_of_strings)
+        return u''.join(list_of_strings)
 
     # Single value
     else:
-        return '  {0} = {1}\n'.format(key, conv_to_fortran(val))
+        return u'  {0} = {1}\n'.format(key, conv_to_fortran(val))


### PR DESCRIPTION
For the most part, the problem had to do with writing unicode strings to
a binary handle, which of course fails in python 3. We now write to a
handle that will write encoded text and make sure the string it receives
is unicode in both versions.

Additionally the `translate` string method has changed interface in py3
which was used in the XML parser.