### PR TITLE
Update the `Q2rWorkChain` and `MatdynWorkChain`

### DIFF
--- a/aiida_quantumespresso/calculations/q2r.py
+++ b/aiida_quantumespresso/calculations/q2r.py
@@ -27,14 +27,15 @@ class Q2rCalculation(NamelistsCalculation):
 
     @classmethod
     def define(cls, spec):
+        # yapf: disable
         super(Q2rCalculation, cls).define(spec)
         spec.input('parent_folder', valid_type=(orm.RemoteData, orm.FolderData), required=True)
-        spec.output('output_parameters', valid_type=orm.Dict)
         spec.output('forceconstants', valid_type=ForceconstantsData)
-        spec.default_output_node = 'output_parameters'
-        spec.exit_code(
-            100, 'ERROR_NO_RETRIEVED_FOLDER', message='The retrieved folder data node could not be accessed.')
-        spec.exit_code(
-            110, 'ERROR_READING_OUTPUT_FILE', message='The output file could not be read from the retrieved folder.')
-        spec.exit_code(
-            130, 'ERROR_JOB_NOT_DONE', message='The computation did not finish properly ("JOB DONE" not found).')
+        spec.exit_code(100, 'ERROR_NO_RETRIEVED_FOLDER',
+            message='The retrieved folder data node could not be accessed.')
+        spec.exit_code(110, 'ERROR_READING_OUTPUT_FILE',
+            message='The output file could not be read from the retrieved folder.')
+        spec.exit_code(120, 'ERROR_READING_FORCE_CONSTANTS_FILE',
+            message='The force constants file could not be read.')
+        spec.exit_code(130, 'ERROR_JOB_NOT_DONE',
+            message='The computation did not finish properly ("JOB DONE" not found).')

--- a/aiida_quantumespresso/cli/calculations/q2r.py
+++ b/aiida_quantumespresso/cli/calculations/q2r.py
@@ -22,7 +22,6 @@ from . import cmd_launch
 @decorators.with_dbenv()
 def launch_calculation(code, calculation, max_num_machines, max_wallclock_seconds, with_mpi, daemon):
     """Run a Q2rCalculation."""
-    from aiida import orm
     from aiida.plugins import CalculationFactory
     from aiida_quantumespresso.utils.resources import get_default_options
 
@@ -37,11 +36,9 @@ def launch_calculation(code, calculation, max_num_machines, max_wallclock_second
             )
         )
 
