### PR TITLE
Fixing documentation for pw to AiiDA 1.0 

### DIFF
--- a/docs/source/module_guide/tcod_dbexporter.rst
+++ b/docs/source/module_guide/tcod_dbexporter.rst
@@ -4,10 +4,12 @@ DbExporter documentation
 .. toctree::
    :maxdepth: 4
 
+
 TCOD database exporter
 ----------------------
 .. automodule:: aiida_quantumespresso.tools.dbexporters.tcod_plugins
    :members:
+
 
 TCOD parameter translator documentation
 ---------------------------------------
@@ -21,3 +23,4 @@ PW
 ++
 .. automodule:: aiida_quantumespresso.tools.dbexporters.tcod_plugins.pw
    :members:
+

--- a/docs/source/module_guide/workflows.rst
+++ b/docs/source/module_guide/workflows.rst
@@ -20,7 +20,6 @@ Base workchains
    :members:
 
    .. autoattribute:: aiida_quantumespresso.common.workchain.base.restart.BaseRestartWorkChain._verbose
-   .. autoattribute:: aiida_quantumespresso.common.workchain.base.restart.BaseRestartWorkChain._error_handlers
    .. autoattribute:: aiida_quantumespresso.common.workchain.base.restart.BaseRestartWorkChain._calculation_class
    .. autoattribute:: aiida_quantumespresso.common.workchain.base.restart.BaseRestartWorkChain._error_handler_entry_point
 

--- a/docs/source/user_guide/calculation_plugins/index.rst
+++ b/docs/source/user_guide/calculation_plugins/index.rst
@@ -1,7 +1,7 @@
 
 .. _sec.quantumespresso:
 
-Avaliable calculation plugins
+Available calculation plugins
 -----------------------------
 
 Description

--- a/docs/source/user_guide/calculation_plugins/pw.rst
+++ b/docs/source/user_guide/calculation_plugins/pw.rst
@@ -34,8 +34,26 @@ Inputs
 * **pseudo**, class :py:class:`UpfData <aiida.orm.nodes.data.upf.UpfData>`
   One pseudopotential file per atomic species.
 
-  Alternatively, pseudo for every atomic species can be set with the **use_pseudos_from_family**
-  method, if a family of pseudopotentials has been installed.
+ If a pseudo potential family is uploaded, the :py:func:`~aiida.orm.nodes.data.upf.get_pseudos_from_structure`
+ function can be used to automatically get the mapping of UpfData nodes for each kind in the StructureData one wants to use.
+For example: ::
+
+    from aiida.orm.nodes.data.upf import get_pseudos_from_structure
+    pseudo_potential_family = 'SSSP_efficiency'
+    structure = StructureData()  # Let's say this is a GaAs structure
+    pseudos = get_pseudos_from_structure(structure, pseudo_potential_family)
+
+The pseudos variable will now be a dictionary of the form: ::
+
+    pseudos = {
+        'Ga': UpfData(),
+        'As': UpfData()
+    }
+
+This can then be used directly in the process builder of for example a ``PwCalculation``.  ::
+
+    builder = PwCalculation.get_builder()
+    builder.pseudos = pseudos
 
 * **kpoints**, class :py:class:`KpointsData <aiida.orm.nodes.data.array.kpoints.KpointsData>`
   Reciprocal space points on which to build the wavefunctions. Can either be
@@ -56,7 +74,7 @@ Inputs
 
   A full list of variables and their meaning is found in the `pw.x documentation`_.
 
-  .. _pw.x documentation: http://www.quantum-espresso.org/wp-content/uploads/Doc/INPUT_PW.html
+   .. _pw.x documentation: https://www.quantum-espresso.org/Doc/INPUT_PW.html
 
   Following keywords, related to the structure or to the file paths, are already taken care of by AiiDA::
 
@@ -88,17 +106,21 @@ Inputs
   The file is copied in the pseudo subfolder, without changing its name, and
   without any check, so it is your responsibility to select the correct file
   that you want to use.
+* **hubbard file**, class  :py:class:`SinglefileData <aiida.orm.nodes.data.singlefile.SinglefileData>` (optional)
+  The file containing the Hubbard parameters, if they have to be read from a file. It requires the
+  *aiida-quantumespresso-hp* plugin.
 
 Outputs
 -------
 
 There are several output nodes that can be created by the plugin, according to the calculation details.
-All output nodes can be accessed with the ``calculation.out`` method.
+All output nodes can be accessed with the ``calculation.outputs`` namespace.
 
 * output_parameters :py:class:`Dict <aiida.orm.nodes.data.dict.Dict>`
   Contains the scalar properties. Example: energy (in eV),
-  total_force (modulus of the sum of forces in eV/Angstrom),
-  warnings (possible error messages generated in the run). ``calculation.outputs.output_parameters`` can also be
+  energy_units (eV),
+  warnings (possible error messages generated in the run).
+  ``calculation.outputs.output_parameters`` can also be
   accessed by the ``calculation.res`` shortcut.
 * output_array :py:class:`ArrayData <aiida.orm.nodes.data.array.ArrayData>`
   Produced in case of calculations which do not change the structure, otherwise,
