### PR TITLE
Use `pytest-regressions` for parser testing

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -4,6 +4,7 @@
     "classifiers": [
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
         "Development Status :: 4 - Beta"
     ],
     "description": "The official AiiDA plugin for Quantum ESPRESSO",
@@ -52,6 +53,7 @@
         ],
         "console_scripts": [
             "launch_calculation_pw = aiida_quantumespresso.cli.calculations.pw.base:cli",
+            "launch_calculation_cp = aiida_quantumespresso.cli.calculations.cp:cli",
             "launch_calculation_dos = aiida_quantumespresso.cli.calculations.dos:cli",
             "launch_workflow_pw_band_structure = aiida_quantumespresso.cli.workflows.pw.band_structure:cli",
             "launch_workflow_pw_bands = aiida_quantumespresso.cli.workflows.pw.bands:cli",
@@ -71,6 +73,7 @@
             "astroid==2.1.0; python_version>='3.0'",
             "pgtest==1.2.0",
             "pytest==3.6.3",
+            "pytest-regressions==1.0.5",
             "yapf==0.26.0"
         ],
         "docs": [

--- a/tests/parsers/test_pw.py
+++ b/tests/parsers/test_pw.py
@@ -3,10 +3,9 @@
 """Tests for the `PwParser`."""
 from __future__ import absolute_import
 
-import pytest
 
-
-def test_pw_default(fixture_database, fixture_computer_localhost, generate_calc_job_node, generate_parser, generate_inputs):
+def test_pw_default(fixture_database, fixture_computer_localhost, generate_calc_job_node, generate_parser, 
+                    generate_inputs, data_regression):
     """Test a default `pw.x` calculation.
 
     The output is created by running a dead simple SCF calculation for a silicon structure.
@@ -24,124 +23,4 @@ def test_pw_default(fixture_database, fixture_computer_localhost, generate_calc_
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
     assert 'output_parameters' in results
-
-    output_parameters = results['output_parameters']
-
-    assert output_parameters['beta_real_space'] is False
-    assert output_parameters['charge_density'] == './charge-density.dat'
-    assert output_parameters['constraint_mag'] == 0
-    assert output_parameters['creator_name'] == 'pwscf'
-    assert output_parameters['creator_version'] == '6.1'
-    assert output_parameters['dft_exchange_correlation'] == 'PBE'
-    assert output_parameters['do_not_use_time_reversal'] is False
-    assert output_parameters['energy'] == pytest.approx(-308.191875414092)
-    assert output_parameters['energy_accuracy'] == pytest.approx(7.347073531662e-06)
-    assert output_parameters['energy_accuracy_units'] == 'eV'
-    assert output_parameters['energy_ewald'] == pytest.approx(-228.561248748643)
-    assert output_parameters['energy_ewald_units'] == 'eV'
-    assert output_parameters['energy_hartree'] == pytest.approx(17.2680757695669)
-    assert output_parameters['energy_hartree_units'] == 'eV'
-    assert output_parameters['energy_one_electron'] == pytest.approx(71.7330877993463)
-    assert output_parameters['energy_one_electron_units'] == 'eV'
-    assert output_parameters['energy_threshold'] == pytest.approx(3.84e-06)
-    assert output_parameters['energy_units'] == 'eV'
-    assert output_parameters['energy_xc'] == pytest.approx(-168.631790234362)
-    assert output_parameters['energy_xc_units'] == 'eV'
-    assert output_parameters['fermi_energy'] == pytest.approx(6.5091589497145)
-    assert output_parameters['fermi_energy_units'] == 'eV'
-    assert output_parameters['fft_grid'] == [36, 36, 36]
-    assert output_parameters['format_name'] == 'qexml'
-    assert output_parameters['format_version'] == '1.4.0'
-    assert output_parameters['has_dipole_correction'] is False
-    assert output_parameters['has_electric_field'] is False
-    assert output_parameters['init_wall_time_seconds'] == 0.9
-    assert output_parameters['inversion_symmetry'] is True
-    assert output_parameters['lda_plus_u_calculation'] is False
-    assert output_parameters['lkpoint_dir'] is True
-    assert output_parameters['lsda'] is False
-    assert output_parameters['magnetization_angle1'] == [0.0]
-    assert output_parameters['magnetization_angle2'] == [0.0]
-    assert output_parameters['monkhorst_pack_grid'] == [2, 2, 2]
-    assert output_parameters['monkhorst_pack_offset'] == [0, 0, 0]
-    assert output_parameters['no_time_rev_operations'] is False
-    assert output_parameters['non_colinear_calculation'] is False
-    assert output_parameters['number_of_atomic_wfc'] == 8
-    assert output_parameters['number_of_atoms'] == 2
-    assert output_parameters['number_of_bands'] == 4
-    assert output_parameters['number_of_bravais_symmetries'] == 48
-    assert output_parameters['number_of_electrons'] == 8.0
-    assert output_parameters['number_of_k_points'] == 3
-    assert output_parameters['number_of_species'] == 1
-    assert output_parameters['number_of_spin_components'] == 1
-    assert output_parameters['number_of_symmetries'] == 48
-    assert output_parameters['parser_info'] == 'aiida-quantumespresso parser pw.x v3.0.0a1'
-    assert output_parameters['parser_version'] == '3.0.0a1'
-    assert output_parameters['parser_warnings'] == []
-    assert output_parameters['pp_check_flag'] is True
-    assert output_parameters['q_real_space'] is False
-    assert output_parameters['rho_cutoff'] == pytest.approx(3265.366014072)
-    assert output_parameters['rho_cutoff_units'] == 'eV'
-    assert output_parameters['scf_iterations'] == 5
-    assert output_parameters['smooth_fft_grid'] == [25, 25, 25]
-    assert output_parameters['spin_orbit_calculation'] is False
-    assert output_parameters['spin_orbit_domag'] is False
-    assert output_parameters['starting_magnetization'] == [0.0]
-    assert output_parameters['symmetries_units'] == 'crystal'
-    assert output_parameters['time_reversal_flag'] is True
-    assert output_parameters['total_number_of_scf_iterations'] == 5
-    assert output_parameters['volume'] == pytest.approx(40.02575175)
-    assert output_parameters['wall_time'] == '         1.86s '
-    assert output_parameters['wall_time_seconds'] == 1.86
-    assert output_parameters['warnings'] == []
-    assert output_parameters['wfc_cutoff'] == pytest.approx(408.170751759)
-    assert output_parameters['wfc_cutoff_units'] == 'eV'
-    assert output_parameters['symmetries'] == [
-        {'symmetry_number': 0, 't_rev': '0'},
-        {'symmetry_number': 1, 't_rev': '0'},
-        {'symmetry_number': 2, 't_rev': '0'},
-        {'symmetry_number': 3, 't_rev': '0'},
-        {'symmetry_number': 4, 't_rev': '0'},
-        {'symmetry_number': 5, 't_rev': '0'},
-        {'symmetry_number': 6, 't_rev': '0'},
-        {'symmetry_number': 7, 't_rev': '0'},
-        {'symmetry_number': 8, 't_rev': '0'},
-        {'symmetry_number': 9, 't_rev': '0'},
-        {'symmetry_number': 10, 't_rev': '0'},
-        {'symmetry_number': 11, 't_rev': '0'},
-        {'symmetry_number': 12, 't_rev': '0'},
-        {'symmetry_number': 13, 't_rev': '0'},
-        {'symmetry_number': 14, 't_rev': '0'},
-        {'symmetry_number': 15, 't_rev': '0'},
-        {'symmetry_number': 16, 't_rev': '0'},
-        {'symmetry_number': 17, 't_rev': '0'},
-        {'symmetry_number': 18, 't_rev': '0'},
-        {'symmetry_number': 19, 't_rev': '0'},
-        {'symmetry_number': 20, 't_rev': '0'},
-        {'symmetry_number': 21, 't_rev': '0'},
-        {'symmetry_number': 22, 't_rev': '0'},
-        {'symmetry_number': 23, 't_rev': '0'},
-        {'symmetry_number': 32, 't_rev': '0'},
-        {'symmetry_number': 33, 't_rev': '0'},
-        {'symmetry_number': 34, 't_rev': '0'},
-        {'symmetry_number': 35, 't_rev': '0'},
-        {'symmetry_number': 36, 't_rev': '0'},
-        {'symmetry_number': 37, 't_rev': '0'},
-        {'symmetry_number': 38, 't_rev': '0'},
-        {'symmetry_number': 39, 't_rev': '0'},
-        {'symmetry_number': 40, 't_rev': '0'},
-        {'symmetry_number': 41, 't_rev': '0'},
-        {'symmetry_number': 42, 't_rev': '0'},
-        {'symmetry_number': 43, 't_rev': '0'},
-        {'symmetry_number': 44, 't_rev': '0'},
-        {'symmetry_number': 45, 't_rev': '0'},
-        {'symmetry_number': 46, 't_rev': '0'},
-        {'symmetry_number': 47, 't_rev': '0'},
-        {'symmetry_number': 48, 't_rev': '0'},
-        {'symmetry_number': 49, 't_rev': '0'},
-        {'symmetry_number': 50, 't_rev': '0'},
-        {'symmetry_number': 51, 't_rev': '0'},
-        {'symmetry_number': 52, 't_rev': '0'},
-        {'symmetry_number': 53, 't_rev': '0'},
-        {'symmetry_number': 54, 't_rev': '0'},
-        {'symmetry_number': 55, 't_rev': '0'}
-    ]
+    data_regression.check(results['output_parameters'].get_dict())

--- a/tests/parsers/test_pw/test_pw_default.yml
+++ b/tests/parsers/test_pw/test_pw_default.yml
@@ -1,0 +1,181 @@
+beta_real_space: false
+charge_density: ./charge-density.dat
+constraint_mag: 0
+creator_name: pwscf
+creator_version: '6.1'
+dft_exchange_correlation: PBE
+do_not_use_time_reversal: false
+energy: -308.19187541409156
+energy_accuracy: 7.3470735316620004e-06
+energy_accuracy_units: eV
+energy_ewald: -228.56124874864287
+energy_ewald_units: eV
+energy_hartree: 17.268075769566853
+energy_hartree_units: eV
+energy_one_electron: 71.73308779934625
+energy_one_electron_units: eV
+energy_threshold: 3.84e-06
+energy_units: eV
+energy_xc: -168.63179023436172
+energy_xc_units: eV
+fermi_energy: 6.5091589497144975
+fermi_energy_units: eV
+fft_grid:
+- 36
+- 36
+- 36
+format_name: qexml
+format_version: 1.4.0
+has_dipole_correction: false
+has_electric_field: false
+init_wall_time_seconds: 0.9
+inversion_symmetry: true
+lda_plus_u_calculation: false
+lkpoint_dir: true
+lsda: false
+magnetization_angle1:
+- 0.0
+magnetization_angle2:
+- 0.0
+monkhorst_pack_grid:
+- 2
+- 2
+- 2
+monkhorst_pack_offset:
+- 0
+- 0
+- 0
+no_time_rev_operations: false
+non_colinear_calculation: false
+number_of_atomic_wfc: 8
+number_of_atoms: 2
+number_of_bands: 4
+number_of_bravais_symmetries: 48
+number_of_electrons: 8.0
+number_of_k_points: 3
+number_of_species: 1
+number_of_spin_components: 1
+number_of_symmetries: 48
+parser_info: aiida-quantumespresso parser pw.x v3.0.0a1
+parser_version: 3.0.0a1
+parser_warnings: []
+pp_check_flag: true
+q_real_space: false
+rho_cutoff: 3265.366014072
+rho_cutoff_units: eV
+scf_iterations: 5
+smooth_fft_grid:
+- 25
+- 25
+- 25
+spin_orbit_calculation: false
+spin_orbit_domag: false
+starting_magnetization:
+- 0.0
+symmetries:
+- symmetry_number: 0
+  t_rev: '0'
+- symmetry_number: 1
+  t_rev: '0'
+- symmetry_number: 2
+  t_rev: '0'
+- symmetry_number: 3
+  t_rev: '0'
+- symmetry_number: 4
+  t_rev: '0'
+- symmetry_number: 5
+  t_rev: '0'
+- symmetry_number: 6
+  t_rev: '0'
+- symmetry_number: 7
+  t_rev: '0'
+- symmetry_number: 8
+  t_rev: '0'
+- symmetry_number: 9
+  t_rev: '0'
+- symmetry_number: 10
+  t_rev: '0'
+- symmetry_number: 11
+  t_rev: '0'
+- symmetry_number: 12
+  t_rev: '0'
+- symmetry_number: 13
+  t_rev: '0'
+- symmetry_number: 14
+  t_rev: '0'
+- symmetry_number: 15
+  t_rev: '0'
+- symmetry_number: 16
+  t_rev: '0'
+- symmetry_number: 17
+  t_rev: '0'
+- symmetry_number: 18
+  t_rev: '0'
+- symmetry_number: 19
+  t_rev: '0'
+- symmetry_number: 20
+  t_rev: '0'
+- symmetry_number: 21
+  t_rev: '0'
+- symmetry_number: 22
+  t_rev: '0'
+- symmetry_number: 23
+  t_rev: '0'
+- symmetry_number: 32
+  t_rev: '0'
+- symmetry_number: 33
+  t_rev: '0'
+- symmetry_number: 34
+  t_rev: '0'
+- symmetry_number: 35
+  t_rev: '0'
+- symmetry_number: 36
+  t_rev: '0'
+- symmetry_number: 37
+  t_rev: '0'
+- symmetry_number: 38
+  t_rev: '0'
+- symmetry_number: 39
+  t_rev: '0'
+- symmetry_number: 40
+  t_rev: '0'
+- symmetry_number: 41
+  t_rev: '0'
+- symmetry_number: 42
+  t_rev: '0'
+- symmetry_number: 43
+  t_rev: '0'
+- symmetry_number: 44
+  t_rev: '0'
+- symmetry_number: 45
+  t_rev: '0'
+- symmetry_number: 46
+  t_rev: '0'
+- symmetry_number: 47
+  t_rev: '0'
+- symmetry_number: 48
+  t_rev: '0'
+- symmetry_number: 49
+  t_rev: '0'
+- symmetry_number: 50
+  t_rev: '0'
+- symmetry_number: 51
+  t_rev: '0'
+- symmetry_number: 52
+  t_rev: '0'
+- symmetry_number: 53
+  t_rev: '0'
+- symmetry_number: 54
+  t_rev: '0'
+- symmetry_number: 55
+  t_rev: '0'
+symmetries_units: crystal
+time_reversal_flag: true
+total_number_of_scf_iterations: 5
+volume: 40.02575174999999
+wall_time: '         1.86s '
+wall_time_seconds: 1.86
+warnings: []
+wfc_cutoff: 408.170751759
+wfc_cutoff_units: eV
+xml_warnings: []


### PR DESCRIPTION
Instead of manually typing all our comparisons, use a yml file automatically generated by the `pytest-regressions` library.