-    parent_folder = calculation.get_outgoing(node_class=orm.RemoteData, link_label_filter='remote_folder').one().node
-
     inputs = {
         'code': code,
-        'parent_folder': parent_folder,
+        'parent_folder': calculation.outputs.remote_folder,
         'metadata': {
             'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi),
         }

--- a/aiida_quantumespresso/cli/workflows/matdyn/base.py
+++ b/aiida_quantumespresso/cli/workflows/matdyn/base.py
@@ -12,7 +12,7 @@ from .. import cmd_launch
 
 @cmd_launch.command('matdyn-base')
 @options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.matdyn'))
-@options.CALCULATION(type=types.CalculationParamType(sub_classes=('aiida.calculations:quantumespresso.q2r',)))
+@options.CALCULATION()
 @options_qe.KPOINTS_MESH(default=[2, 2, 2])
 @options_qe.CLEAN_WORKDIR()
 @options_qe.MAX_NUM_MACHINES()
@@ -24,15 +24,19 @@ def launch_workflow(
     code, calculation, kpoints_mesh, clean_workdir, max_num_machines, max_wallclock_seconds, with_mpi, daemon
 ):
     """Run the `MatdynBaseWorkChain` for a previously completed `Q2rCalculation`."""
-    from aiida.orm import Bool, Dict
+    from aiida.orm import Bool
     from aiida.plugins import WorkflowFactory
     from aiida_quantumespresso.utils.resources import get_default_options
 
     inputs = {
-        'code': code,
-        'kpoints': kpoints_mesh,
-        'parent_folder': calculation.outputs.force_constants,
-        'options': Dict(dict=get_default_options(max_num_machines, max_wallclock_seconds, with_mpi)),
+        'matdyn': {
+            'code': code,
+            'kpoints': kpoints_mesh,
+            'parent_folder': calculation.outputs.forceconstants,
+            'metadata': {
+                'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi),
+            }
+        }
     }
 
     if clean_workdir:

--- a/aiida_quantumespresso/cli/workflows/matdyn/base.py
+++ b/aiida_quantumespresso/cli/workflows/matdyn/base.py
@@ -2,6 +2,8 @@
 """Command line scripts to launch a `MatdynBaseWorkChain` for testing and demonstration purposes."""
 from __future__ import absolute_import
 
+import click
+
 from aiida.cmdline.params import options, types
 from aiida.cmdline.utils import decorators
 
@@ -12,7 +14,7 @@ from .. import cmd_launch
 
 @cmd_launch.command('matdyn-base')
 @options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.matdyn'))
-@options.CALCULATION()
+@options.CALCULATION(required=True)
 @options_qe.KPOINTS_MESH(default=[2, 2, 2])
 @options_qe.CLEAN_WORKDIR()
 @options_qe.MAX_NUM_MACHINES()
@@ -27,6 +29,14 @@ def launch_workflow(
     from aiida.orm import Bool
     from aiida.plugins import WorkflowFactory
     from aiida_quantumespresso.utils.resources import get_default_options
+
+    expected_process_type = 'aiida.calculations:quantumespresso.q2r'
+    if calculation.process_type != expected_process_type:
+        raise click.BadParameter(
+            'The input calculation node has a process_type: {}; should be {}'.format(
+                calculation.process_type, expected_process_type
+            )
+        )
 
     inputs = {
         'matdyn': {

--- a/aiida_quantumespresso/cli/workflows/q2r/base.py
+++ b/aiida_quantumespresso/cli/workflows/q2r/base.py
@@ -12,7 +12,7 @@ from .. import cmd_launch
 
 @cmd_launch.command('q2r-base')
 @options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.q2r'))
-@options.CALCULATION(type=types.CalculationParamType(sub_classes=('aiida.calculations:quantumespresso.ph',)))
+@options.CALCULATION()
 @options_qe.CLEAN_WORKDIR()
 @options_qe.MAX_NUM_MACHINES()
 @options_qe.MAX_WALLCLOCK_SECONDS()
@@ -21,14 +21,18 @@ from .. import cmd_launch
 @decorators.with_dbenv()
 def launch_workflow(code, calculation, clean_workdir, max_num_machines, max_wallclock_seconds, with_mpi, daemon):
     """Run the `Q2rBaseWorkChain` for a previously completed `PhCalculation`."""
-    from aiida.orm import Bool, Dict
+    from aiida.orm import Bool
     from aiida.plugins import WorkflowFactory
     from aiida_quantumespresso.utils.resources import get_default_options
 
     inputs = {
-        'code': code,
-        'parent_folder': calculation.outputs.retrieved,
-        'options': Dict(dict=get_default_options(max_num_machines, max_wallclock_seconds, with_mpi)),
+        'q2r': {
+            'code': code,
+            'parent_folder': calculation.outputs.remote_folder,
+            'metadata': {
+                'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi),
+            }
+        }
     }
 
     if clean_workdir:

--- a/aiida_quantumespresso/cli/workflows/q2r/base.py
+++ b/aiida_quantumespresso/cli/workflows/q2r/base.py
@@ -2,6 +2,8 @@
 """Command line scripts to launch a `Q2rBaseWorkChain` for testing and demonstration purposes."""
 from __future__ import absolute_import
 
+import click
+
 from aiida.cmdline.params import options, types
 from aiida.cmdline.utils import decorators
 
@@ -12,7 +14,7 @@ from .. import cmd_launch
 
 @cmd_launch.command('q2r-base')
 @options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.q2r'))
-@options.CALCULATION()
+@options.CALCULATION(required=True)
 @options_qe.CLEAN_WORKDIR()
 @options_qe.MAX_NUM_MACHINES()
 @options_qe.MAX_WALLCLOCK_SECONDS()
@@ -24,6 +26,14 @@ def launch_workflow(code, calculation, clean_workdir, max_num_machines, max_wall
     from aiida.orm import Bool
     from aiida.plugins import WorkflowFactory
     from aiida_quantumespresso.utils.resources import get_default_options
+
+    expected_process_type = 'aiida.calculations:quantumespresso.ph'
+    if calculation.process_type != expected_process_type:
+        raise click.BadParameter(
+            'The input calculation node has a process_type: {}; should be {}'.format(
+                calculation.process_type, expected_process_type
+            )
+        )
 
     inputs = {
         'q2r': {

--- a/aiida_quantumespresso/workflows/matdyn/base.py
+++ b/aiida_quantumespresso/workflows/matdyn/base.py
@@ -2,14 +2,12 @@
 """Workchain to run a Quantum ESPRESSO matdyn.x calculation with automated error handling and restarts."""
 from __future__ import absolute_import
 
-from aiida import orm
 from aiida.common import AttributeDict
 from aiida.engine import while_
 from aiida.plugins import CalculationFactory
 
 from aiida_quantumespresso.common.workchain.base.restart import BaseRestartWorkChain
-from aiida_quantumespresso.data.forceconstants import ForceconstantsData
-from aiida_quantumespresso.utils.resources import get_default_options
+from aiida_quantumespresso.common.workchain.utils import register_error_handler, ErrorHandlerReport
 
 MatdynCalculation = CalculationFactory('quantumespresso.matdyn')
 
@@ -21,48 +19,46 @@ class MatdynBaseWorkChain(BaseRestartWorkChain):
 
     @classmethod
     def define(cls, spec):
+        # yapf: disable
         super(MatdynBaseWorkChain, cls).define(spec)
-        spec.input('code', valid_type=orm.Code)
-        spec.input('kpoints', valid_type=orm.KpointsData)
-        spec.input('parent_folder', valid_type=ForceconstantsData)
-        spec.input('parameters', valid_type=orm.Dict, required=False)
-        spec.input('settings', valid_type=orm.Dict, required=False)
-        spec.input('options', valid_type=orm.Dict, required=False)
+        spec.expose_inputs(MatdynCalculation, namespace='matdyn')
+        spec.expose_outputs(MatdynCalculation, exclude=('remote_folder',))
         spec.outline(
             cls.setup,
-            cls.validate_inputs,
             while_(cls.should_run_calculation)(
                 cls.run_calculation,
                 cls.inspect_calculation,
             ),
             cls.results,
         )
-        spec.output('output_parameters', valid_type=orm.Dict)
-        spec.output('output_phonon_bands', valid_type=orm.BandsData)
+        spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
+            message='The calculation failed with an unrecoverable error.')
 
-    def validate_inputs(self):
+    def setup(self):
+        """Call the `setup` of the `BaseRestartWorkChain` and then create the inputs dictionary in `self.ctx.inputs`.
+
+        This `self.ctx.inputs` dictionary will be used by the `BaseRestartWorkChain` to submit the calculations in the
+        internal loop.
         """
-        Validate inputs that depend might depend on each other and cannot be validated by the spec. Also define
-        dictionary `inputs` in the context, that will contain the inputs for the calculation that will be launched
-        in the `run_calculation` step.
+        super(MatdynBaseWorkChain, self).setup()
+        self.ctx.inputs = AttributeDict(self.exposed_inputs(MatdynCalculation, 'matdyn'))
+
+    def report_error_handled(self, calculation, action):
+        """Report an action taken for a calculation that has failed.
+
+        This should be called in a registered error handler if its condition is met and an action was taken.
+
+        :param calculation: the failed calculation node
+        :param action: a string message with the action taken
         """
-        self.ctx.inputs = AttributeDict({
-            'code': self.inputs.code,
-            'kpoints': self.inputs.kpoints,
-            'parent_folder': self.inputs.parent_folder,
-        })
+        arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
+        self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
+        self.report('Action taken: {}'.format(action))
 
-        if 'parameters' in self.inputs:
-            self.ctx.inputs.parameters = self.inputs.parameters.get_dict()
-        else:
-            self.ctx.inputs.parameters = {'INPUT': {}}
 
-        if 'settings' in self.inputs:
-            self.ctx.inputs.settings = self.inputs.settings.get_dict()
-        else:
-            self.ctx.inputs.settings = {}
-
-        if 'options' in self.inputs:
-            self.ctx.inputs.options = self.inputs.options.get_dict()
-        else:
-            self.ctx.inputs.options = get_default_options()
+@register_error_handler(MatdynBaseWorkChain, 600)
+def _handle_unrecoverable_failure(self, calculation):
+    """Calculations with an exit status below 400 are unrecoverable, so abort the work chain."""
+    if calculation.exit_status < 400:
+        self.report_error_handled(calculation, 'unrecoverable error, aborting...')
+        return ErrorHandlerReport(True, True, self.exit_codes.ERROR_UNRECOVERABLE_FAILURE)

--- a/aiida_quantumespresso/workflows/matdyn/base.py
+++ b/aiida_quantumespresso/workflows/matdyn/base.py
@@ -22,7 +22,7 @@ class MatdynBaseWorkChain(BaseRestartWorkChain):
         # yapf: disable
         super(MatdynBaseWorkChain, cls).define(spec)
         spec.expose_inputs(MatdynCalculation, namespace='matdyn')
-        spec.expose_outputs(MatdynCalculation, exclude=('remote_folder',))
+        spec.expose_outputs(MatdynCalculation)
         spec.outline(
             cls.setup,
             while_(cls.should_run_calculation)(

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -77,7 +77,7 @@ class PwBaseWorkChain(BaseRestartWorkChain):
             cls.results,
         )
 
-        spec.expose_outputs(PwCalculation, exclude=('retrieved_folder',))
+        spec.expose_outputs(PwCalculation)
         spec.output('automatic_parallelization', valid_type=orm.Dict, required=False,
             help='The results of the automatic parallelization analysis if performed.')
 

--- a/aiida_quantumespresso/workflows/q2r/base.py
+++ b/aiida_quantumespresso/workflows/q2r/base.py
@@ -22,7 +22,7 @@ class Q2rBaseWorkChain(BaseRestartWorkChain):
         # yapf: disable
         super(Q2rBaseWorkChain, cls).define(spec)
         spec.expose_inputs(Q2rCalculation, namespace='q2r')
-        spec.expose_outputs(Q2rCalculation, exclude=('remote_folder',))
+        spec.expose_outputs(Q2rCalculation)
         spec.outline(
             cls.setup,
             while_(cls.should_run_calculation)(

--- a/aiida_quantumespresso/workflows/q2r/base.py
+++ b/aiida_quantumespresso/workflows/q2r/base.py
@@ -2,14 +2,12 @@
 """Workchain to run a Quantum ESPRESSO q2r.x calculation with automated error handling and restarts."""
 from __future__ import absolute_import
 
-from aiida import orm
 from aiida.common import AttributeDict
 from aiida.engine import while_
 from aiida.plugins import CalculationFactory
 
 from aiida_quantumespresso.common.workchain.base.restart import BaseRestartWorkChain
-from aiida_quantumespresso.data.forceconstants import ForceconstantsData
-from aiida_quantumespresso.utils.resources import get_default_options
+from aiida_quantumespresso.common.workchain.utils import register_error_handler, ErrorHandlerReport
 
 Q2rCalculation = CalculationFactory('quantumespresso.q2r')
 
@@ -21,46 +19,46 @@ class Q2rBaseWorkChain(BaseRestartWorkChain):
 
     @classmethod
     def define(cls, spec):
+        # yapf: disable
         super(Q2rBaseWorkChain, cls).define(spec)
-        spec.input('code', valid_type=orm.Code)
-        spec.input('parent_folder', valid_type=orm.FolderData)
-        spec.input('parameters', valid_type=orm.Dict, required=False)
-        spec.input('settings', valid_type=orm.Dict, required=False)
-        spec.input('options', valid_type=orm.Dict, required=False)
+        spec.expose_inputs(Q2rCalculation, namespace='q2r')
+        spec.expose_outputs(Q2rCalculation, exclude=('remote_folder',))
         spec.outline(
             cls.setup,
-            cls.validate_inputs,
             while_(cls.should_run_calculation)(
                 cls.run_calculation,
                 cls.inspect_calculation,
             ),
             cls.results,
         )
-        spec.output('force_constants', valid_type=ForceconstantsData)
-        spec.output('remote_folder', valid_type=orm.RemoteData)
+        spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
+            message='The calculation failed with an unrecoverable error.')
 
-    def validate_inputs(self):
+    def setup(self):
+        """Call the `setup` of the `BaseRestartWorkChain` and then create the inputs dictionary in `self.ctx.inputs`.
+
+        This `self.ctx.inputs` dictionary will be used by the `BaseRestartWorkChain` to submit the calculations in the
+        internal loop.
         """
-        Validate inputs that depend might depend on each other and cannot be validated by the spec. Also define
-        dictionary `inputs` in the context, that will contain the inputs for the calculation that will be launched
-        in the `run_calculation` step.
+        super(Q2rBaseWorkChain, self).setup()
+        self.ctx.inputs = AttributeDict(self.exposed_inputs(Q2rCalculation, 'q2r'))
+
+    def report_error_handled(self, calculation, action):
+        """Report an action taken for a calculation that has failed.
+
+        This should be called in a registered error handler if its condition is met and an action was taken.
+
+        :param calculation: the failed calculation node
+        :param action: a string message with the action taken
         """
-        self.ctx.inputs = AttributeDict({
-            'code': self.inputs.code,
-            'parent_folder': self.inputs.parent_folder,
-        })
+        arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
+        self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
+        self.report('Action taken: {}'.format(action))
 
-        if 'parameters' in self.inputs:
-            self.ctx.inputs.parameters = self.inputs.parameters.get_dict()
-        else:
-            self.ctx.inputs.parameters = {'INPUT': {}}
 
-        if 'settings' in self.inputs:
-            self.ctx.inputs.settings = self.inputs.settings.get_dict()
-        else:
-            self.ctx.inputs.settings = {}
-
-        if 'options' in self.inputs:
-            self.ctx.inputs.options = self.inputs.options.get_dict()
-        else:
-            self.ctx.inputs.options = get_default_options()
+@register_error_handler(Q2rBaseWorkChain, 600)
+def _handle_unrecoverable_failure(self, calculation):
+    """Calculations with an exit status below 400 are unrecoverable, so abort the work chain."""
+    if calculation.exit_status < 400:
+        self.report_error_handled(calculation, 'unrecoverable error, aborting...')
+        return ErrorHandlerReport(True, True, self.exit_codes.ERROR_UNRECOVERABLE_FAILURE)


### PR DESCRIPTION
Fixes #379 

Leverage the expose functionality to expose the inputs and outputs of
the calculation jobs they wrap. Update the CLI launchers to make sure
that they work.