### PR TITLE
Add profile option to the command line interface

### DIFF
--- a/aiida_quantumespresso/cli/cli.py
+++ b/aiida_quantumespresso/cli/cli.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 """Module for the command line interface."""
 from __future__ import absolute_import
+
 import click
+
+from aiida.cmdline.params import options, types
 
 
 @click.group('aiida-quantumespresso', context_settings={'help_option_names': ['-h', '--help']})
-def root():
+@options.PROFILE(type=types.ProfileParamType(load_profile=True))
+def root(profile):  # pylint: disable=unused-argument
     """CLI for the `aiida-quantumespresso` plugin."""
 
 

--- a/setup.json
+++ b/setup.json
@@ -73,7 +73,7 @@
         ]
     },
     "install_requires": [
-        "aiida_core[atomic_tools]>=1.0.0b4",
+        "aiida_core[atomic_tools]>=1.0.0b5",
         "matplotlib<3.0.0; python_version<'3'",
         "xmlschema==1.0.13"
     ],


### PR DESCRIPTION
Fixes #354 

This will allow users to choose the profile without having to change
the default just like it is possible to do with `verdi`.