### PR TITLE
Leverage `expose_inputs` on `PwCalculation` in `PwBaseWorkChain`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@
         aiida_quantumespresso/utils/.*|
         aiida_quantumespresso/workflows/.*|
         docs/.*|
-        examples/.*|
         tests/.*
       )$
 

--- a/aiida_quantumespresso/calculations/__init__.py
+++ b/aiida_quantumespresso/calculations/__init__.py
@@ -66,12 +66,18 @@ class BasePwCpInputGenerator(CalcJob):
     def define(cls, spec):
         super(BasePwCpInputGenerator, cls).define(spec)
         spec.input('metadata.options.withmpi', valid_type=bool, default=True)  # Override default withmpi=False
-        spec.input('structure', valid_type=orm.StructureData, help='')
-        spec.input('parameters', valid_type=orm.Dict, help='')
-        spec.input('settings', valid_type=orm.Dict, required=False, help='')
-        spec.input('parent_folder', valid_type=orm.RemoteData, required=False, help='')
-        spec.input('vdw_table', valid_type=orm.SinglefileData, required=False, help='')
-        spec.input_namespace('pseudos', valid_type=orm.UpfData, dynamic=True, help='')
+        spec.input('structure', valid_type=orm.StructureData,
+            help='The input structure.')
+        spec.input('parameters', valid_type=orm.Dict,
+            help='The input parameters that are to be used to construct the input file.')
+        spec.input('settings', valid_type=orm.Dict, required=False,
+            help='Optional parameters to affect the way the calculation job and the parsing are performed.')
+        spec.input('parent_folder', valid_type=orm.RemoteData, required=False,
+            help='An optional working directory of a previously completed calculation to restart from.')
+        spec.input('vdw_table', valid_type=orm.SinglefileData, required=False,
+            help='Optional van der Waals table contained in a `SinglefileData`.')
+        spec.input_namespace('pseudos', valid_type=orm.UpfData, dynamic=True,
+            help='A mapping of `UpfData` nodes onto the kind name to which they should apply.')
 
     def prepare_for_submission(self, folder):
         """Create the input files from the input nodes passed to this instance of the `CalcJob`.

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -70,11 +70,15 @@ class PwCalculation(BasePwCpInputGenerator):
             help='kpoint mesh or kpoint path')
         spec.input('hubbard_file', valid_type=orm.SinglefileData, required=False,
             help='SinglefileData node containing the output Hubbard parameters from a HpCalculation')
-        spec.output('output_parameters', valid_type=orm.Dict)
-        spec.output('output_structure', valid_type=orm.StructureData, required=False)
+        spec.output('output_parameters', valid_type=orm.Dict,
+            help='The `output_parameters` output node of the successful calculation.')
+        spec.output('output_structure', valid_type=orm.StructureData, required=False,
+            help='The `output_structure` output node of the successful calculation if present.')
         spec.output('output_trajectory', valid_type=orm.TrajectoryData, required=False)
-        spec.output('output_array', valid_type=orm.ArrayData, required=False)
-        spec.output('output_band', valid_type=orm.BandsData, required=False)
+        spec.output('output_array', valid_type=orm.ArrayData, required=False,
+            help='The `output_array` output node of the successful calculation if present.')
+        spec.output('output_band', valid_type=orm.BandsData, required=False,
+            help='The `output_band` output node of the successful calculation if present.')
         spec.output('output_kpoints', valid_type=orm.KpointsData, required=False)
         spec.output('output_atomic_occupations', valid_type=orm.Dict, required=False)
         spec.default_output_node = 'output_parameters'

--- a/aiida_quantumespresso/cli/utils/launch.py
+++ b/aiida_quantumespresso/cli/utils/launch.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 import click
 
-from aiida.engine import launch
+from aiida.engine import launch, Process
 from .display import echo_process_results
 
 
@@ -16,10 +16,15 @@ def launch_process(process, daemon, **inputs):
     :param daemon: boolean, if True will submit to the daemon instead of running in current interpreter
     :param inputs: inputs for the process
     """
+    if isinstance(process, Process):
+        process_name = process.__name__
+    else:
+        process_name = process.process_class.__name__
+
     if daemon:
         node = launch.submit(process, **inputs)
-        click.echo('Submitted {}<{}> to the daemon'.format(process.__name__, node.pk))
+        click.echo('Submitted {}<{}> to the daemon'.format(process_name, node.pk))
     else:
