### PR TITLE
Allow for optional XML parsing

### DIFF
--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -66,7 +66,8 @@ class PwCalculation(BasePwCpInputGenerator):
         spec.input('metadata.options.input_filename', valid_type=six.string_types, default=cls._DEFAULT_INPUT_FILE)
         spec.input('metadata.options.output_filename', valid_type=six.string_types, default=cls._DEFAULT_OUTPUT_FILE)
         spec.input('metadata.options.parser_name', valid_type=six.string_types, default='quantumespresso.pw')
-        spec.input('metadata.options.require_xml', valid_type=bool, default=True)
+        spec.input('metadata.options.require_xml', valid_type=bool, default=True,
+            help='if True, output parsing will fail if an XML file cannot be found')
         spec.input('kpoints', valid_type=orm.KpointsData,
             help='kpoint mesh or kpoint path')
         spec.input('hubbard_file', valid_type=orm.SinglefileData, required=False,

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -66,6 +66,7 @@ class PwCalculation(BasePwCpInputGenerator):
         spec.input('metadata.options.input_filename', valid_type=six.string_types, default=cls._DEFAULT_INPUT_FILE)
         spec.input('metadata.options.output_filename', valid_type=six.string_types, default=cls._DEFAULT_OUTPUT_FILE)
         spec.input('metadata.options.parser_name', valid_type=six.string_types, default='quantumespresso.pw')
+        spec.input('metadata.options.require_xml', valid_type=bool, default=True)
         spec.input('kpoints', valid_type=orm.KpointsData,
             help='kpoint mesh or kpoint path')
         spec.input('hubbard_file', valid_type=orm.SinglefileData, required=False,

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -34,6 +34,7 @@ class PwParser(Parser):
             return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
 
         parameters = self.node.inputs.parameters.get_dict()
+        in_struc = self.node.inputs.structure
 
         # Look for optional settings input node and potential 'parser_options' dictionary within it
         try:
@@ -80,7 +81,7 @@ class PwParser(Parser):
             xml_file = os.path.join(output_folder._repository._get_base_folder().abspath, xml_files[0])
 
         # Call the raw parsing function
-        parsing_args = [filepath_stdout, parameters, parser_options, self.logger, xml_file, dir_with_bands]
+        parsing_args = [filepath_stdout, parameters, parser_options, self.logger, xml_file, dir_with_bands, in_struc]
         out_dict, trajectory_data, structure_data, bands_data, raw_successful = parse_raw_output(*parsing_args)
 
         # If the parser option 'all_symmetries' is not set to True, we reduce the raw parsed symmetries to safe space
@@ -190,7 +191,6 @@ class PwParser(Parser):
                         self.logger.error("Warning: key '{}' is not present in raw output dictionary".format(symmetry_type))
 
         # I eventually save the new structure. structure_data is unnecessary after this
-        in_struc = self.node.get_incoming(link_label_filter='structure').one().node
         type_calc = parameters['CONTROL']['calculation']
         struc = in_struc
         if type_calc in ['relax', 'vc-relax', 'md', 'vc-md']:

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -70,8 +70,9 @@ class PwParser(Parser):
         xml_file = None
 
         if not xml_files:
-            self.logger.error('no XML output files found, which is required for parsing')
-            return self.exit_codes.ERROR_MISSING_XML_FILE
+            if self.node.get_option("require_xml"):
+                self.logger.error('no XML output files found, which is required for parsing')
+                return self.exit_codes.ERROR_MISSING_XML_FILE
         elif len(xml_files) > 1:
             self.logger.error('more than one XML file retrieved, which should never happen')
             return self.exit_codes.ERROR_MULTIPLE_XML_FILES


### PR DESCRIPTION
This is mainly for immigrating existing outputs, where the XML file is not available.
Mostly all the output data can still be extracted from the text output, except the input structure is required to generate the final structure (for `relax` calculations).

As you can see, in the `PwCalculation.define`, I have added an option `metadata.options.require_xml`. By default, this is True so, unless specifically set to False, this functionality will not be called on.