### PR TITLE
Add default for structure option in certain CLI launchers

### DIFF
--- a/aiida_quantumespresso/cli/calculations/cp.py
+++ b/aiida_quantumespresso/cli/calculations/cp.py
@@ -5,46 +5,15 @@ from __future__ import absolute_import
 from aiida.cmdline.params import options, types
 from aiida.cmdline.utils import decorators
 
+from ..utils import defaults
 from ..utils import launch
 from ..utils import options as options_qe
 from . import cmd_launch
 
 
-def silicon_structure():
-    """Return a `StructureData` representing bulk silicon.
-
-    The database will first be queried for the existence of the structure in case it might have already been created
-    before. If nothing is found, a new structure will be created
-
-    :return: a `StructureData` representing bulk silicon
-    """
-    from ase.spacegroup import crystal
-    from aiida.orm import QueryBuilder, StructureData
-
-    label = '__example__{name}'.format(name=__name__)
-    structure = QueryBuilder().append(StructureData, filters={'label': label}).first()
-    if not structure:
-        alat = 5.4
-        ase_structure = crystal(
-            'Si',
-            [(0, 0, 0)],
-            spacegroup=227,
-            cellpar=[alat, alat, alat, 90, 90, 90],
-            primitive_cell=True,
-        )
-        structure = StructureData(ase=ase_structure)
-        structure.label = label
-        structure.store()
-    else:
-        # .first() returns none if it doesn't exist or a list of one item if objects exist
-        structure = structure[0]
-
-    return structure.uuid
-
-
 @cmd_launch.command('cp')
 @options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.cp'))
-@options_qe.STRUCTURE(default=silicon_structure)
+@options_qe.STRUCTURE(default=defaults.get_structure)
 @options_qe.PSEUDO_FAMILY(required=True)
 @options_qe.MAX_NUM_MACHINES()
 @options_qe.MAX_WALLCLOCK_SECONDS()

--- a/aiida_quantumespresso/cli/utils/defaults.py
+++ b/aiida_quantumespresso/cli/utils/defaults.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Module with utitlies for the CLI to generate default values."""
+from __future__ import absolute_import
+
+
+def get_structure():
+    """Return a `StructureData` representing bulk silicon.
+
+    The database will first be queried for the existence of a bulk silicon crystal. If this is not the case, one is
+    created and stored. This function should be used as a default for CLI options that require a `StructureData` node.
+    This way new users can launch the command without having to construct or import a structure first. This is the
+    reason that we hardcode a bulk silicon crystal to be returned. More flexibility is not required for this purpose.
+
+    :return: a `StructureData` representing bulk silicon
+    """
+    from ase.spacegroup import crystal
+    from aiida.orm import QueryBuilder, StructureData
+
+    # Filters that will match any elemental Silicon structure with 2 or less sites in total
+    filters = {
+        'attributes.sites': {
+            'of_length': 2
+        },
+        'attributes.kinds': {
+            'of_length': 1
+        },
+        'attributes.kinds.0.symbols.0': 'Si'
+    }
+
+    builder = QueryBuilder().append(StructureData, filters=filters)
+    results = builder.first()
+
+    if not results:
+        alat = 5.43
+        ase_structure = crystal(
+            'Si',
+            [(0, 0, 0)],
+            spacegroup=227,
+            cellpar=[alat, alat, alat, 90, 90, 90],
+            primitive_cell=True,
+        )
+        structure = StructureData(ase=ase_structure)
+        structure.store()
+    else:
+        structure = results[0]
+
+    return structure.uuid

--- a/aiida_quantumespresso/cli/workflows/pw/base.py
+++ b/aiida_quantumespresso/cli/workflows/pw/base.py
@@ -6,6 +6,7 @@ import click
 from aiida.cmdline.params import options, types
 from aiida.cmdline.utils import decorators
 
+from ...utils import defaults
 from ...utils import launch
 from ...utils import options as options_qe
 from ...utils import validate
@@ -14,7 +15,7 @@ from .. import cmd_launch
 
 @cmd_launch.command('pw-base')
 @options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pw'))
-@options_qe.STRUCTURE(required=True)
+@options_qe.STRUCTURE(default=defaults.get_structure)
 @options_qe.PSEUDO_FAMILY(required=True)
 @options_qe.KPOINTS_DISTANCE()
 @options_qe.ECUTWFC()


### PR DESCRIPTION
Fixes #375 

The default is added for the launchers of:

 * `PhCalculation`
 * `PwCalculation`
 * `PwBaseWorkChain`

Since having a default structure automatically created is mostly useful
for demonstration purposes on clean databases, we only add them to the
most basic launchers.