### PR TITLE
Function for creating a populated Pw builder, from an existing input file

### DIFF
--- a/aiida_quantumespresso/tools/pwinputparser.py
+++ b/aiida_quantumespresso/tools/pwinputparser.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 import re
 import numpy as np
 import six
-from six.moves import map
+from six.moves import map, zip
 
 from aiida.orm import Code, Dict, UpfData
 from aiida.orm.nodes.data.array.kpoints import KpointsData
@@ -330,7 +330,7 @@ def create_builder_from_file(input_folder, input_file_name, code, metadata, pseu
     :param input_file_name: the name of the input file
     :type input_file_name: str
     :param code: the code associated with the calculation
-    :type code: aiida.orm.Code
+    :type code: aiida.orm.Code or str
     :param metadata: metadata values for the calculation (e.g. resources)
     :type metadata: dict
     :param pseudo_folder_path: the folder containing the upf files (if None, then input_folder is used)

--- a/tests/tools/test_immigrate.py
+++ b/tests/tools/test_immigrate.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument
+"""Tests for immigrating `PwCalculation`s."""
+from __future__ import absolute_import
+import os
+
+from aiida_quantumespresso.tools.pwinputparser import create_builder_from_file
+
+
+def test_create_builder(fixture_database, fixture_computer_localhost, generate_code_localhost, generate_upf_data,
+                        generate_calc_job, fixture_sandbox_folder):
+    """ this test uses the input file generated from tests.calculations.test_pw.test_pw_default"""
+    entry_point_name = 'quantumespresso.pw'
+    code = generate_code_localhost(entry_point_name, fixture_computer_localhost)
+
+    metadata = {
+        'options': {
+            'resources': {
+                'num_machines': 1,
+                'num_mpiprocs_per_machine': 32,
+            },
+            'max_memory_kb': 1000,
+            'max_wallclock_seconds': 60 * 60 * 12,
+            'withmpi': True,
+        }
+    }
+
+    in_foldername = os.path.join('tests', 'calculations', 'test_pw')
+    in_folderpath = os.path.abspath(in_foldername)
+
+    upf_foldername = os.path.join('tests', 'fixtures', 'pseudos')
+    upf_folderpath = os.path.abspath(upf_foldername)
+    si_upf = generate_upf_data('Si')
+    si_upf.store()
+
+    builder = create_builder_from_file(in_folderpath, 'test_pw_default.in', code, metadata, upf_folderpath)
+
+    assert builder["code"] == code
+    assert builder["metadata"] == metadata
+    assert builder["pseudos"]["Si"].id == si_upf.id
+    assert builder["parameters"].get_dict() == {
+        'CONTROL': {
+            'calculation': 'scf',
+            'verbosity': 'high'
+        },
+        'SYSTEM': {
+            'ecutrho': 240.0,
+            'ecutwfc': 30.0
+        }
+    }
+    assert "kpoints" in builder
+    assert "structure" in builder
+
+    generate_calc_job(fixture_sandbox_folder, entry_point_name, builder)

--- a/tests/tools/test_immigrate.py
+++ b/tests/tools/test_immigrate.py
@@ -35,10 +35,10 @@ def test_create_builder(fixture_database, fixture_computer_localhost, generate_c
 
     builder = create_builder_from_file(in_folderpath, 'test_pw_default.in', code, metadata, upf_folderpath)
 
-    assert builder["code"] == code
-    assert builder["metadata"] == metadata
-    assert builder["pseudos"]["Si"].id == si_upf.id
-    assert builder["parameters"].get_dict() == {
+    assert builder['code'] == code
+    assert builder['metadata'] == metadata
+    assert builder['pseudos']['Si'].id == si_upf.id
+    assert builder['parameters'].get_dict() == {
         'CONTROL': {
             'calculation': 'scf',
             'verbosity': 'high'
@@ -48,7 +48,7 @@ def test_create_builder(fixture_database, fixture_computer_localhost, generate_c
             'ecutwfc': 30.0
         }
     }
-    assert "kpoints" in builder
-    assert "structure" in builder
+    assert 'kpoints' in builder
+    assert 'structure' in builder
 
     generate_calc_job(fixture_sandbox_folder, entry_point_name, builder)


### PR DESCRIPTION
`aiida_quantumespresso.tools.pwinputparser.create_builder_from_file` is essentially code,
extracted and updated, from the deprecated `PwimmigrantCalculation.create_input_nodes` method.

The advantage of having it as an isolated function, is that it can be used for either:

- Setting up a calculation for submission, or
- The first step in creating a fully immigrated run (with an existing output file)