### PR TITLE
`BaseRestartWorkChain`: check for existence of `_error_handlers`

### DIFF
--- a/aiida_quantumespresso/common/workchain/base/restart.py
+++ b/aiida_quantumespresso/common/workchain/base/restart.py
@@ -243,11 +243,11 @@ class BaseRestartWorkChain(WorkChain):
         is_handled = False
         handler_report = None
 
+        if not hasattr(self, '_error_handlers') or not self._error_handlers:
+            raise UnexpectedCalculationFailure('no calculation error handlers were registered')
+
         # Sort the handlers based on their priority in reverse order
         handlers = sorted(self._error_handlers, key=lambda x: x.priority, reverse=True)
-
-        if not handlers:
-            raise UnexpectedCalculationFailure('no calculation error handlers were registered')
 
         for handler in handlers:
             handler_report = handler.method(self, calculation)


### PR DESCRIPTION
Fixes #330 

The `WorkChain._error_handlers` attribute is only initialized when a
handler gets registered through the `register_error_handler` decorator.
This is because it cannot be done on the `BaseRestartWorkChain` base
class since then handlers will be attached to all sub classes and not
just the one to which the decorator is applied. However, this means that
if *no* handlers are registered, the class will have no `_error_handlers`
attribute. The `_handle_calculation_failure` method, however, was
assuming its existance, resulting in an `AttributeError`. The fix is to
simply explicitly check for the existence of the attribute first.