### PR TITLE
ensure the ERROR_INVALID_KPOINT_UNITS exit code is captured

### DIFF
--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -443,7 +443,8 @@ class PwParser(Parser):
 
         if k_points_units != '1 / angstrom':
             self.logger.error('Error in kpoints units (should be cartesian)')
-            self.exit_code_parser.ERROR_INVALID_KPOINT_UNITS
+            self.exit_code_parser = self.exit_codes.ERROR_INVALID_KPOINT_UNITS
+            return None
 
         kpoints = orm.KpointsData()
         kpoints.set_cell_from_structure(structure)


### PR DESCRIPTION
I noticed this, because it was highlighted by pylint (unused-variable). Then I noticed that you're currently excluding most of the files from the pylint pre-commit. I'm guessing that's on the todo list :)