### PR TITLE
Parser `CalcJobNode` fixture: add inputs before storing node

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,11 @@ def generate_calc_job_node():
         if attributes:
             node.set_attributes(attributes)
 
+        if inputs:
+            for link_label, input_node in inputs.items():
+                input_node.store()
+                node.add_incoming(input_node, link_type=LinkType.INPUT_CALC, link_label=link_label)
+
         node.store()
 
         basepath = os.path.dirname(os.path.abspath(__file__))
@@ -84,9 +89,6 @@ def generate_calc_job_node():
         retrieved.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
         retrieved.store()
 
-        if inputs:
-            for link_label, input_node in inputs.items():
-                node.add_incoming(input_node, link_type=LinkType.INPUT_CALC, link_label=link_label)
 
         return node
 


### PR DESCRIPTION
The `generate_calc_job_node` fixture for the parser tests mocks a
calculation job node, but it was failing, because it was adding inputs
after having stored the `CalcJobNode`. A recent change in `aiida-core`
forbids inputs to be added after a `ProcessNode` is stored. The fix is
to simply add the input nodes, before storing the process node itself.
Since at least one of the nodes has to be stored when adding a link, the
input nodes now have to be explicitly stored, if they weren't already.