### PR TITLE
Immigrate existing outputs

### DIFF
--- a/aiida_quantumespresso/tools/pwimmigrant.py
+++ b/aiida_quantumespresso/tools/pwimmigrant.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""
+Immigrate a Quantum Espresso pw.x job that was not run using AiiDa.
+"""
+
+from __future__ import absolute_import
+
+from aiida.common.datastructures import CalcJobState
+from aiida.common.folders import Folder, SandboxFolder
+from aiida.common.links import LinkType
+from aiida.engine import ProcessState
+from aiida.engine.daemon.execmanager import parse_results
+from aiida.engine.utils import instantiate_process
+from aiida.manage.manager import get_manager
+from aiida.orm import FolderData, RemoteData
+from aiida.plugins import CalculationFactory
+
+import six
+
+
+def immigrate_existing(builder, folder, infile, outfile, xml_file=None, remote_path=None):
+    """Immigrate a Quantum Espresso pw.x job that was not run using AiiDa.
+
+    Note, it is intended that this function is used in conjunction with
+    aiida_quantumespresso.tools.pwinputparser.create_builder_from_file, to create the builder
+
+    :param builder: a populated builder instance for PwCalculation
+    :param folder: the folder containing the input and output files
+    :type folder: aiida.common.folders.Folder or str
+    :param infile: the file name of the input file
+    :type infile: str
+    :param outfile: the file name of the output file
+    :type outfile: str
+    :param xml_file: the file name of the XML file
+    :type xml_file: str or None
+    :param remote_path: the path on the remote computer to the run folder
+    :type remote_path: str or None
+
+    :rtype: aiida.orm.CalcJobNode
+
+    """
+    if isinstance(folder, six.string_types):
+        folder = Folder(folder)
+
+    # initialise calcjob
+    runner = get_manager().get_runner()
+    pw_calc_cls = CalculationFactory('quantumespresso.pw')
+    process = instantiate_process(runner, pw_calc_cls, **builder)
+    calc_node = process.node
+
+    # create and populate retrieved folder
+    retrieve_list = [
+        process.metadata.options.input_filename,
+        process.metadata.options.output_filename]
+    retrieved_files = FolderData()
+    retrieved_files.put_object_from_file(
+        folder.get_abs_path(infile), process.metadata.options.input_filename)
+    retrieved_files.put_object_from_file(
+        folder.get_abs_path(outfile), process.metadata.options.output_filename)
+    if xml_file is not None:
+        retrieve_list.append(pw_calc_cls._DATAFILE_XML_POST_6_2)
+        retrieved_files.put_object_from_file(
+            folder.get_abs_path(xml_file), pw_calc_cls._DATAFILE_XML_POST_6_2)
+    retrieved_files.add_incoming(calc_node, link_type=LinkType.CREATE,
+                                 link_label=calc_node.link_label_retrieved)
+    retrieved_files.store()
+    calc_node.set_retrieve_list(retrieve_list)
+
+    # create remote data folder
+    if remote_path is not None:
+        calc_node.set_remote_workdir(remote_path)
+        remotedata = RemoteData(computer=calc_node.computer, remote_path=remote_path)
+        remotedata.add_incoming(calc_node, link_type=LinkType.CREATE,
+                                link_label='remote_folder')
+        remotedata.store()
+
+    # parse output and link outgoing nodes
+    calc_node.set_state(CalcJobState.PARSING)
+    with SandboxFolder() as temp_retrieved:
+        exit_code = process.parse(temp_retrieved.abspath)
+    process.update_outputs()
+
+    # finalise calc node
+    calc_node.delete_state()
+    calc_node.delete_checkpoint()
+    calc_node.set_process_state(ProcessState.FINISHED)
+    calc_node.set_exit_status(exit_code.status)
+    calc_node.set_exit_message(exit_code.message)
+    calc_node.seal()
+
+    # record that the node was created via immigration
+    calc_node.set_extra('immigrated', True)
+    calc_node.set_extra('immigration_func', 'aiida_quantumespresso.tools.pwimmigrant.immigrate_existing')
+
+    return calc_node

--- a/tests/tools/test_immigrate.py
+++ b/tests/tools/test_immigrate.py
@@ -91,11 +91,10 @@ def test_immigrate_existing(fixture_database, fixture_computer_localhost,
     builder = create_builder_from_file(in_folderpath, 'test_pw_default.in', code, metadata, upf_folderpath)
 
     with SandboxFolder() as folder:
-        folder.insert_path(os.path.join(in_folderpath, 'test_pw_default.in'))
         folder.insert_path(os.path.join(out_folderpath, 'aiida.out'))
         folder.insert_path(os.path.join(out_folderpath, 'data-file.xml'))
 
-        calc_node = immigrate_existing(builder, folder, 'test_pw_default.in', 'aiida.out',
+        calc_node = immigrate_existing(builder, folder, 'aiida.out',
                                        'data-file.xml', 'path/to/remote')
 
     data_regression.check(calc_node.attributes)

--- a/tests/tools/test_immigrate.py
+++ b/tests/tools/test_immigrate.py
@@ -4,7 +4,10 @@
 from __future__ import absolute_import
 import os
 
+from aiida.common.folders import SandboxFolder
+
 from aiida_quantumespresso.tools.pwinputparser import create_builder_from_file
+from aiida_quantumespresso.tools.pwimmigrant import immigrate_existing
 
 
 def test_create_builder(fixture_database, fixture_computer_localhost, generate_code_localhost, generate_upf_data,
@@ -52,3 +55,52 @@ def test_create_builder(fixture_database, fixture_computer_localhost, generate_c
     assert 'structure' in builder
 
     generate_calc_job(fixture_sandbox_folder, entry_point_name, builder)
+
+
+def test_immigrate_existing(fixture_database, fixture_computer_localhost,
+                            generate_code_localhost, generate_upf_data, data_regression):
+    """ this test uses the input file generated from tests.calculations.test_pw.test_pw_default,
+    and input file generated from tests.parsers.test_pw.test_pw_default
+    """
+    entry_point_name = 'quantumespresso.pw'
+    code = generate_code_localhost(entry_point_name, fixture_computer_localhost)
+
+    metadata = {
+        'options': {
+            'resources': {
+                'num_machines': 1,
+                'num_mpiprocs_per_machine': 32,
+            },
+            'max_memory_kb': 1000,
+            'max_wallclock_seconds': 60 * 60 * 12,
+            'withmpi': True,
+        }
+    }
+
+    in_foldername = os.path.join('tests', 'calculations', 'test_pw')
+    in_folderpath = os.path.abspath(in_foldername)
+
+    upf_foldername = os.path.join('tests', 'fixtures', 'pseudos')
+    upf_folderpath = os.path.abspath(upf_foldername)
+    si_upf = generate_upf_data('Si')
+    si_upf.store()
+
+    out_foldername = os.path.join('tests', 'parsers', 'fixtures', 'pw', 'default')
+    out_folderpath = os.path.abspath(out_foldername)
+
+    builder = create_builder_from_file(in_folderpath, 'test_pw_default.in', code, metadata, upf_folderpath)
+
+    with SandboxFolder() as folder:
+        folder.insert_path(os.path.join(in_folderpath, 'test_pw_default.in'))
+        folder.insert_path(os.path.join(out_folderpath, 'aiida.out'))
+        folder.insert_path(os.path.join(out_folderpath, 'data-file.xml'))
+
+        calc_node = immigrate_existing(builder, folder, 'test_pw_default.in', 'aiida.out',
+                                       'data-file.xml', 'path/to/remote')
+
+    data_regression.check(calc_node.attributes)
+
+    outputs = calc_node.get_outgoing()
+    assert set(outputs.all_link_labels()) == set(
+        ['retrieved', 'remote_folder', 'output_array',
+         'output_parameters', 'output_kpoints'])

--- a/tests/tools/test_immigrate.py
+++ b/tests/tools/test_immigrate.py
@@ -103,3 +103,6 @@ def test_immigrate_existing(fixture_database, fixture_computer_localhost,
     assert set(outputs.all_link_labels()) == set(
         ['retrieved', 'remote_folder', 'output_array',
          'output_parameters', 'output_kpoints'])
+
+    assert calc_node.outputs.output_parameters.get_dict()['warnings'] == []
+    assert calc_node.outputs.output_parameters.get_dict()['parser_warnings'] == []

--- a/tests/tools/test_immigrate/test_immigrate_existing.yml
+++ b/tests/tools/test_immigrate/test_immigrate_existing.yml
@@ -1,0 +1,27 @@
+append_text: ''
+custom_scheduler_commands: ''
+environment_variables: {}
+exit_status: 0
+import_sys_environment: true
+input_filename: aiida.in
+max_memory_kb: 1000
+max_wallclock_seconds: 43200
+mpirun_extra_params: []
+output_filename: aiida.out
+parser_name: quantumespresso.pw
+prepend_text: ''
+process_label: PwCalculation
+process_state: finished
+remote_workdir: path/to/remote
+resources:
+  default_mpiprocs_per_machine: 1
+  num_machines: 1
+  num_mpiprocs_per_machine: 32
+retrieve_list:
+- aiida.in
+- aiida.out
+- data-file-schema.xml
+scheduler_stderr: _scheduler-stderr.txt
+scheduler_stdout: _scheduler-stdout.txt
+sealed: true
+withmpi: true


### PR DESCRIPTION
This would replace the deprecated `PwimmigrantCalculation`.

I think it does a decent job, of replicating the main process steps and output data.
Unless you think there is a better way?