@@ -154,12 +176,13 @@ Quantum ESPRESSO pw.x plugin (note that most of them apply also to the
 cp.x plugin).
 
 While the input link with name 'parameters' is used for the content of the
-Quantum Espresso namelists, additional parameters can be specified in the 'settings' input, also as Dict.
+Quantum Espresso namelists, additional parameters can be specified in the 'settings' input, also as
+:py:class:`Dict <aiida.orm.nodes.data.dict.Dict>`.
 
-After having defined the content of ``settings_dict``, you can use
-it as input of a calculation ``calc`` by doing::
+After having defined the content of ``settings_dict``,
+you can use it as an input by adding it to the process builder::
 
-    calc.use_settings(Dict(dict=settings_dict))
+    builder.settings = Dict(dict=settings_dict)
 
 The different options are described below.
 

--- a/docs/source/user_guide/get_started/examples/pw_short_example.py
+++ b/docs/source/user_guide/get_started/examples/pw_short_example.py
@@ -10,21 +10,29 @@
 ###########################################################################
 from __future__ import absolute_import
 from __future__ import print_function
-from aiida import load_dbenv
-load_dbenv()
+from aiida import load_profile
 
-from aiida.plugins import Code, DataFactory
+from aiida.orm import Code
+from aiida.plugins import DataFactory
+from aiida.engine import submit
+from aiida.orm.nodes.data.upf import get_pseudos_from_structure
+
+load_profile()
+
+
 StructureData = DataFactory('structure')
 Dict = DataFactory('dict')
 KpointsData = DataFactory('array.kpoints')
 
 ###############################
 # Set your values here
-codename = 'pw-5.1@TheHive'
-pseudo_family = 'lda_pslibrary'
+codename = 'pw-6.3@TheHive'
+pseudo_family = 'SSSP_efficiency'
 ###############################
 
+
 code = Code.get_from_string(codename)
+builder = code.get_builder()
 
 # BaTiO3 cubic structure
 alat = 4. # angstrom
