### PR TITLE
`PwBaseWorkChain`: document spec and fix automatic parallelization

### DIFF
--- a/aiida_quantumespresso/utils/resources.py
+++ b/aiida_quantumespresso/utils/resources.py
@@ -128,7 +128,7 @@ def get_pw_parallelization_parameters(calculation, max_num_machines, target_time
     """
     from fractions import gcd
 
-    default_num_mpiprocs_per_machine = calculation.get_computer().get_default_mpiprocs_per_machine()
+    default_num_mpiprocs_per_machine = calculation.computer.get_default_mpiprocs_per_machine()
 
     input_parameters = calculation.inputs.parameters.get_dict()
     output_parameters = calculation.outputs.output_parameters.get_dict()
@@ -188,7 +188,7 @@ def get_pw_parallelization_parameters(calculation, max_num_machines, target_time
 
     # Increase the number of machines in case of memory problem during initialization
     # TODO: make it more general and less dependent on the scheduler exact message
-    if calculation.get_scheduler_error() and 'OOM' in calculation.get_scheduler_error():
+    if calculation.get_scheduler_stderr() and 'OOM' in calculation.get_scheduler_stderr():
         num_machines = max([i for i in range(num_machines, max_num_machines + 1) if i % num_machines == 0])
 
     estimated_time = time_single_cpu / (num_mpiprocs_per_machine * num_machines)


### PR DESCRIPTION
Fixes #264 and fixes #306 

The spec did not specify any help messages yet for the inputs and the
outputs which have now been added. Additionally, the automatic
parallelization functionality has been fixed. There were a few calls to
methods that have been removed in `aiida-core==1.0.0`. Note that this
functionality requires an initialization run, which is performed by
running `pw.x` with an exit file in the directory. This will cause the
code to perform the preamble and then exit. This functionality seems to
be broken for versions of `pw.x` that produce the XML output with the
new schema format. As a result the automatic parallelization only works
for codes that produce the XML in the old format.