### PR TITLE
Make a PW relax calculation work

### DIFF
--- a/aiida_quantumespresso/calculations/__init__.py
+++ b/aiida_quantumespresso/calculations/__init__.py
@@ -72,6 +72,8 @@ class BasePwCpInputGenerator(CalcJob):
         spec.input('parent_folder', valid_type=orm.RemoteData, required=False, help='')
         spec.input('vdw_table', valid_type=orm.SinglefileData, required=False, help='')
         spec.input_namespace('pseudos', valid_type=orm.UpfData, dynamic=True, help='')
+        # Override default withmpi=False
+        spec.input('metadata.options.withmpi', valid_type=bool, default=True)
 
     def prepare_for_submission(self, folder):
         """Create the input files from the input nodes passed to this instance of the `CalcJob`.
@@ -84,6 +86,7 @@ class BasePwCpInputGenerator(CalcJob):
             settings_dict = _uppercase_dict(settings, dict_name='settings')
         else:
             settings = {}
+            settings_dict = {}
 
         # Check that a pseudo potential was specified for each kind present in the `StructureData`
         kinds = [kind.name for kind in self.inputs.structure.kinds]

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -76,6 +76,7 @@ class PwCalculation(BasePwCpInputGenerator):
         spec.output('output_band', valid_type=orm.BandsData, required=False)
         spec.output('output_kpoints', valid_type=orm.KpointsData, required=False)
         spec.output('output_atomic_occupations', valid_type=orm.Dict, required=False)
+        spec.default_output_node = 'output_parameters'
 
         spec.exit_code(
             100, 'ERROR_NO_RETRIEVED_FOLDER', message='The retrieved folder data node could not be accessed.')

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -39,7 +39,7 @@ class PwParser(Parser):
         try:
             settings = self.node.inputs.settings.get_dict()
             parser_options = settings[self.get_parser_settings_key()]
-        except (AttributeError, KeyError):
+        except (AttributeError, KeyError, exceptions.NotExistent):
             settings = {}
             parser_options = {}
 


### PR DESCRIPTION
I want to make a simple relax calculation work :smile: 

Here is my code for you to try. 

```python 
import time

from aiida.engine import WorkChain, submit
from aiida.orm import Float, Int, Code
from aiida.plugins import DataFactory

from aiida_quantumespresso.utils.pseudopotential import get_pseudos_from_structure

StructureData = DataFactory('structure')
KpointsData = DataFactory('array.kpoints')
Dict = DataFactory('dict')


TEST_ONLY = True # Set to True to run with unconverged paramters for a quick run

code_name = 'pw-6.4-release'

calc_label = 'trial'
calc_resources = {'num_machines':1}
calc_walltime = 10800

alat=7.53560200*0.529177 #A
c_a=1.057004746/0.999812071

the_cell = [[alat,0,0],
            [0,alat,0],
            [0,0,alat*c_a]]
symbols = ['Ti','Ba','O','O','O']

atoms_crystal = [[0.500000000,   0.500000000,   0.538212532],
                 [0.000000000,   0.000000000,   0.020163431],
                 [0.500000000,   0.500000000,  -0.032360811],
                 [0.500000000,   0.000000000,   0.489492424],
                 [0.000000000,   0.500000000,   0.489492424]]


if TEST_ONLY:
	param_dict={'CONTROL': {'calculation':'relax', 'tstress': True, 'tprnfor': True, 'forc_conv_thr':0.0001},
	            'SYSTEM': {'ecutwfc':30., 'ecutrho':160., 'use_all_frac': False },
	            'ELECTRONS': {'diagonalization':'david', 'mixing_beta':0.3}
	           }

	kpoints_mesh = 2
else: # Production run
	param_dict={'CONTROL': {'calculation':'relax', 'tstress': True, 'tprnfor': True, 'lelfield':True, 'nberrycyc':2,'verbosity':'high', 'forc_conv_thr':0.0001},
	            'SYSTEM': {'ecutwfc':80., 'ecutrho':320., 'use_all_frac': False },
	            'ELECTRONS': {'diagonalization':'david', 'mixing_beta':0.3, 'efield_cart(1)':0.0, 'efield_cart(2)':0.0,'efield_cart(3)':0.0}
	           }

	kpoints_mesh = 5


pseudos_family_name = 'SSSP_efficiency_pseudos'


######

code = Code.get_from_string(code_name)

calc_builder = code.get_builder()
calc_builder.metadata.label = calc_label
calc_builder.metadata.options.resources = calc_resources
calc_builder.metadata.options.max_wallclock_seconds = calc_walltime


atoms_cart = []
for i in range(len(atoms_crystal)):	
	atoms_cart.append([ atoms_crystal[i][0]*alat, atoms_crystal[i][1]*alat, atoms_crystal[i][2]*alat*c_a  ])
	
"""
CELL_PARAMETERS (alat=  7.53560200)
   0.999812071   0.000000000   0.000000000
   0.000000000   0.999812071   0.000000000
   0.000000000   0.000000000   1.057004746

Ti       0.500000000   0.500000000   0.538212532
Ba       0.000000000   0.000000000   0.020163431
O        0.500000000   0.500000000  -0.032360811
O        0.500000000   0.000000000   0.489492424
O        0.000000000   0.500000000   0.489492424
"""

structure = StructureData(cell=the_cell)

for i in range(len(atoms_cart)):
	structure.append_atom(position=atoms_cart[i],symbols=str(symbols[i]))
calc_builder.structure = structure

parameters = Dict(dict=param_dict)
calc_builder.parameters = parameters

calc_builder.pseudos = get_pseudos_from_structure(structure=structure, family_name=pseudos_family_name)

kpoints = KpointsData()
kpoints.set_kpoints_mesh([kpoints_mesh,kpoints_mesh,kpoints_mesh])
calc_builder.kpoints = kpoints

#calc.submit_test()

calc = submit(calc_builder)

## Alternatively:
# PwCalculation = CalculationFactory(code.get_input_plugin_name())
#inputs = {'code': code, 'kpoints': kpoints, 'structure': structure, 'metadata': {'options': {
#	'resources': {'num_machines':1},
#	'max_wallclock_seconds': 10000,
#}}}
# run(PwCalculation, **inputs)

last_pk = calc.pk

print("Calculation run; PK={}".format(last_pk))
```

@odarbelaeze @borellim 