### PR TITLE
Extend functionality of CLI to NSCF and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.vscode
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ install:
     # Upgrade pip setuptools and wheel to be able to run the next command
     - pip install -U pip==18.1 wheel setuptools reentry
 
+    - pip install "numpy==1.16.4"  # see https://github.com/materialsproject/pymatgen/issues/1520
+
     # Install the repository with some optional dependencies
     - pip install .[dev,docs]
 

--- a/aiida_quantumespresso/cli/utils/display.py
+++ b/aiida_quantumespresso/cli/utils/display.py
@@ -2,6 +2,8 @@
 """Module with display utitlies for the CLI."""
 from __future__ import absolute_import
 
+import os
+
 import click
 
 
@@ -14,6 +16,13 @@ def echo_process_results(node):
 
     class_name = node.process_class.__name__
     outputs = node.get_outgoing(link_type=(LinkType.CREATE, LinkType.RETURN)).all()
+
+    if hasattr(node, 'dry_run_info'):
+        # It is a dry-run: get the information and print it
+        rel_path = os.path.relpath(node.dry_run_info['folder'])
+        click.echo("-> Files created in folder '{}'".format(rel_path))
+        click.echo("-> Submission script filename: '{}'".format(node.dry_run_info['script_filename']))
+        return
 
     if node.is_finished and node.exit_message:
         state = '{} [{}] `{}`'.format(node.process_state.value, node.exit_status, node.exit_message)

--- a/aiida_quantumespresso/cli/utils/launch.py
+++ b/aiida_quantumespresso/cli/utils/launch.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Module with launch utitlies for the CLI."""
 from __future__ import absolute_import
+from __future__ import print_function
 import click
 
 from aiida.engine import launch, Process, ProcessBuilder
@@ -27,6 +28,9 @@ def launch_process(process, daemon, **inputs):
         node = launch.submit(process, **inputs)
         click.echo('Submitted {}<{}> to the daemon'.format(process_name, node.pk))
     else:
-        click.echo('Running a {}...'.format(process_name))
+        if inputs.get('metadata', {}).get('dry_run', False):
+            click.echo('Running a dry run for {}...'.format(process_name))
+        else:
+            click.echo('Running a {}...'.format(process_name))
         _, node = launch.run_get_node(process, **inputs)
         echo_process_results(node)

--- a/aiida_quantumespresso/cli/utils/options.py
+++ b/aiida_quantumespresso/cli/utils/options.py
@@ -53,6 +53,15 @@ MAX_WALLCLOCK_SECONDS = OverridableOption(
 WITH_MPI = OverridableOption(
     '-i', '--with-mpi', is_flag=True, default=False, show_default=True, help=u'Run the calculations with MPI enabled.')
 
+PARENT_FOLDER = OverridableOption(
+    '-P',
+    '--parent-folder',
+    'parent_folder',
+    type=types.DataParamType(sub_classes=('aiida.data:remote',)),
+    show_default=True,
+    required=False,
+    help=u'The PK of a parent remote folder (for restarts).')
+
 DAEMON = OverridableOption(
     '-d',
     '--daemon',


### PR DESCRIPTION
This PR adds the following functionality:

- support for 'NSCF' calculations in the `aiida-quantumespresso` cli
- support for a `--parent-folder` option to allow for restarts
- check for calculation modes like NSCF that require a parent folder
- add of an option to perform a dry-run (and improved output in
  that case, and a check that this is not used in combination with
  `--daemon``)
- added an option ``--unfolded-kpoints`` to compute all kpoints
  ignoring symmetry, since this is required e.g. when running an
  NSCF to be followed by a Wannier90 calculation

Note that this functionality requires the new `dry_run_info` attribute
that is added in aiidateam/aiida-core#3212