### PR TITLE
Renaming of `ForceconstantsData` to `ForceConstantsData`

### DIFF
--- a/aiida_quantumespresso/calculations/matdyn.py
+++ b/aiida_quantumespresso/calculations/matdyn.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 from aiida import orm
 from aiida_quantumespresso.calculations.namelists import NamelistsCalculation
-from aiida_quantumespresso.data.forceconstants import ForceconstantsData
+from aiida_quantumespresso.data.force_constants import ForceConstantsData
 
 
 class MatdynCalculation(NamelistsCalculation):
@@ -30,7 +30,7 @@ class MatdynCalculation(NamelistsCalculation):
     @classmethod
     def define(cls, spec):
         super(MatdynCalculation, cls).define(spec)
-        spec.input('parent_folder', valid_type=ForceconstantsData, required=True)
+        spec.input('parent_folder', valid_type=ForceConstantsData, required=True)
         spec.input('kpoints', valid_type=orm.KpointsData, help='Kpoints on which to calculate the phonon frequencies.')
         spec.output('output_parameters', valid_type=orm.Dict)
         spec.output('output_phonon_bands', valid_type=orm.BandsData)

--- a/aiida_quantumespresso/calculations/q2r.py
+++ b/aiida_quantumespresso/calculations/q2r.py
@@ -6,7 +6,7 @@ import os
 from aiida import orm
 from aiida_quantumespresso.calculations.namelists import NamelistsCalculation
 from aiida_quantumespresso.calculations.ph import PhCalculation
-from aiida_quantumespresso.data.forceconstants import ForceconstantsData
+from aiida_quantumespresso.data.force_constants import ForceConstantsData
 
 
 class Q2rCalculation(NamelistsCalculation):
@@ -30,7 +30,7 @@ class Q2rCalculation(NamelistsCalculation):
         # yapf: disable
         super(Q2rCalculation, cls).define(spec)
         spec.input('parent_folder', valid_type=(orm.RemoteData, orm.FolderData), required=True)
-        spec.output('forceconstants', valid_type=ForceconstantsData)
+        spec.output('force_constants', valid_type=ForceConstantsData)
         spec.exit_code(100, 'ERROR_NO_RETRIEVED_FOLDER',
             message='The retrieved folder data node could not be accessed.')
         spec.exit_code(110, 'ERROR_READING_OUTPUT_FILE',

--- a/aiida_quantumespresso/cli/calculations/matdyn.py
+++ b/aiida_quantumespresso/cli/calculations/matdyn.py
@@ -14,8 +14,8 @@ from . import cmd_launch
 @options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.matdyn'))
 @options.DATUM(
     required=True,
-    type=types.DataParamType(sub_classes=('aiida.data:quantumespresso.forceconstants',)),
-    help='A ForceconstantsData node produced by a `Q2rCalculation`'
+    type=types.DataParamType(sub_classes=('aiida.data:quantumespresso.force_constants',)),
+    help='A ForceConstantsData node produced by a `Q2rCalculation`'
 )
 @options_qe.KPOINTS_MESH(default=[1, 1, 1])
 @options_qe.MAX_NUM_MACHINES()

--- a/aiida_quantumespresso/cli/workflows/matdyn/base.py
+++ b/aiida_quantumespresso/cli/workflows/matdyn/base.py
@@ -42,7 +42,7 @@ def launch_workflow(
         'matdyn': {
             'code': code,
             'kpoints': kpoints_mesh,
-            'parent_folder': calculation.outputs.forceconstants,
+            'parent_folder': calculation.outputs.force_constants,
             'metadata': {
                 'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi),
             }

--- a/aiida_quantumespresso/data/force_constants.py
+++ b/aiida_quantumespresso/data/force_constants.py
@@ -9,7 +9,7 @@ from aiida.orm import SinglefileData
 from aiida_quantumespresso.parsers.constants import bohr_to_ang
 
 
-class ForceconstantsData(SinglefileData):
+class ForceConstantsData(SinglefileData):
     """Class to handle interatomic force constants from the Quantum ESPRESSO q2r.x code"""
 
     def set_file(self, file):
@@ -18,7 +18,7 @@ class ForceconstantsData(SinglefileData):
         :param file: absolute path to the file or a filelike object
         """
         # pylint: disable=redefined-builtin,arguments-differ
-        super(ForceconstantsData, self).set_file(file)
+        super(ForceConstantsData, self).set_file(file)
 
         # Parse the force constants file
         dictionary, _, _ = parse_q2r_force_constants_file(self.get_content().splitlines(), also_force_constants=False)

--- a/aiida_quantumespresso/parsers/q2r.py
+++ b/aiida_quantumespresso/parsers/q2r.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from aiida.common import exceptions
 from aiida.parsers import Parser
 from aiida_quantumespresso.calculations.q2r import Q2rCalculation
-from aiida_quantumespresso.data.forceconstants import ForceconstantsData
+from aiida_quantumespresso.data.force_constants import ForceConstantsData
 
 
 class Q2rParser(Parser):
@@ -33,6 +33,6 @@ class Q2rParser(Parser):
             return self.exit_codes.ERROR_JOB_NOT_DONE
 
         with output_folder.open(filename_force_constants, 'rb') as handle:
-            self.out('forceconstants', ForceconstantsData(file=handle))
+            self.out('force_constants', ForceConstantsData(file=handle))
 
         return

--- a/setup.json
+++ b/setup.json
@@ -24,7 +24,7 @@
             "quantumespresso.pwimmigrant = aiida_quantumespresso.calculations.pwimmigrant:PwimmigrantCalculation"
         ],
         "aiida.data": [
-            "quantumespresso.forceconstants = aiida_quantumespresso.data.forceconstants:ForceconstantsData"
+            "quantumespresso.force_constants = aiida_quantumespresso.data.force_constants:ForceConstantsData"
         ],
         "aiida.parsers": [
             "quantumespresso.cp = aiida_quantumespresso.parsers.cp:CpParser",

--- a/tests/parsers/test_q2r.py
+++ b/tests/parsers/test_q2r.py
@@ -24,5 +24,5 @@ def test_q2r_default(fixture_database, fixture_computer_localhost, generate_calc
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
-    assert 'forceconstants' in results
-    data_regression.check(results['forceconstants'].get_content())
+    assert 'force_constants' in results
+    data_regression.check(results['force_constants'].get_content())


### PR DESCRIPTION
Fixes #383 

This also indirectly changes `forceconstants` to `force_constants` both
in module name as well as the output link label used for calculations
and work chains.