### PR TITLE
fix pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,11 +47,14 @@
     pass_filenames: false
 
 - repo: https://github.com/python-modernize/python-modernize.git
-  sha: a234ce4e185cf77a55632888f1811d83b4ad9ef2
+  rev: a234ce4e185cf77a55632888f1811d83b4ad9ef2
   hooks:
   - id: python-modernize
-    exclude: ^docs/
-    exclude: ^examples/
+    exclude: >
+      (?x)^(
+        docs/.*|
+        examples/.*
+      )$
     args:
       - --write
       - --nobackups


### PR DESCRIPTION
minor fix: `sha` is deprecated for `rev`