@@ -56,18 +64,18 @@ parameters = Dict(dict={
 kpoints = KpointsData()
 kpoints.set_kpoints_mesh([4,4,4])
 
-calc = code.new_calc(max_wallclock_seconds=3600,
-    resources={'num_machines': 1})
-calc.label = 'A generic title'
-calc.description = 'A much longer description'
+builder.pseudos = get_pseudos_from_structure(s,pseudo_family)
 
-calc.use_structure(s)
-calc.use_code(code)
-calc.use_parameters(parameters)
-calc.use_kpoints(kpoints)
-calc.use_pseudos_from_family(pseudo_family)
+builder.metadata.options.resources = {'num_machines': 1}
+builder.metadata.options.max_wallclock_seconds = 1800
 
-calc.store_all()
+builder.metadata.label = 'My generic title'
+builder.metadata.description ='My generic description'
+
+builder.structure = s
+builder.parameters = parameters
+builder.kpoints = kpoints
+
+calc = submit(builder)
+
 print('created calculation with PK={}'.format(calc.pk))
-calc.submit()
-

--- a/docs/source/user_guide/get_started/examples/pw_tutorial.rst
+++ b/docs/source/user_guide/get_started/examples/pw_tutorial.rst
@@ -1,17 +1,27 @@
 .. _my-ref-to-pw-tutorial:
 
-PWscf
-=====
+Running a PWscf calculation
+===================================
 
 .. toctree::
    :maxdepth: 2
 
-This chapter will show how to launch a single PWscf (``pw.x``) calculation. It is assumed that you have already performed the installation, and that you already setup a computer (with ``verdi``), installed Quantum Espresso on the cluster and in AiiDA. Although the code could be quite readable, a basic knowledge of Python and object programming is useful.
+This section will show how to launch a single PWscf (``pw.x`` executable) calculation.
+It is assumed that you have already performed the installation, and that you already:
 
-Your classic pw.x input file
-----------------------------
+  - setup a computer (with ``verdi``);
+  - installed Quantum ESPRESSO on your machine or a cluster;
+  - setup the code and computer you want to use.
 
-This is the input file of Quantum Espresso that we will try to execute. It consists in the total energy calculation of a 5 atom cubic cell of BaTiO3. Note also that AiiDA is a tool to use other codes: if the following input is not clear to you, please refer to the Quantum Espresso Documentation.
+Although the code could be quite readable, a basic knowledge of Python and object programming is useful.
+
+The classic ``pw.x`` input file
+--------------------------------
+
+This is the input file of Quantum ESPRESSO that we will try to execute.
+It consists in the total energy calculation of a 5 atom cubic cell of BaTiO\ :sub:`3`\.
+Note also that AiiDA is a tool to use other codes:
+if the following input is not clear to you, please refer to the Quantum ESPRESSO documentation.
 
 ::
 
@@ -51,62 +61,125 @@ This is the input file of Quantum Espresso that we will try to execute. It consi
           0.0000000000       4.0000000000       0.0000000000
           0.0000000000       0.0000000000       4.0000000000
 
-In the old way, not only you had to prepare 'manually' this file, but also prepare the scheduler submission script, send everything on the cluster, etc.
+Without AiiDA, not only you would have to prepare 'manually' this file,
+but also prepare the scheduler submission script, send everything on the cluster, etc.
 We are going instead to prepare everything in a more programmatic way.
 
-Quantum Espresso Pw Walkthrough
--------------------------------
+Running a pw calculation with AiiDA
+-----------------------------------
 
-We've got to prepare a script to submit a job to your local installation of AiiDA.
-This example will be a rather long script: in fact there is still nothing in your database, so that we will have to load everything, like the pseudopotential files and the structure.
-In a more practical situation, you might load data from the database and perform a small modification to re-use it.
+Now we are going to prepare a script to submit a job to your local installation of AiiDA.
+This example will be a rather long script: in fact it assumes that nothing in your database,
+so that we will have to load everything, like the pseudopotential files and the structure.
+In a more practical situation, you might load data from the database and
+perform a small modification to re-use it.
 
 Let's say that through the ``verdi`` command you have already installed
-a cluster, say ``TheHive``, and that you also compiled Quantum Espresso
-on the cluster, and installed the code pw.x with ``verdi`` with label ``pw-5.1``
+a cluster, say ``TheHive``, and that you also compiled Quantum ESPRESSO
+on the cluster, and installed the code pw.x with ``verdi`` with label ``pw-6.3``
 for instance, so that in the rest of this tutorial we will reference to the
-code as ``pw-5.1@TheHive``.
+code as ``pw-6.3@TheHive``.
 
 Let's start writing the python script.
 First of all, we need to load the configuration concerning your
 particular installation, in particular, the details of your database installation::
 
   #!/usr/bin/env python
-  from aiida import load_dbenv
-  load_dbenv()
+  from aiida import load_profile
+  load_profile()
 
 Code
 ----
 
+
 Now we have to select the code. Note that in AiiDA the object 'code' in the
 database is meant to represent a specific executable, i.e. a given
-compiled version of a code.
-This means that if you install Quantum Espresso (QE) on two computers A and B,
+compiled version of a code. Every calculation in AiiDA is linked to a *code*, installed on
+a specific *computer*.
+This means that if you install Quantum ESPRESSO on two computers *A* and *B*,
 you will need to have two different 'codes' in the database
 (although the source of the code is the same, the binary file is different).
 
-If you setup the code ``pw-5.1`` on machine ``TheHive`` correctly, then it is
+If you setup the code ``pw-6.3`` on machine ``TheHive`` correctly, then it is
 sufficient to write::
 
-  codename = 'pw-5.1@TheHive'
+  codename = 'pw-6.3@TheHive'
   from aiida.orm import Code
   code = Code.get_from_string(codename)
 
-Where in the last line we just load the database object representing the code.
+where in the last line we just load the database object representing the code.
 
 .. note:: the ``.get_from_string()`` method is just a helper method for user
   convenience, but there are some weird cases that cannot be dealt in a
   simple way (duplicated labels, code names
-  that are an integer number, code names containing the '@' symbol, ...: try
+  that are an integer number, code names containing the '@' symbol, ...): try
   to not do this! This is not an error, but does not allow to use the
-  ``.get_from_string()`` method to get those calculations).
-  In this case, you can use directly the ``.get()`` method, for instance::
+  ``.get_from_string()`` method to get those calculations.
+  You can use directly the ``.get()`` method, for instance::
 
-    code = Code.get(label='pw-5.1', machinename='TheHive')
+    code = Code.get(label='pw-6.3', machinename='TheHive')
 
-  or even more generally get the code from its (integer) PK::
+  or even more generally get the code from its (integer) ``PK``::
 
     code = load_node(PK)
+
+Once you have a code, you can start to assemble the inputs to run
+a PWscf calculation.
+
+.. note:: To learn more about calculations and processes in AiiDA you can
+  refer to the :ref:`working_calculations` and :ref:`concepts_processes` sections
+  of the AiiDA manual
+  Remember that what is shown here refers to the Quantum ESPRESSO plugin:
+  different codes will in general required different inputs.
+
+
+Preparing a calculation
+------------------------
+
+To make it easier to prepare the inputs of an AiiDA calculation, process classes
+have a ``get_builder`` method, that simplify the access to the inputs of a calculation.
+
+To use it, you can load the calculation class that you need through the
+``CalculationFactory`` ::
+
+  PwCalculation = CalculationFactory('quantumespresso.pw')
+  builder = PwCalculation.get_builder()
+
+In a similar way, you can use the ``get_builder`` utility from a code, with the advantage
+that the *code* input gets automatically populated: ::
+
+  builder = code.get_builder()
+
+
+If you are using the builder to a verdi shell, you will
+see all the inputs that are available for a calculation by pressing the ``TAB`` key
+after typing ``builder.``. To understand what type of data is expected for a
+particular input, you can append the ``?`` or the ``??`` at the end of an input. For example: ::
+
+    >>> builder.structure?
+    Type:        property
+    String form: <property object at 0x7f58bdcc6728>
+    Docstring:   {"name": "structure", "required": "True", "valid_type": "<class '`aiida.orm.nodes.data.structure.StructureData`'>", "help": "The input structure."}
+
+In this case, the helper lets you know you what kind of data it expects
+(:py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`),
+that it is a *required* input for the calculation, and a short string explaining what the *structure* input represents.
+
+The plugin requires at least the presence of:
+
+    - An input structure;
+    - A k-points mesh, in the form of a :py:class:`KpointsData <aiida.orm.nodes.data.array.kpoints.KpointsData>` object;
+    - Pseudopotential files for the atomic species present;
+    - A parameters dictionary, that contains the details of the Quantum ESPRESSO calculation;
+
+
+Other inputs are optional, for example:
+
+    - *metadata* is a dictionary of inputs that modify slightly the behaviour of a processes;
+    - *settings* is a :py:class:`Dict <aiida.orm.nodes.data.dict.Dict>` dictionary that provides access to more advanced, non-default feature of the code.
+
+
+
 
 Structure
 ---------
@@ -119,17 +192,28 @@ We now proceed in setting up the structure.
     For more detailed information, give a look to the
     :ref:`structure_tutorial`.
 
-There are two ways to do that in AiiDA, a first one is to use the AiiDA Structure, which we will explain in the following; the second choice is the `Atomic Simulation Environment (ASE) <http://wiki.fysik.dtu.dk/ase/>`_ which provides excellent tools to manipulate structures (the ASE Atoms object needs to be converted into an AiiDA Structure, see the note at the end of the section).
+There are two ways to do that in AiiDA, a first one is to use the AiiDA Structure,
+which we will explain in the following; the second choice is the
+`Atomic Simulation Environment (ASE) <http://wiki.fysik.dtu.dk/ase/>`_
+which provides excellent tools to manipulate structures (the ASE Atoms object
+needs to be converted into an AiiDA Structure, see the note at the end of the section).
 
 We first have to load the abstract object class that describes a structure.
-We do it in the following way: we load the DataFactory, which is a tool to load the classes by their name, and then call StructureData the abstract class that we loaded.
-(NB: it's not yet a class instance!)
-(If you are not familiar with the terminology of object programming, we could take `Wikipedia <http://en.wikipedia.org/wiki/Object_(computer_science)>`_ and see their short explanation: in common speech that one refers to *a* file as a class, while *the* file is the object or the class instance. In other words, the class is our definition of the object Structure, while its instance is what will be saved as an object in the database)::
+We do it in the following way: we load the ``DataFactory``, which is a tool to load the classes
+by their name, and then call ``StructureData`` the abstract class that we loaded.
+Note that it is not yet a class instance!
+If you are not familiar with the terminology of object programming,
+you can look at `Wikipedia <http://en.wikipedia.org/wiki/Object_(computer_science)>`_ for
+their short explanation: in common speech that one refers to *a* file as a class,
+while *the* file is the object or the class instance. In other words,
+the class is our definition of the object ``Structure``,
+while its instance is what will be saved as an object in the database::
 
   from aiida.plugins import DataFactory
   StructureData = DataFactory('structure')
 
-We define the cell with a 3x3 matrix (we choose the convention where each ROW represents a lattice vector), which in this case is just a cube of size 4 Angstroms::
+We define the cell with a 3x3 matrix (we choose the convention
+where each ROW represents a lattice vector), which in this case is just a cube of size 4 Angstroms::
 
   alat = 4. # angstrom
   cell = [[alat, 0., 0.,],
@@ -137,7 +221,7 @@ We define the cell with a 3x3 matrix (we choose the convention where each ROW re
           [0., 0., alat,],
          ]
 
-Now, we create the StructureData instance, assigning immediately the cell.
+Now, we create the ``StructureData`` instance, assigning immediately the cell.
 Then, we append to the empty crystal cell the atoms, specifying their element name and their positions::
 
   # BaTiO3 cubic structure
@@ -148,43 +232,46 @@ Then, we append to the empty crystal cell the atoms, specifying their element na
   s.append_atom(position=(alat/2.,0.,alat/2.),symbols='O')
   s.append_atom(position=(0.,alat/2.,alat/2.),symbols='O')
 
-To see more methods associated to the class StructureData, look at the :ref:`my-ref-to-structure` documentation.
+To see more methods associated to the ``StructureData`` class,
+look at the :ref:`my-ref-to-structure` documentation on the AiiDA manual.
 
 .. note:: When you create a node (in this case a ``StructureData`` node) as
   described above, you are just creating it in the computer memory, and not
   in the database. This is particularly useful to run tests without filling
   the AiiDA database with garbage.
 
-  You will see how to store all the nodes in one shot toward the end of this
-  tutorial; if, however, you want to directly store the structure in the
+  It is not necessary to store anything to the database at this point;
+  if, however, you want to directly store the structure in the
   database for later use, you can just call the ``store()`` method of the Node::
 
     s.store()
 
-For an extended tutorial about the creation of Structure objects,
+For an extended tutorial about the creation of ``Structure`` objects,
 check :ref:`this tutorial on the AiiDA-core documentation <aiida:structure_tutorial>`.
 
-.. note:: AiiDA supports also ASE structures. Once you created your structure
+.. note:: AiiDA also supports  ASE structures. Once you created your structure
   with ASE, in an object instance called say ``ase_s``, you can
-  straightforwardly use it to create the AiiDA StructureData, as::
+  straightforwardly use it to create the AiiDA ``StructureData``, as::
 
     s = StructureData(ase=ase_s)
 
   and then save it ``s.store()``.
 
+
 Parameters
 ----------
 
-Now we need to provide also the parameters of a Quantum Espresso calculation,
-like the cutoff for the wavefunctions, some convergence threshold, etc...
+Now we need to provide also the parameters of a Quantum ESPRESSO calculation,
+like the cutoff for the wavefunctions, some convergence threshold, and so on.
 The Quantum ESPRESSO pw.x plugin requires to pass this information within a
-Dict object, that is a specific AiiDA data node that can store a
+``Dict`` object, that is a specific AiiDA data node that can store a
 dictionary (even nested) of basic data types: integers, floats, strings, lists,
 dates, ...
-We first load the class through the DataFactory, just like we did for the Structure.
+We first load the class through the ``DataFactory``,
+just like we did for the ``Structure``.
 Then we create the instance of the object ``parameter``.
-To represent closely the structure of the QE input file,
-Dict is a nested dictionary, at the first level the namelists
+To represent closely the structure of the Quantum ESPRESSO input file,
+``Dict`` is a nested dictionary, at the first level the namelists
 (capitalized), and then the variables with their values (in lower case).
 
 Note also that numbers and booleans are written in Python, i.e. ``False`` and
@@ -213,9 +300,9 @@ not the Fortran string ``.false.``!
 
     parameters = Dict(dict={...}).store()
 
-The experienced QE user will have noticed also that a couple of variables
-are missing: the prefix, the pseudo directory and the scratch directory are
-reserved to the plugin which will use default values, and there are specific
+The experienced Quantum ESPRESSO user will have noticed also that a couple of variables
+are missing: the *prefix*, the *pseudo directory* and the *scratch directory* are
+reserved to the plugin, which will use default values, and there are specific
 AiiDA methods to restart from a previous calculation.
 
 Input parameters validation
@@ -224,7 +311,7 @@ The dictionary provided above is the standard format for storing the inputs
 of Quantum ESPRESSO pw.x in the database. It is important to store the inputs
 of different calculations in a consistent way because otherwise later querying
 becomes impossible (e.g. if different units are used for the same flags,
-if the same input is provided in different formats, ...).
+if the same input is provided in different formats, and so on).
 
 In the PW input plugin, we provide a function that will help you in
 both validating the input, and creating the input in the expected format
@@ -255,7 +342,7 @@ exception, and the error message will have a verbose explanation of the possible
 errors, and in many cases it will suggest how to fix them. Otherwise, in ``resdict``
 you will find the same dictionary you passed in input, potentially slightly modified
 to fix some small mistakes (e.g., if you pass an integer value where a float is expected,
-the type will be converted). You can then use the output for the input Dict node::
+the type will be converted). You can then use the output for the input ``Dict`` node::
 
   parameters = Dict(dict=resdict)
 
@@ -291,10 +378,10 @@ similar valid names is provided (e.g. for the wrong keyword "convthr" above).
 
 There are a few additional options that are useful:
 
-  - If you don't want to remember the namelists, you can pass a 'flat' dictionary, without
+  - If you don't remember the namelists, you can pass a 'flat' dictionary, without
     namelists, and add the ``flat_mode=True`` option to ``input_helper``. Beside the usual
     validation, the function will reconstruct the correct dictionary to pass as input for
-    the AiiDA QE calculation. Example::
+    the AiiDA Quantum ESPRESSO calculation. Example::
 
         test_dict_flat = {
             'calculation': 'scf',
@@ -335,7 +422,7 @@ There are a few additional options that are useful:
    is released, but consider the ``input_helper`` function as a utility, rather than the
    official way to provide the input -- the only officially supported way to provide
    an input to pw.x is through a direct dictionary, as described earlier in the section "Parameters".
-   This applies in particular if you are using very old versions of QE, or customized versions
+   This applies in particular if you are using very old versions of Quantum ESPRESSO, or customized versions
    that accept different parameters.
 
 
@@ -434,10 +521,10 @@ and 3 in the ultimate input file, respectively.
     and will indiscriminately map the value to an atomic species index if that value corresponds to a kind name.
 
 
-Other inputs
-------------
+K-points mesh
+-------------
 
-The k-points have to be saved in another kind of data, namely KpointsData::
+The k-points have to be saved in another kind of data, namely ``KpointsData``::
 
   KpointsData = DataFactory('array.kpoints')
   kpoints = KpointsData()
@@ -457,85 +544,12 @@ in crystal coordinates (here they all have equal weights)::
     kpoints.set_kpoints([[i,i,0] for i in numpy.linspace(0,1,10)],
         weights = [1. for i in range(10)])
 
-.. _gamma-only:
-.. note:: It is also possible to generate a gamma-only computation. To do so
-  one has to specify additional settings, of type Dict, putting
-  gamma-only to True::
 
-    settings = Dict(dict={'gamma_only':True})
+A Gamma point calculation can be submitted by providing the 'gamma_only' flag to
+the options dictionary ::
 
-  then set the kpoints mesh to a single point (gamma)::
-
-    kpoints.set_kpoints_mesh([1,1,1])
-
-  and in the end add (after ``calc = code.new_calc()``, see below) a line to use
-  these settings::
-
-    calc.use_settings(settings)
-
-As a further comment, this is specific to the way the plugin
-for Quantum Espresso works.
-Other codes may need more than two Dict, or even none of them.
-And also how this parameters have to be written depends on the plugin:
-what is discussed here is just the format that we decided for
-the Quantum Espresso plugins.
-
-Calculation
------------
-
-Now we proceed to set up the calculation.
-Since during the setup of the code we already set the code to be a
-``quantumespresso.pw`` code, there is a simple method to create a new
-calculation::
-
-  calc = code.new_calc()
-
-We have to specify the details required by the scheduler.
-For example, on a SLURM or PBS scheduler, we have to specify the number
-of nodes (``num_machines``), possibly the number of MPI processes per node
-(``num_mpiprocs_per_machine``) if we want to run with a different number
-of MPI processes with respect to the default value configured when setting up
-the computer in AiiDA, the job walltime, the queue name (if desired), ...::
-
-  calc.set_option('max_wallclock_seconds', 30*60) # 30 min
-  calc.set_option('resources', {"num_machines": 1})
-  ## OPTIONAL, use only if you need to explicitly specify a queue name
-  # calc.set_option('queue_name', "the_queue_name")
-
-(For the complete scheduler documentation, see :ref:`my-reference-to-scheduler`)
-
-.. note:: an alternative way of calling a method starting with the string
-  ``set_``, is to pass directly the value to the ``.new_calc()`` method. This
-  is to say that the following lines::
-
-    calc = code.new_calc()
-    calc.set_option('max_wallclock_seconds', 3600)
-    calc.set_option('resources', {"num_machines": 1})
-
-  is equivalent to::
-
-    calc = code.new_calc(max_wallclock_seconds=3600,
-        resources={"num_machines": 1})
-
-At this point, we just created a "lone" calculation, that still does not know
-anything about the inputs that we created before. We need therefore to
-tell the calculation to use the parameters that we prepared before, by
-properly linking them using the ``use_`` methods::
-
-  calc.use_structure(s)
-  calc.use_code(code)
-  calc.use_parameters(parameters)
-  calc.use_kpoints(kpoints)
-
-In practice, when you say ``calc.use_structure(s)``, you are setting a link
-between the two nodes (``s`` and ``calc``), that means that
-``s`` is the input *structure* for *calculation* ``calc``. Also these links
-are cached and do not require to store anything in the database yet.
-
-In the case of the gamma-only computation (see :ref:`above <gamma-only>`), you
-also need to add::
-
-  calc.use_settings(settings)
+   kpoints.set_kpoints_mesh([1,1,1])
+   builder.settings = Dict(dict={'gamma_only': True})
 
 Pseudopotentials
 ----------------
@@ -543,16 +557,35 @@ Pseudopotentials
 There is still one missing piece of information, that is the
 pseudopotential files, one for each element of the structure.
 
-In AiiDA, it is possible to specify manually which pseudopotential files to use
+.. note::
+
+   For a more extended documentation on how to import pseudopotentials in the database,
+   and how to handle and instal pseudopotential families, you can find more
+   information in :ref:`my-ref-to-pseudo-tutorial`.
+
+The ``builder.pseudos`` input is a dictionary, where the keys are the names of
+the elements, and the values are the ``UpfData`` objects stored in the database.
+
+It is possible to specify manually which pseudopotential files to use
 for each atomic species. However, for any practical use, it is convenient
 to use the pseudopotential families.
-Its use is documented in :ref:`my-ref-to-pseudo-tutorial`.
+
 If you got one installed, you can simply tell the calculation to use the
 pseudopotential family with a given name, and AiiDA will take care of
 linking the proper pseudopotentials to the calculation, one for each atomic
 species present in the input structure. This can be done using::
 
-  calc.use_pseudos_from_family('my_pseudo_family')
+  from aiida.orm.nodes.data.upf import get_pseudos_from_structure
+  builder.pseudos = get_pseudos_from_structure(structure, <PSEUDOPOTENTIAL_FAMILY_NAME>)
+
+
+.. note::
+
+   The list of pseudopotential families installed in your database can be accessed
+   by command line with ::
+
+       verdi data upf listfamilies
+
 
 Labels and comments
 -------------------
@@ -564,82 +597,115 @@ Comments are a special set of properties of the calculation, in the sense
 that it is one of the few properties that can be changed, even after
 the calculation has run.
 
-Comments come in various flavours. The most basic one is the label property,
-a string of max 255 characters, which is meant to be the title of the calculation.
-To create it, simply write::
+These properties can be set in the ``metadata`` input of the calculation,
+with a *label* (a short description) and *description* (longer) ::
 
-  calc.label = "A generic title"
+    builder.metadata.label = 'My generic title'
+    builder.metadata.description ' a PWscf calculation of BaTiO3'
 
-The label can be later accessed as a class property, i.e. the command::
+.. note::
+   The ``TAB`` expansion works also on nested properties: from ``builder.metadata.``
+   you can explore the available options
 
-  calc.label
+Calculation resources
+---------------------
 
-will return the string you previously set (empty by default).
-Another important property to set is the description, which instead does not have a
-limitation on the maximum number of characters::
+General options that are independent on  the code or the plugin
+are grouped under  ``builder.metadata.options``.
+Here you can set up the resource that you want to allocate
+to this calculation, that will be passed to the scheduler
+that handles the queue on your computer: ::
 
-  calc.description = "A much longer description"
+    builder.metadata.options.resources = {'num_machines': 1}
+    builder.metadata.options.max_wallclock_seconds = 1800
 
-And finally, there is the possibility to add comments to any calculation
-(actually, to any node).
-The peculiarity of comments is that they are user dependent
-(like the comments that you can post on facebook pages), so it is best
-suited to calculation exposed on a website, where you want to remember
-the comments of each user.
-To set a comment, you need first to import the django user, and then
-write it with a dedicated method::
-
-  from aiida.backends.djsite.utils import get_automatic_user
-  calc.add_comment("Some comment", user=get_automatic_user())
-
-The comments can be accessed with this function::
-
-  calc.get_comments_tuple()
+More options are available, and can be explored by expanding
+``builder.metadata.options.`` + ``TAB``.
 
 
-Execute
--------
-If we are satisfied with what you created, it is time to store everything
-in the database.
-Note that after storing it, it will not be possible to modify it
-(nor you should: you risk of compromising the integrity of the database)!
 
-Unless you already stored all the inputs beforehand, you will need to store
-the inputs before being able to store the calculation itself.
-Since this is a very common operation, there is an utility method that will
-automatically store both all the input nodes of ``calc`` and then ``calc``
-itself::
 
-  calc.store_all()
+Launching the calculation
+-------------------------
 
-Once we store the calculation, it is useful to print its PK (principal key,
-that is its identifier) that is useful in the following to interact with it::
 
-  print "created calculation; with uuid='{}' and PK={}".format(calc.uuid,calc.pk)
+If we are satisfied with what you created, it is time to attach all the required inputs
+to the calculation: ::
 
-.. note:: the PK will change if you give the calculation to someone else,
-  while the UUID (the Universally Unique IDentifier) is a string that is
-  assured to be always the same also if you share your data with collaborators.
+    builder.structure = structure
+    builder.kpoints = kpoints
+    builder.parameters = parameters
+
+
+The data nodes do not need to be stored at this point, as AiiDA will store them upon submission.
+
+
+To execute the calculation, there are two possible ways:
+
+   - run: the calculation gets executed in the shell, locking it until it is finished;
+   - submit: the calculation is handled to the AiiDA daemon, and it will be running in the background
+
+The commands are explained more in detail in the :ref:`working_processes_launching` documentation of AiiDA.
+
+To run your calculation, you can execute: ::
+
+    from aiida.engine import run
+    results = run(builder)
+
+where the ``results`` variable will contain  a dictionary containing all the nodes that were produced as output.
+Alternatively, it is possible to use either ``run.get_node`` or ``run.get_pk`` methods to retrive more information
+about the calculation node: ::
+
+
+    from aiida.engine import run
+    result, node = run.get_node(builder)
+    result, pk = run.get_pk(builder)
+
+where ``pk`` and ``node`` will contain, respectively, the ``node`` object of the calculation or its ``pk``.
+
+To submit the calculation to the daemon, you can use instead ::
+
+    from aiida.engine import submit
+    calc = submit(builder)
+
+Note that, in this case, ``calc`` is the calculation node, and *not* the result dictionary.
+
+.. note::
+    In order to inspect the inputs created by AiiDA without actually running the calculation,
+    we can perform a *dry run* of the submission process: ::
+
+        builder.metadata.dry_run = True
+        builder.metadata.store_provenance = False
+
+    This will create the input files, that are available for inspection.
+
+.. note::
+     You're not forced to assign the inputs through the builder: they can be provided as keywords argument
+     when you launch the calculation, passing the calculation class as the first argument: ::
+
+        run(PwCalculation, structure=s, pseudos=pseudos, kpoints = kpoints, ...)
+
+
+
+The calculation results are directly accessible as a result of the ``run`` job, or they can be
+easily accessed from ``calc.res.``, a shortcut to the ``calc.outputs.output_parameters`` dictionary: ::
+
+    calc.res.energy
+    calc.res.energy_units
+
+to access the final energy and its units.
+
+
 
 Summarizing, we created all the inputs needed by a PW calculation,
 that are: parameters, kpoints, pseudopotential files and the structure.
 We then created the calculation, where we specified that it is a PW calculation
 and we specified the details of the remote cluster.
-We set the links between the inputs and the calculation (``calc.use_***``)
-and finally we stored all this objects in the database (``.store_all()``).
 
-That's all that the calculation needs.  Now we just need to submit it::
-
-   calc.submit()
-
-Everything else will be managed by AiiDA: the inputs will be checked to verify
-that it is consistent with a PW input. If the input is complete, the pw input
-file will be prepared in a folder together with all the other files required
-for the execution (pseudopotentials, etc.). It will be then sent on cluster,
-submitted, and after execution automatically retrieved and parsed.
 
 .. To know how to monitor and check the state of submitted calculations, check the
    :ref:<AiiDA-core documentation`aiida:calculation_state`>.
+
 
 To continue the tutorial with the ``ph.x`` phonon code of Quantum ESPRESSO,
 continue here: :ref:`my-ref-to-ph-tutorial`.
@@ -659,90 +725,7 @@ and ``pseudo_family`` with the correct values, and execute it with::
 
 (It requires to have one family of pseudopotentials configured).
 
-You will also find a longer version, with more exception checks, error
-management and user interaction.
-Note that the configuration of the computer resources
-(like number of nodes and machines) is hardware and scheduler dependent.
-The configuration used below should work for a pbspro or slurm cluster,
-asking to run on 1 node only.
-
-Compact script
---------------
 Download: :download:`this example script <pw_short_example.py>`
-
-::
-
-  #!/usr/bin/env python
-  from aiida import load_dbenv
-  load_dbenv()
-
-  from aiida.orm import Code, DataFactory
-  StructureData = DataFactory('structure')
-  Dict = DataFactory('dict')
-  KpointsData = DataFactory('array.kpoints')
-
-  ###############################
-  # Set your values here
-  codename = 'pw-5.1@TheHive'
-  pseudo_family = 'lda_pslibrary'
-  ###############################
-
-  code = Code.get_from_string(codename)
-
-  # BaTiO3 cubic structure
-  alat = 4. # angstrom
-  cell = [[alat, 0., 0.,],
-          [0., alat, 0.,],
-          [0., 0., alat,],
-         ]
-  s = StructureData(cell=cell)
-  s.append_atom(position=(0.,0.,0.),symbols='Ba')
-  s.append_atom(position=(alat/2.,alat/2.,alat/2.),symbols='Ti')
-  s.append_atom(position=(alat/2.,alat/2.,0.),symbols='O')
-  s.append_atom(position=(alat/2.,0.,alat/2.),symbols='O')
-  s.append_atom(position=(0.,alat/2.,alat/2.),symbols='O')
-
-  parameters = Dict(dict={
-            'CONTROL': {
-                'calculation': 'scf',
-                'restart_mode': 'from_scratch',
-                'wf_collect': True,
-                },
-            'SYSTEM': {
-                'ecutwfc': 30.,
-                'ecutrho': 240.,
-                },
-            'ELECTRONS': {
-                'conv_thr': 1.e-6,
-                }})
-
-  kpoints = KpointsData()
-  kpoints.set_kpoints_mesh([4,4,4])
-
-  calc = code.new_calc(max_wallclock_seconds=3600,
-      resources={"num_machines": 1})
-  calc.label = "A generic title"
-  calc.description = "A much longer description"
-
-  calc.use_structure(s)
-  calc.use_code(code)
-  calc.use_parameters(parameters)
-  calc.use_kpoints(kpoints)
-  calc.use_pseudos_from_family(pseudo_family)
-
-  calc.store_all()
-  print "created calculation with PK={}".format(calc.pk)
-  calc.submit()
-
-
-
-
-Exception tolerant code
------------------------
-You can find a more sophisticated example, called ``test_pw.py`` (that checks the possible exceptions
-and prints nice error messages) inside your AiiDA-quantumespresso source folder, in the top
-``examples/submission/`` folder
-(or directly on `GitHub <https://github.com/aiidateam/aiida-quantumespresso/tree/develop/examples/submission>`_).
 
 Advanced features
 -----------------
@@ -751,8 +734,8 @@ command line parameters, blocking some coordinates, ...) you can refer
 to :ref:`this section<pw-advanced-features>`
 in the pw.x input plugin documentation.
 
-Importing previously run Quantum ESPRESSO pw.x calculations: PwImmigrant
-------------------------------------------------------------------------
+Importing previously run Quantum ESPRESSO pw.x calculations: ``PwImmigrant``
+----------------------------------------------------------------------------
 
 Once you start using AiiDA to run simulations, we believe that you will find it
 so convenient that you will use it for all your calculations.
@@ -760,6 +743,6 @@ so convenient that you will use it for all your calculations.
 At the beginning, however, you may have some calculations that you already have
 run and are sitting in some folders, and that you want to import inside AiiDA.
 
-This can be achieved with the PwImmigrant class described below,
+This can be achieved with the ``PwImmigrant`` class described below,
 for which you can find a tutorial :ref:`here <pwimmigrant-tutorial>`.
 


### PR DESCRIPTION
Fixes #356

I checked that the two documentation pages for pw are up to date with
the latest version of AiiDA, including an example script. Modifications inspired from
the latest AiiDA tutorial pages.

Fixed the automodule documentation pages to remove references to outdated classes where it was OK to do so. 

Still 2 warnings in the compilation for me, that I did not touch, (since I 
expect that this files have not been migrated yet)
reference to non-existing AiiDA classes -- ``aiida.tools.dbexporters.tcod_plugins``