### PR TITLE
Update dependency requirement `aiida-core==1.0.0b2`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -1,2 +1,2 @@
 setuptools>34
-aiida-core>=0.12.0,<1.0.0
+aiida_core[atomic_tools]>=1.0.0b2

--- a/setup.json
+++ b/setup.json
@@ -74,7 +74,7 @@
         ]
     },
     "install_requires": [
-        "aiida_core[atomic_tools]>=1.0.0b1",
+        "aiida_core[atomic_tools]>=1.0.0b2",
         "matplotlib<3.0.0; python_version < '3'",
         "xmlschema==1.0.6"
     ],


### PR DESCRIPTION
Fixes #294 

Doing the same for the ReadTheDocs requirements will fix the builds that
have been failing due to a mismatch in versions.