-        click.echo('Running a {}...'.format(process.__name__))
+        click.echo('Running a {}...'.format(process_name))
         _, node = launch.run_get_node(process, **inputs)
         echo_process_results(node)

--- a/aiida_quantumespresso/cli/workflows/pw/bands.py
+++ b/aiida_quantumespresso/cli/workflows/pw/bands.py
@@ -36,9 +36,12 @@ def launch_workflow(code, structure, pseudo_family, kpoints_distance, ecutwfc, e
                     hubbard_file_pk, starting_magnetization, smearing, automatic_parallelization, clean_workdir,
                     max_num_machines, max_wallclock_seconds, with_mpi, daemon):
     """Run a `PwBandsWorkChain`."""
+    # pylint: disable=too-many-statements
     from aiida.orm import Bool, Float, Str, Dict
     from aiida.plugins import WorkflowFactory
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
+
+    builder = WorkflowFactory('quantumespresso.pw.bands').get_builder()
 
     parameters = {
         'SYSTEM': {
@@ -66,48 +69,38 @@ def launch_workflow(code, structure, pseudo_family, kpoints_distance, ecutwfc, e
     pseudo_family = Str(pseudo_family)
     parameters = Dict(dict=parameters)
 
-    inputs = {
-        'structure': structure,
-        'relax': {
-            'base': {
-                'code': code,
-                'pseudo_family': pseudo_family,
-                'kpoints_distance': Float(kpoints_distance),
-                'parameters': parameters,
-            },
-            'meta_convergence': Bool(False),
-        },
-        'scf': {
-            'code': code,
-            'pseudo_family': pseudo_family,
-            'kpoints_distance': Float(kpoints_distance),
-            'parameters': parameters,
-        },
-        'bands': {
-            'code': code,
-            'pseudo_family': pseudo_family,
-            'kpoints_distance': Float(kpoints_distance),
-            'parameters': parameters,
-        }
-    }
+    builder.structure = structure
+    builder.relax.base.pw.code = code
+    builder.relax.base.pw.parameters = parameters
+    builder.relax.base.pseudo_family = pseudo_family
+    builder.relax.base.kpoints_distance = Float(kpoints_distance)
+    builder.relax.meta_convergence = Bool(False)
+    builder.scf.pw.code = code
+    builder.scf.pw.parameters = parameters
+    builder.scf.pseudo_family = pseudo_family
+    builder.scf.kpoints_distance = Float(kpoints_distance)
+    builder.bands.pw.code = code
+    builder.bands.pw.parameters = parameters
+    builder.bands.pseudo_family = pseudo_family
+    builder.bands.kpoints_distance = Float(kpoints_distance)
 
     if hubbard_file:
-        inputs['relax']['base']['hubbard_file'] = hubbard_file
-        inputs['scf']['base']['hubbard_file'] = hubbard_file
-        inputs['bands']['base']['hubbard_file'] = hubbard_file
+        builder.relax.base.pw.hubbard_file = hubbard_file
+        builder.scf.base.pw.hubbard_file = hubbard_file
+        builder.bands.base.pw.hubbard_file = hubbard_file
 
     if automatic_parallelization:
         auto_para = Dict(dict=get_automatic_parallelization_options(max_num_machines, max_wallclock_seconds))
-        inputs['relax']['base']['automatic_parallelization'] = auto_para
-        inputs['scf']['automatic_parallelization'] = auto_para
-        inputs['bands']['automatic_parallelization'] = auto_para
+        builder.relax.base.automatic_parallelization = auto_para
+        builder.scf.automatic_parallelization = auto_para
+        builder.bands.automatic_parallelization = auto_para
     else:
-        options = Dict(dict=get_default_options(max_num_machines, max_wallclock_seconds, with_mpi))
-        inputs['relax']['base']['options'] = options
-        inputs['scf']['options'] = options
-        inputs['bands']['options'] = options
+        options = get_default_options(max_num_machines, max_wallclock_seconds, with_mpi)
+        builder.relax.base.pw.metadata.options = options
+        builder.scf.pw.metadata.options = options
+        builder.bands.pw.metadata.options = options
 
     if clean_workdir:
-        inputs['clean_workdir'] = Bool(True)
+        builder.clean_workdir = Bool(True)
 
-    launch.launch_process(WorkflowFactory('quantumespresso.pw.bands'), daemon, **inputs)
+    launch.launch_process(builder, daemon)

--- a/aiida_quantumespresso/cli/workflows/pw/base.py
+++ b/aiida_quantumespresso/cli/workflows/pw/base.py
@@ -39,6 +39,8 @@ def launch_workflow(code, structure, pseudo_family, kpoints_distance, ecutwfc, e
     from aiida.plugins import WorkflowFactory
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
+    builder = WorkflowFactory('quantumespresso.pw.base').get_builder()
+
     parameters = {
         'SYSTEM': {
             'ecutwfc': ecutwfc,
@@ -62,24 +64,22 @@ def launch_workflow(code, structure, pseudo_family, kpoints_distance, ecutwfc, e
     except ValueError as exception:
         raise click.BadParameter(str(exception))
 
-    inputs = {
-        'code': code,
-        'structure': structure,
-        'pseudo_family': Str(pseudo_family),
-        'kpoints_distance': Float(kpoints_distance),
-        'parameters': Dict(dict=parameters),
-    }
+    builder.pw.code = code
+    builder.pw.structure = structure
+    builder.pw.parameters = Dict(dict=parameters)
+    builder.pseudo_family = Str(pseudo_family)
+    builder.kpoints_distance = Float(kpoints_distance)
 
     if hubbard_file:
-        inputs['hubbard_file'] = hubbard_file
+        builder.hubbard_file = hubbard_file
 
     if automatic_parallelization:
         automatic_parallelization = get_automatic_parallelization_options(max_num_machines, max_wallclock_seconds)
-        inputs['automatic_parallelization'] = Dict(dict=automatic_parallelization)
+        builder.automatic_parallelization = Dict(dict=automatic_parallelization)
     else:
-        inputs['options'] = Dict(dict=get_default_options(max_num_machines, max_wallclock_seconds, with_mpi))
+        builder.pw.metadata.options = get_default_options(max_num_machines, max_wallclock_seconds, with_mpi)
 
     if clean_workdir:
-        inputs['clean_workdir'] = Bool(True)
+        builder.clean_workdir = Bool(True)
 
-    launch.launch_process(WorkflowFactory('quantumespresso.pw.base'), daemon, **inputs)
+    launch.launch_process(builder, daemon)

--- a/aiida_quantumespresso/cli/workflows/pw/relax.py
+++ b/aiida_quantumespresso/cli/workflows/pw/relax.py
@@ -46,6 +46,8 @@ def launch_workflow(code, structure, pseudo_family, kpoints_distance, ecutwfc, e
     from aiida.plugins import WorkflowFactory
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
+    builder = WorkflowFactory('quantumespresso.pw.relax').get_builder()
+
     parameters = {
         'SYSTEM': {
             'ecutwfc': ecutwfc,
@@ -69,29 +71,25 @@ def launch_workflow(code, structure, pseudo_family, kpoints_distance, ecutwfc, e
     except ValueError as exception:
         raise click.BadParameter(str(exception))
 
-    inputs = {
-        'structure': structure,
-        'base': {
-            'code': code,
-            'pseudo_family': Str(pseudo_family),
-            'kpoints_distance': Float(kpoints_distance),
-            'parameters': Dict(dict=parameters),
-        }
-    }
+    builder.structure = structure
+    builder.base.pseudo_family = Str(pseudo_family)
+    builder.base.kpoints_distance = Float(kpoints_distance)
+    builder.base.pw.code = code
+    builder.base.pw.parameters = Dict(dict=parameters)
 
     if hubbard_file:
-        inputs['base']['hubbard_file'] = hubbard_file
+        builder.base.pw.hubbard_file = hubbard_file
 
     if automatic_parallelization:
         automatic_parallelization = get_automatic_parallelization_options(max_num_machines, max_wallclock_seconds)
-        inputs['base']['automatic_parallelization'] = Dict(dict=automatic_parallelization)
+        builder.base.automatic_parallelization = Dict(dict=automatic_parallelization)
     else:
-        inputs['base']['options'] = Dict(dict=get_default_options(max_num_machines, max_wallclock_seconds, with_mpi))
+        builder.base.pw.metadata.options = get_default_options(max_num_machines, max_wallclock_seconds, with_mpi)
 
     if clean_workdir:
-        inputs['clean_workdir'] = Bool(True)
+        builder.clean_workdir = Bool(True)
 
     if final_scf:
-        inputs['final_scf'] = Bool(True)
+        builder.final_scf = Bool(True)
 
-    launch.launch_process(WorkflowFactory('quantumespresso.pw.relax'), daemon, **inputs)
+    launch.launch_process(builder, daemon)

--- a/aiida_quantumespresso/utils/mapping.py
+++ b/aiida_quantumespresso/utils/mapping.py
@@ -1,31 +1,32 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+
 from collections import Mapping
-from aiida.common.extendeddicts import AttributeDict
-from aiida.orm.nodes.data.dict import Dict
-import six
+
+from aiida.common import AttributeDict
+from aiida.orm import Dict
 
 
 def update_mapping(original, source):
-    """
-    Update a nested dictionary with another optionally nested dictionary. The dictionaries may be plain
-    Mapping objects or Dict nodes. If the original dictionary is an instance of Dict
-    the returned dictionary will also be wrapped in Dict.
+    """Update a nested dictionary with another optionally nested dictionary.
 
-    :param original: Mapping object or Dict instance
-    :param source: Mapping object or Dict instance
+    The dictionaries may be plain Mapping objects or `Dict` nodes. If the original dictionary is an instance of `Dict`
+    the returned dictionary will also be wrapped in `Dict`.
+
+    :param original: Mapping object or `Dict` instance
+    :param source: Mapping object or `Dict` instance
     :return: the original dictionary updated with the source dictionary
     """
-    return_parameter_data = False
+    return_node = False
 
     if isinstance(original, Dict):
-        return_parameter_data = True
+        return_node = True
         original = original.get_dict()
 
     if isinstance(source, Dict):
         source = source.get_dict()
 
-    for key, value in six.iteritems(source):
+    for key, value in source.items():
         if (
             key in original and
             (isinstance(value, Mapping) or isinstance(value, Dict)) and
@@ -35,38 +36,51 @@ def update_mapping(original, source):
         else:
             original[key] = value
 
-    if return_parameter_data:
+    if return_node:
         original = Dict(dict=original)
 
     return original
 
 
 def prepare_process_inputs(process, inputs):
-    """
-    Prepare the inputs for submission for the given process, according to its spec. That is to say that
-    when an input is found in the inputs that corresponds to an input port in the spec of the process that
-    expects a Dict, yet the value in the inputs is a plain dictionary, the value will be wrapped
-    in by the Dict class to create a valid input.
+    """Prepare the inputs for submission for the given process, according to its spec.
 
-    :param process: sub class of Process for which to prepare the inputs dictionary
+    That is to say that when an input is found in the inputs that corresponds to an input port in the spec of the
+    process that expects a `Dict`, yet the value in the inputs is a plain dictionary, the value will be wrapped in by
+    the `Dict` class to create a valid input.
+
+    :param process: sub class of `Process` for which to prepare the inputs dictionary
     :param inputs: a dictionary of inputs intended for submission of the process
-    :return: a dictionary with all bare dictionaries wrapped in Dict if dictated by process spec
+    :return: a dictionary with all bare dictionaries wrapped in `Dict` if dictated by the process spec
     """
-    prepared_inputs = AttributeDict()
+    prepared_inputs = wrap_bare_dict_inputs(process.spec().inputs, inputs)
+    return AttributeDict(prepared_inputs)
 
-    try:
-        process_spec = process.spec()
-    except AttributeError:
-        raise ValueError('process {} does not have a spec')
 
-    for key, value in six.iteritems(inputs):
+def wrap_bare_dict_inputs(port_namespace, inputs):
+    """Wrap bare dictionaries in `inputs` in a `Dict` node if dictated by the corresponding port in given namespace.
 
-        if key not in process_spec.inputs:
+    :param port_namespace: a `PortNamespace`
+    :param inputs: a dictionary of inputs intended for submission of the process
+    :return: a dictionary with all bare dictionaries wrapped in `Dict` if dictated by the port namespace
+    """
+    from aiida.engine.processes import PortNamespace
+
+    wrapped = {}
+
+    for key, value in inputs.items():
+
+        if key not in port_namespace:
+            wrapped[key] = value
             continue
 
-        if process_spec.inputs[key].valid_type == Dict and isinstance(value, dict):
-            prepared_inputs[key] = Dict(dict=value)
-        else:
-            prepared_inputs[key] = value
+        port = port_namespace[key]
 
-    return prepared_inputs
+        if isinstance(port, PortNamespace):
+            wrapped[key] = wrap_bare_dict_inputs(port, value)
+        elif port.valid_type == Dict and isinstance(value, dict):
+            wrapped[key] = Dict(dict=value)
+        else:
+            wrapped[key] = value
+
+    return wrapped

--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -22,9 +22,9 @@ class PwBandsWorkChain(WorkChain):
     @classmethod
     def define(cls, spec):
         super(PwBandsWorkChain, cls).define(spec)
-        spec.expose_inputs(PwRelaxWorkChain, namespace='relax', exclude=('structure', 'clean_workdir'))
-        spec.expose_inputs(PwBaseWorkChain, namespace='scf', exclude=('structure', 'clean_workdir'))
-        spec.expose_inputs(PwBaseWorkChain, namespace='bands', exclude=('structure', 'clean_workdir'))
+        spec.expose_inputs(PwRelaxWorkChain, namespace='relax', exclude=('clean_workdir', 'structure'))
+        spec.expose_inputs(PwBaseWorkChain, namespace='scf', exclude=('clean_workdir', 'pw.structure'))
+        spec.expose_inputs(PwBaseWorkChain, namespace='bands', exclude=('clean_workdir', 'pw.structure'))
         spec.input('structure', valid_type=orm.StructureData)
         spec.input('clean_workdir', valid_type=orm.Bool, default=orm.Bool(False))
         spec.input('nbands_factor', valid_type=orm.Float, default=orm.Float(1.2))
@@ -104,10 +104,10 @@ class PwBandsWorkChain(WorkChain):
     def run_scf(self):
         """Run the PwBaseWorkChain in scf mode on the primitive cell of (optionally relaxed) input structure"""
         inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, namespace='scf'))
-        inputs.structure = self.ctx.current_structure
-        inputs.parameters = inputs.parameters.get_dict()
-        inputs.parameters.setdefault('CONTROL', {})
-        inputs.parameters['CONTROL']['calculation'] = 'scf'
+        inputs.pw.structure = self.ctx.current_structure
+        inputs.pw.parameters = inputs.pw.parameters.get_dict()
+        inputs.pw.parameters.setdefault('CONTROL', {})
+        inputs.pw.parameters['CONTROL']['calculation'] = 'scf'
 
         inputs = prepare_process_inputs(PwBaseWorkChain, inputs)
         running = self.submit(PwBaseWorkChain, **inputs)
@@ -138,23 +138,23 @@ class PwBandsWorkChain(WorkChain):
             int(0.5 * nelectron * nspin) + 4 * nspin)
 
         inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, namespace='bands'))
-        inputs.parameters = inputs.parameters.get_dict()
+        inputs.pw.parameters = inputs.pw.parameters.get_dict()
 
-        inputs.parameters.setdefault('CONTROL', {})
-        inputs.parameters.setdefault('SYSTEM', {})
-        inputs.parameters.setdefault('ELECTRONS', {})
+        inputs.pw.parameters.setdefault('CONTROL', {})
+        inputs.pw.parameters.setdefault('SYSTEM', {})
+        inputs.pw.parameters.setdefault('ELECTRONS', {})
 
-        inputs.parameters['CONTROL']['restart_mode'] = 'restart'
-        inputs.parameters['CONTROL']['calculation'] = 'bands'
-        inputs.parameters['ELECTRONS']['diagonalization'] = 'cg'
-        inputs.parameters['ELECTRONS']['diago_full_acc'] = True
-        inputs.parameters['SYSTEM']['nbnd'] = nbands
+        inputs.pw.parameters['CONTROL']['restart_mode'] = 'restart'
+        inputs.pw.parameters['CONTROL']['calculation'] = 'bands'
+        inputs.pw.parameters['ELECTRONS']['diagonalization'] = 'cg'
+        inputs.pw.parameters['ELECTRONS']['diago_full_acc'] = True
+        inputs.pw.parameters['SYSTEM']['nbnd'] = nbands
 
         if 'kpoints' not in self.inputs.bands:
             inputs.kpoints = self.ctx.kpoints_path
 
-        inputs.structure = self.ctx.current_structure
-        inputs.parent_folder = self.ctx.current_folder
+        inputs.pw.structure = self.ctx.current_structure
+        inputs.pw.parent_folder = self.ctx.current_folder
 
         inputs = prepare_process_inputs(PwBaseWorkChain, inputs)
         running = self.submit(PwBaseWorkChain, **inputs)

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -20,7 +20,7 @@ class PwRelaxWorkChain(WorkChain):
     @classmethod
     def define(cls, spec):
         super(PwRelaxWorkChain, cls).define(spec)
-        spec.expose_inputs(PwBaseWorkChain, namespace='base', exclude=('structure', 'clean_workdir'))
+        spec.expose_inputs(PwBaseWorkChain, namespace='base', exclude=('clean_workdir', 'pw.structure'))
         spec.input('structure', valid_type=orm.StructureData)
         spec.input('final_scf', valid_type=orm.Bool, default=orm.Bool(False))
         spec.input('relaxation_scheme', valid_type=orm.Str, default=orm.Str('vc-relax'))
@@ -44,7 +44,7 @@ class PwRelaxWorkChain(WorkChain):
             message='the relax PwBaseWorkChain sub process failed')
         spec.exit_code(402, 'ERROR_SUB_PROCESS_FAILED_FINAL_SCF',
             message='the final scf PwBaseWorkChain sub process failed')
-        spec.expose_outputs(PwBaseWorkChain, exclude=['output_structure'])
+        spec.expose_outputs(PwBaseWorkChain, exclude=('output_structure',))
         spec.output('output_structure', valid_type=orm.StructureData, required=True)
 
     def setup(self):
@@ -80,11 +80,11 @@ class PwRelaxWorkChain(WorkChain):
         self.ctx.iteration += 1
 
         inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, namespace='base'))
-        inputs.structure = self.ctx.current_structure
-        inputs.parameters = inputs.parameters.get_dict()
+        inputs.pw.structure = self.ctx.current_structure
+        inputs.pw.parameters = inputs.pw.parameters.get_dict()
 
-        inputs.parameters.setdefault('CONTROL', {})
-        inputs.parameters['CONTROL']['calculation'] = self.inputs.relaxation_scheme.value
+        inputs.pw.parameters.setdefault('CONTROL', {})
+        inputs.pw.parameters['CONTROL']['calculation'] = self.inputs.relaxation_scheme.value
 
         # Do not clean workdirs of sub workchains, because then we won't be able to restart from them
         inputs.pop('clean_workdir', None)
@@ -151,13 +151,13 @@ class PwRelaxWorkChain(WorkChain):
     def run_final_scf(self):
         """Run the PwBaseWorkChain to run a final scf PwCalculation for the relaxed structure."""
         inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, namespace='base'))
-        inputs.structure = self.ctx.current_structure
-        inputs.parent_folder = self.ctx.current_parent_folder
-        inputs.parameters = inputs.parameters.get_dict()
+        inputs.pw.structure = self.ctx.current_structure
+        inputs.pw.parent_folder = self.ctx.current_parent_folder
+        inputs.pw.parameters = inputs.pw.parameters.get_dict()
 
-        inputs.parameters.setdefault('CONTROL', {})
-        inputs.parameters['CONTROL']['calculation'] = 'scf'
-        inputs.parameters['CONTROL']['restart_mode'] = 'restart'
+        inputs.pw.parameters.setdefault('CONTROL', {})
+        inputs.pw.parameters['CONTROL']['calculation'] = 'scf'
+        inputs.pw.parameters['CONTROL']['restart_mode'] = 'restart'
 
         inputs = prepare_process_inputs(PwBaseWorkChain, inputs)
         running = self.submit(PwBaseWorkChain, **inputs)
@@ -184,7 +184,7 @@ class PwRelaxWorkChain(WorkChain):
         # Get the latest workchain, which is either the workchain_scf if it ran or otherwise the last regular workchain
         try:
             workchain = self.ctx.workchain_scf
-            structure = workchain.inputs.structure
+            structure = workchain.inputs.pw.structure
         except AttributeError:
             workchain = self.ctx.workchains[-1]
             structure = workchain.outputs.output_structure


### PR DESCRIPTION
Fixes #341 

Now that calculation jobs are sub classes of `Process` and have their
specification defined through a `ProcessSpec` the `PwBaseWorkChain` can
exploit the `expose_inputs` functionality to expose its inputs just like
it would another sub process.