### PR TITLE
Non-zero exit code if a critical warning is encountered

### DIFF
--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -92,6 +92,8 @@ class PwCalculation(BasePwCpInputGenerator):
         spec.exit_code(
             117, 'ERROR_READING_XML_FILE', message='The required XML file could not be read.')
         spec.exit_code(120, 'ERROR_INVALID_OUTPUT', message='The output file contains invalid output.')
+        spec.exit_code(200, 'ERROR_CRITICAL_COMPUTATION_WARNING',
+                       message='a critical warning was encountered in the parsed output')
 
     @classproperty
     def input_file_name_hubbard_file(cls):

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -301,7 +301,10 @@ class PwParser(Parser):
                     arraydata.set_array(x[0], numpy.array(x[1]))
                 self.out(self.get_linkname_outarray(), arraydata)
 
-        return ExitCode(0)
+        if raw_successful:
+            return ExitCode(0)
+        else:
+            return self.exit_codes.ERROR_CRITICAL_COMPUTATION_WARNING
 
     def get_parser_settings_key(self):
         """


### PR DESCRIPTION
At present a 0 exit code is returned, even when `parse_raw_output` returns `job_successful=False`, which occurs for example when a critical message is encountered like `convergence NOT achieved`.

This feels wrong, and I think we can take advantage of the new exit code functionality to highlight these computation failures.