### PR TITLE
Fix the TCOD export plugins for `PwCalculation` and `PhCalculation`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@
       (?x)^(
         aiida_quantumespresso/calculations.*|
         aiida_quantumespresso/parsers/.*|
-        aiida_quantumespresso/tools/dbexporters/.*|
         aiida_quantumespresso/utils/restart.py|
         docs/.*|
         tests/.*

--- a/aiida_quantumespresso/tools/dbexporters/tcod_plugins/cp.py
+++ b/aiida_quantumespresso/tools/dbexporters/tcod_plugins/cp.py
@@ -1,17 +1,22 @@
 # -*- coding: utf-8 -*-
-
+"""TCOD export plugin for `CpCalculations`."""
 from __future__ import absolute_import
-from aiida.tools.dbexporters.tcod_plugins import BaseTcodtranslator
+
+try:
+    from aiida_tcod.tools.dbexporters.tcod import BaseTcodtranslator  # pylint: disable=import-error
+except ImportError:
+    raise ImportError('dependency `aiida-tcod` not installed; run `pip install aiida-tcod` to do so.')
+
 
 class CpTcodtranslator(BaseTcodtranslator):
-    """
-    Quantum ESPRESSO's CP-specific input and output parameter translator
-    to TCOD CIF dictionary tags.
-    """
+    """TCOD export plugin for `CpCalculations`."""
+
+    # pylint: disable=abstract-method
+
     _plugin_type_string = 'quantumespresso.cp.CpCalculation'
 
     @classmethod
-    def get_software_package(cls,calc,**kwargs):
+    def get_software_package(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns the package or program name that was used to produce
         the structure. Only package or program name should be used,
@@ -20,7 +25,7 @@ class CpTcodtranslator(BaseTcodtranslator):
         return 'Quantum ESPRESSO'
 
     @classmethod
-    def get_number_of_electrons(cls,calc,**kwargs):
+    def get_number_of_electrons(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns the number of electrons.
         """
@@ -30,7 +35,7 @@ class CpTcodtranslator(BaseTcodtranslator):
         return parameters.get_attr('number_of_electrons')
 
     @classmethod
-    def get_computation_wallclock_time(cls,calc,**kwargs):
+    def get_computation_wallclock_time(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns the computation wallclock time in seconds.
         """

--- a/aiida_quantumespresso/tools/dbexporters/tcod_plugins/pw.py
+++ b/aiida_quantumespresso/tools/dbexporters/tcod_plugins/pw.py
@@ -1,15 +1,22 @@
 # -*- coding: utf-8 -*-
+"""TCOD export plugin for `PwCalculations`."""
 from __future__ import absolute_import
+
 import re
 
 from aiida.orm.nodes.data.upf import UpfData
-from aiida.tools.dbexporters.tcod_plugins import BaseTcodtranslator
+
+try:
+    from aiida_tcod.tools.dbexporters.tcod import BaseTcodtranslator  # pylint: disable=import-error
+except ImportError:
+    raise ImportError('dependency `aiida-tcod` not installed; run `pip install aiida-tcod` to do so.')
+
 
 class PwTcodtranslator(BaseTcodtranslator):
-    """
-    Quantum ESPRESSO's PW-specific input and output parameter translator
-    to TCOD CIF dictionary tags.
-    """
+    """TCOD export plugin for `CpCalculations`."""
+
+    # pylint: disable=too-many-public-methods,abstract-method
+
     _plugin_type_string = 'quantumespresso.pw.PwCalculation'
 
     _smearing_aliases = {
@@ -27,16 +34,17 @@ class PwTcodtranslator(BaseTcodtranslator):
         'fd': 'Marzari-Vanderbilt',
     }
 
-    _pseudopotential_types = [ 'NCPP', 'USPP', 'PAW' ]
+    _pseudopotential_types = ['NCPP', 'USPP', 'PAW']
 
     _upf_type_v2_regexp = re.compile(
         r"""
         \s*
         Pseudopotential type:\s*(?P<upf_type>.*)
-        """, re.VERBOSE)
+        """, re.VERBOSE
+    )
 
     @classmethod
-    def get_software_package(cls,calc,**kwargs):
+    def get_software_package(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns the package or program name that was used to produce
         the structure. Only package or program name should be used,
@@ -45,7 +53,7 @@ class PwTcodtranslator(BaseTcodtranslator):
         return 'Quantum ESPRESSO'
 
     @classmethod
-    def _get_pw_energy_value(cls,calc,energy_type,**kwargs):
+    def _get_pw_energy_value(cls, calc, energy_type, **kwargs):  # pylint: disable=unused-argument
         """
         Returns the energy of defined type in eV.
         """
@@ -53,18 +61,17 @@ class PwTcodtranslator(BaseTcodtranslator):
         if energy_type not in parameters.attrs():
             return None
         if energy_type + '_units' not in parameters.attrs():
-            raise ValueError('energy units for {} are '
-                             'unknown'.format(energy_type))
+            raise ValueError('energy units for {} are unknown'.format(energy_type))
         if parameters.get_attr(energy_type + '_units') != 'eV':
-            raise ValueError('energy units for {} are {} '
-                             'instead of eV -- unit '
-                             'conversion is not possible '
-                             'yet'.format(energy_type,
-                                          parameters.get_attr(energy_type + '_units')))
+            raise ValueError(
+                'energy units for {} are {} instead of eV -- unit conversion is not possible yet'.format(
+                    energy_type, parameters.get_attr(energy_type + '_units')
+                )
+            )
         return parameters.get_attr(energy_type)
 
     @classmethod
-    def _get_atom_site_residual_force_Cartesian(cls,calc,index,**kwargs):
+    def _get_atom_site_residual_force_Cartesian(cls, calc, index, **kwargs):  # pylint: disable=unused-argument,invalid-name
         """
         Returns an array with residual force components along the Cartesian
         axes.
@@ -76,13 +83,13 @@ class PwTcodtranslator(BaseTcodtranslator):
             return None
 
     @classmethod
-    def _get_BZ_integration_grid(cls,calc,**kwargs):
+    def _get_BZ_integration_grid(cls, calc, **kwargs):  # pylint: disable=unused-argument,invalid-name
         """
         Returns an array with Brillouin zone point counts along each
         vector of reciprocal lattice.
         """
         try:
-            array,_ = calc.inputs.kpoints.get_kpoints_mesh()
+            array, _ = calc.inputs.kpoints.get_kpoints_mesh()
             return array
         except AttributeError:
             return None
@@ -90,13 +97,13 @@ class PwTcodtranslator(BaseTcodtranslator):
             return None
 
     @classmethod
-    def _get_BZ_integration_grid_shift(cls,calc,**kwargs):
+    def _get_BZ_integration_grid_shift(cls, calc, **kwargs):  # pylint: disable=unused-argument,invalid-name
         """
         Returns an array with Brillouin zone point shifts along each
         vector of reciprocal lattice.
         """
         try:
-            _,array = calc.inputs.kpoints.get_kpoints_mesh()
+            _, array = calc.inputs.kpoints.get_kpoints_mesh()
             return array
         except AttributeError:
             return None
@@ -104,7 +111,7 @@ class PwTcodtranslator(BaseTcodtranslator):
             return None
 
     @classmethod
-    def _get_raw_integration_smearing_method(cls,calc,**kwargs):
+    def _get_raw_integration_smearing_method(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns the smearing method name as string, as specified in the
         input parameters (if specified). If not 'smearing' is not
@@ -122,54 +129,54 @@ class PwTcodtranslator(BaseTcodtranslator):
             try:
                 if parameters.get_dict()['SYSTEM']['occupations'] == 'smearing':
                     smearing = 'gaussian'
-            except KeyError as e:
+            except KeyError:
                 pass
         return smearing
 
     @classmethod
-    def get_total_energy(cls,calc,**kwargs):
+    def get_total_energy(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns the total energy in eV.
         """
-        return cls._get_pw_energy_value(calc,'energy')
+        return cls._get_pw_energy_value(calc, 'energy')
 
     @classmethod
-    def get_one_electron_energy(cls,calc,**kwargs):
+    def get_one_electron_energy(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns one electron energy in eV.
         """
-        return cls._get_pw_energy_value(calc,'energy_one_electron')
+        return cls._get_pw_energy_value(calc, 'energy_one_electron')
 
     @classmethod
-    def get_exchange_correlation_energy(cls,calc,**kwargs):
+    def get_exchange_correlation_energy(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns exchange correlation (XC) energy in eV.
         """
-        return cls._get_pw_energy_value(calc,'energy_xc')
+        return cls._get_pw_energy_value(calc, 'energy_xc')
 
     @classmethod
-    def get_ewald_energy(cls,calc,**kwargs):
+    def get_ewald_energy(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns Ewald energy in eV.
         """
-        return cls._get_pw_energy_value(calc,'energy_ewald')
+        return cls._get_pw_energy_value(calc, 'energy_ewald')
 
     @classmethod
-    def get_hartree_energy(cls,calc,**kwargs):
+    def get_hartree_energy(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns Hartree energy in eV.
         """
-        return cls._get_pw_energy_value(calc,'energy_hartree')
+        return cls._get_pw_energy_value(calc, 'energy_hartree')
 
     @classmethod
-    def get_fermi_energy(cls,calc,**kwargs):
+    def get_fermi_energy(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns Fermi energy in eV.
         """
-        return cls._get_pw_energy_value(calc,'fermi_energy')
+        return cls._get_pw_energy_value(calc, 'fermi_energy')
 
     @classmethod
-    def get_number_of_electrons(cls,calc,**kwargs):
+    def get_number_of_electrons(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns the number of electrons.
         """
@@ -179,7 +186,7 @@ class PwTcodtranslator(BaseTcodtranslator):
         return parameters.get_attr('number_of_electrons')
 
     @classmethod
-    def get_computation_wallclock_time(cls,calc,**kwargs):
+    def get_computation_wallclock_time(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         Returns the computation wallclock time in seconds.
         """
@@ -189,142 +196,127 @@ class PwTcodtranslator(BaseTcodtranslator):
         return parameters.get_attr('wall_time_seconds')
 
     @classmethod
-    def get_atom_site_residual_force_Cartesian_x(cls,calc,**kwargs):
+    def get_atom_site_residual_force_Cartesian_x(cls, calc, **kwargs):  # pylint: disable=unused-argument,invalid-name
         """
         Returns a list of x components for Cartesian coordinates of
         residual force for atom. The list order MUST be the same as in
         the resulting structure.
         """
-        return cls._get_atom_site_residual_force_Cartesian(calc,0)
+        return cls._get_atom_site_residual_force_Cartesian(calc, 0)
 
     @classmethod
-    def get_atom_site_residual_force_Cartesian_y(cls,calc,**kwargs):
+    def get_atom_site_residual_force_Cartesian_y(cls, calc, **kwargs):  # pylint: disable=unused-argument,invalid-name
         """
         Returns a list of y components for Cartesian coordinates of
         residual force for atom. The list order MUST be the same as in
         the resulting structure.
         """
-        return cls._get_atom_site_residual_force_Cartesian(calc,1)
+        return cls._get_atom_site_residual_force_Cartesian(calc, 1)
 
     @classmethod
-    def get_atom_site_residual_force_Cartesian_z(cls,calc,**kwargs):
+    def get_atom_site_residual_force_Cartesian_z(cls, calc, **kwargs):  # pylint: disable=unused-argument,invalid-name
         """
         Returns a list of z components for Cartesian coordinates of
         residual force for atom. The list order MUST be the same as in
         the resulting structure.
         """
-        return cls._get_atom_site_residual_force_Cartesian(calc,2)
+        return cls._get_atom_site_residual_force_Cartesian(calc, 2)
 
     @classmethod
-    def get_BZ_integration_grid_X(cls,calc,**kwargs):
+    def get_BZ_integration_grid_X(cls, calc, **kwargs):  # pylint: disable=invalid-name
         """
         Returns a number of points in the Brillouin zone along reciprocal
         lattice vector X.
         """
-        array = cls._get_BZ_integration_grid(calc,**kwargs)
+        array = cls._get_BZ_integration_grid(calc, **kwargs)
         if array is not None:
             return array[0]
-        else:
-            return None
+        return None
 
     @classmethod
-    def get_BZ_integration_grid_Y(cls,calc,**kwargs):
+    def get_BZ_integration_grid_Y(cls, calc, **kwargs):  # pylint: disable=invalid-name
         """
         Returns a number of points in the Brillouin zone along reciprocal
         lattice vector Y.
         """
-        array = cls._get_BZ_integration_grid(calc,**kwargs)
+        array = cls._get_BZ_integration_grid(calc, **kwargs)
         if array is not None:
             return array[1]
-        else:
-            return None
 
     @classmethod
-    def get_BZ_integration_grid_Z(cls,calc,**kwargs):
+    def get_BZ_integration_grid_Z(cls, calc, **kwargs):  # pylint: disable=invalid-name
         """
         Returns a number of points in the Brillouin zone along reciprocal
         lattice vector Z.
         """
-        array = cls._get_BZ_integration_grid(calc,**kwargs)
+        array = cls._get_BZ_integration_grid(calc, **kwargs)
         if array is not None:
             return array[2]
-        else:
-            return None
+        return None
 
     @classmethod
-    def get_BZ_integration_grid_shift_X(cls,calc,**kwargs):
+    def get_BZ_integration_grid_shift_X(cls, calc, **kwargs):  # pylint: disable=invalid-name
         """
         Returns the shift of the Brillouin zone points along reciprocal
         lattice vector X.
         """
-        array = cls._get_BZ_integration_grid_shift(calc,**kwargs)
+        array = cls._get_BZ_integration_grid_shift(calc, **kwargs)
         if array is not None:
             return array[0]
-        else:
-            return None
 
     @classmethod
-    def get_BZ_integration_grid_shift_Y(cls,calc,**kwargs):
+    def get_BZ_integration_grid_shift_Y(cls, calc, **kwargs):  # pylint: disable=invalid-name
         """
         Returns the shift of the Brillouin zone points along reciprocal
         lattice vector Y.
         """
-        array = cls._get_BZ_integration_grid_shift(calc,**kwargs)
+        array = cls._get_BZ_integration_grid_shift(calc, **kwargs)
         if array is not None:
             return array[1]
-        else:
-            return None
 
     @classmethod
-    def get_BZ_integration_grid_shift_Z(cls,calc,**kwargs):
+    def get_BZ_integration_grid_shift_Z(cls, calc, **kwargs):  # pylint: disable=invalid-name
         """
         Returns the shift of the Brillouin zone points along reciprocal
         lattice vector Z.
         """
-        array = cls._get_BZ_integration_grid_shift(calc,**kwargs)
+        array = cls._get_BZ_integration_grid_shift(calc, **kwargs)
         if array is not None:
             return array[2]
-        else:
-            return None
 
     @classmethod
-    def get_integration_smearing_method(cls,calc,**kwargs):
+    def get_integration_smearing_method(cls, calc, **kwargs):
         """
         Returns the smearing method name as string.
         """
-        smearing = cls._get_raw_integration_smearing_method(calc,**kwargs)
+        smearing = cls._get_raw_integration_smearing_method(calc, **kwargs)
         if smearing is None:
             return None
-        elif smearing in cls._smearing_aliases:
+        if smearing in cls._smearing_aliases:
             return cls._smearing_aliases[smearing]
-        else:
-            return 'other'
+        return 'other'
 
     @classmethod
-    def get_integration_smearing_method_other(cls,calc,**kwargs):
+    def get_integration_smearing_method_other(cls, calc, **kwargs):  # pylint: disable=invalid-name
         """
         Returns the smearing method name as string if the name is different
         from specified in cif_dft.dic.
         """
-        smearing = cls._get_raw_integration_smearing_method(calc,**kwargs)
+        smearing = cls._get_raw_integration_smearing_method(calc, **kwargs)
         if smearing is None or smearing in cls._smearing_aliases:
             return None
-        else:
-            return smearing
+        return smearing
 
     @classmethod
-    def get_integration_Methfessel_Paxton_order(cls,calc,**kwargs):
+    def get_integration_Methfessel_Paxton_order(cls, calc, **kwargs):  # pylint: disable=invalid-name
         """
         Returns the order of Methfessel-Paxton approximation if used.
         """
-        if cls.get_integration_smearing_method(calc,**kwargs) == \
-           'Methfessel-Paxton':
+        if cls.get_integration_smearing_method(calc, **kwargs) == 'Methfessel-Paxton':
             return 1
-        else:
-            return None
 
     @classmethod
-    def get_kinetic_energy_cutoff_wavefunctions(cls,calc,**kwargs):
+    def get_kinetic_energy_cutoff_wavefunctions(cls, calc, **kwargs):  # pylint: disable=invalid-name,unused-argument
         """
         Returns kinetic energy cutoff for wavefunctions in eV.
         """
@@ -337,11 +329,10 @@ class PwTcodtranslator(BaseTcodtranslator):
             pass
         if ecutwfc is None:
             return None
-        else:
-            return ecutwfc * ry_to_ev
+        return ecutwfc * ry_to_ev
 
     @classmethod
-    def get_kinetic_energy_cutoff_charge_density(cls,calc,**kwargs):
+    def get_kinetic_energy_cutoff_charge_density(cls, calc, **kwargs):  # pylint: disable=invalid-name,unused-argument
         """
         Returns kinetic energy cutoff for charge density in eV.
 
@@ -357,11 +348,10 @@ class PwTcodtranslator(BaseTcodtranslator):
         ecutwfc = cls.get_kinetic_energy_cutoff_wavefunctions(calc)
         if ecutwfc is None:
             return None
-        else:
-            return 4 * ecutwfc
+        return 4 * ecutwfc
 
     @classmethod
-    def get_kinetic_energy_cutoff_EEX(cls,calc,**kwargs):
+    def get_kinetic_energy_cutoff_EEX(cls, calc, **kwargs):  # pylint: disable=invalid-name,unused-argument
         """
         Returns kinetic energy cutoff for exact exchange (EEX)
         operator in eV.
@@ -378,7 +368,7 @@ class PwTcodtranslator(BaseTcodtranslator):
         return cls.get_kinetic_energy_cutoff_charge_density(calc)
 
     @classmethod
-    def _get_raw_pseudopotential_type(cls,calc,**kwargs):
+    def _get_raw_pseudopotential_type(cls, calc, **kwargs):  # pylint: disable=unused-argument
         """
         """
         from aiida.orm.nodes.data.upf import parse_upf
@@ -390,9 +380,9 @@ class PwTcodtranslator(BaseTcodtranslator):
                 types[element] = None
                 continue
             upf_type = None
-            with open(fname) as f:
-                for line in f:
-                    match = _upf_type_v2_regexp.match(line.strip())
+            with open(node.filename) as handle:
+                for line in handle:
+                    match = cls._upf_type_v2_regexp.match(line.strip())
                     if match:
                         upf_type = match.group('upf_type')
                         break
@@ -400,41 +390,39 @@ class PwTcodtranslator(BaseTcodtranslator):
         return types
 
     @classmethod
-    def get_pseudopotential_atom_type(cls,calc,**kwargs):
+    def get_pseudopotential_atom_type(cls, calc, **kwargs):
         """
         Returns a list of atom types. Each atom type MUST occur only
         once in this list. List MUST be sorted.
         """
-        raw_types = cls._get_raw_pseudopotential_type(calc,**kwargs)
+        raw_types = cls._get_raw_pseudopotential_type(calc, **kwargs)
         return sorted(raw_types)
 
     @classmethod
-    def get_pseudopotential_type(cls,calc,**kwargs):
+    def get_pseudopotential_type(cls, calc, **kwargs):
         """
         Returns a list of pseudopotential types. List MUST be sorted
         by atom types.
         """
         types = []
-        raw_types = cls._get_raw_pseudopotential_type(calc,**kwargs)
+        raw_types = cls._get_raw_pseudopotential_type(calc, **kwargs)
         for element in sorted(raw_types):
-            if raw_types[element] is None or \
-               raw_types[element] in _pseudopotential_types:
+            if raw_types[element] is None or raw_types[element] in cls._pseudopotential_types:
                 types.append(raw_types[element])
             else:
                 types.append('other')
         return types
 
     @classmethod
-    def get_pseudopotential_type_other_name(cls,calc,**kwargs):
+    def get_pseudopotential_type_other_name(cls, calc, **kwargs):  # pylint: disable=invalid-name
         """
         Returns a list of other pseudopotential type names. List MUST be
         sorted by atom types.
         """
         types = []
-        raw_types = cls._get_raw_pseudopotential_type(calc,**kwargs)
+        raw_types = cls._get_raw_pseudopotential_type(calc, **kwargs)
         for element in sorted(raw_types):
-            if raw_types[element] is None or \
-               raw_types[element] in _pseudopotential_types:
+            if raw_types[element] is None or raw_types[element] in cls._pseudopotential_types:
                 types.append(None)
             else:
                 types.append(raw_types[element])

--- a/setup.json
+++ b/setup.json
@@ -65,6 +65,9 @@
             "pytest-regressions==1.0.5",
             "yapf==0.28.0"
         ],
+        "tcod": [
+            "aiida-tcod"
+        ],
         "docs": [
             "Sphinx",
             "docutils",


### PR DESCRIPTION
Fixes #365 

The base translator class was moved from `aiida-core` to `aiida-tcod`.
Add the latter as dependency, fix the imports and drop the directory
from the pre-commit exclude list.