### PR TITLE
Implement support for multidimension tag in pw.x XML input spec

### DIFF
--- a/aiida_quantumespresso/calculations/helpers/INPUT_PW-6.3.xml
+++ b/aiida_quantumespresso/calculations/helpers/INPUT_PW-6.3.xml
@@ -1,0 +1,3063 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml-stylesheet type="text/xsl" href="input_xx.xsl"?>
+<!-- FILE AUTOMATICALLY CREATED: DO NOT EDIT, CHANGES WILL BE LOST -->
+
+<input_description distribution="Quantum Espresso" package="PWscf" program="pw.x" >
+   <toc>
+   </toc>
+   <intro>
+<b>Input data format:</b> { } = optional, [ ] = it depends, | = or
+
+All quantities whose dimensions are not explicitly specified are in
+RYDBERG ATOMIC UNITS. Charge is &quot;number&quot; charge (i.e. not multiplied
+by e); potentials are in energy units (i.e. they are multiplied by e).
+
+<b>BEWARE:</b> TABS, DOS &lt;CR&gt;&lt;LF&gt; CHARACTERS ARE POTENTIAL SOURCES OF TROUBLE
+
+Namelists must appear in the order given below.
+Comment lines in <i>namelists</i> can be introduced by a &quot;!&quot;, exactly as in
+fortran code. Comments lines in <i>cards</i> can be introduced by
+either a &quot;!&quot; or a &quot;#&quot; character in the first position of a line.
+Do not start any line in <i>cards</i> with a &quot;/&quot; character.
+Leave a space between card names and card options, e.g.
+ATOMIC_POSITIONS (bohr), not ATOMIC_POSITIONS(bohr)
+Do not start any line in <i>cards</i> with a &quot;/&quot; character.
+
+
+<b>Structure of the input data:</b>
+===============================================================================
+
+<b>&amp;CONTROL</b>
+  ...
+<b>/</b>
+
+<b>&amp;SYSTEM</b>
+  ...
+<b>/</b>
+
+<b>&amp;ELECTRONS</b>
+  ...
+<b>/</b>
+
+[ <b>&amp;IONS</b>
+  ...
+ <b>/</b> ]
+
+[ <b>&amp;CELL</b>
+  ...
+ <b>/</b> ]
+
+<b>ATOMIC_SPECIES</b>
+ X  Mass_X  PseudoPot_X
+ Y  Mass_Y  PseudoPot_Y
+ Z  Mass_Z  PseudoPot_Z
+
+<b>ATOMIC_POSITIONS</b> { alat | bohr | crystal | angstrom | crystal_sg }
+  X 0.0  0.0  0.0  {if_pos(1) if_pos(2) if_pos(3)}
+  Y 0.5  0.0  0.0
+  Z O.0  0.2  0.2
+
+<b>K_POINTS</b> { tpiba | automatic | crystal | gamma | tpiba_b | crystal_b | tpiba_c | crystal_c }
+if (gamma)
+   nothing to read
+if (automatic)
+   nk1, nk2, nk3, k1, k2, k3
+if (not automatic)
+   nks
+   xk_x, xk_y, xk_z,  wk
+
+[ <b>CELL_PARAMETERS</b> { alat | bohr | angstrom }
+   v1(1) v1(2) v1(3)
+   v2(1) v2(2) v2(3)
+   v3(1) v3(2) v3(3) ]
+
+[ <b>OCCUPATIONS</b>
+   f_inp1(1)  f_inp1(2)  f_inp1(3) ... f_inp1(10)
+   f_inp1(11) f_inp1(12) ... f_inp1(nbnd)
+ [ f_inp2(1)  f_inp2(2)  f_inp2(3) ... f_inp2(10)
+   f_inp2(11) f_inp2(12) ... f_inp2(nbnd) ] ]
+
+[ <b>CONSTRAINTS</b>
+   nconstr  { constr_tol }
+   constr_type(.)   constr(1,.)   constr(2,.) [ constr(3,.)   constr(4,.) ] { constr_target(.) } ]
+
+[ <b>ATOMIC_FORCES</b>
+   label_1 Fx(1) Fy(1) Fz(1)
+   .....
+   label_n Fx(n) Fy(n) Fz(n) ]
+   </intro>
+   <namelist name="CONTROL" >
+      <var name="calculation" type="CHARACTER" >
+         <default> &apos;scf&apos;
+         </default>
+         <options>
+            <info>
+A string describing the task to be performed. Options are:
+            </info>
+            <opt val="'scf'" >
+            </opt>
+            <opt val="'nscf'" >
+            </opt>
+            <opt val="'bands'" >
+            </opt>
+            <opt val="'relax'" >
+            </opt>
+            <opt val="'md'" >
+            </opt>
+            <opt val="'vc-relax'" >
+            </opt>
+            <opt val="'vc-md'" >
+            </opt>
+            <info>
+(vc = variable-cell).
+            </info>
+         </options>
+      </var>
+      <var name="title" type="CHARACTER" >
+         <default> &apos; &apos;
+         </default>
+         <info>
+reprinted on output.
+         </info>
+      </var>
+      <var name="verbosity" type="CHARACTER" >
+         <default> &apos;low&apos;
+         </default>
+         <options>
+            <info>
+Currently two verbosity levels are implemented:
+            </info>
+            <opt val="'high'" >
+            </opt>
+            <opt val="'low'" >
+            </opt>
+            <info>
+<b>&apos;debug&apos;</b> and <b>&apos;medium&apos;</b> have the same effect as <b>&apos;high&apos;;</b>
+<b>&apos;default&apos;</b> and <b>&apos;minimal&apos;</b> as <b>&apos;low&apos;</b>
+            </info>
+         </options>
+      </var>
+      <var name="restart_mode" type="CHARACTER" >
+         <default> &apos;from_scratch&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'from_scratch'" >
+From scratch. This is the normal way to perform a PWscf calculation
+            </opt>
+            <opt val="'restart'" >
+From previous interrupted run. Use this switch only if you want to
+continue an interrupted calculation, not to start a new one, or to
+perform non-scf calculations.  Works only if the calculation was
+cleanly stopped using variable <ref>max_seconds</ref>, or by user request
+with an &quot;exit file&quot; (i.e.: create a file &quot;prefix&quot;.EXIT, in directory
+&quot;outdir&quot;; see variables <ref>prefix</ref>, <ref>outdir</ref>).  Overrides <ref>startingwfc</ref>
+and <ref>startingpot</ref>.
+            </opt>
+         </options>
+      </var>
+      <var name="wf_collect" type="LOGICAL" >
+         <default> .TRUE.
+         </default>
+         <info>
+This flag controls the way wavefunctions are stored to disk :
+
+.TRUE.  collect wavefunctions from all processors, store them
+        into the output data directory &quot;outdir&quot;/&quot;prefix&quot;.save
+        The resulting format is portable to a different number
+        of processor, or different kind of parallelization
+
+.FALSE. do not collect wavefunctions, leave them in temporary
+        local files (one per processor). The resulting format
+        is readable only on the same number of processors and
+        with the same kind of parallelization used to write it.
+
+Note that this flag has no effect on reading, only on writing.
+         </info>
+      </var>
+      <var name="nstep" type="INTEGER" >
+         <info>
+number of molecular-dynamics or structural optimization steps
+performed in this run
+         </info>
+         <default>
+1  if <ref>calculation</ref> == &apos;scf&apos;, &apos;nscf&apos;, &apos;bands&apos;;
+50 for the other cases
+         </default>
+      </var>
+      <var name="iprint" type="INTEGER" >
+         <default> write only at convergence
+         </default>
+         <info>
+band energies are written every <i>iprint</i> iterations
+         </info>
+      </var>
+      <var name="tstress" type="LOGICAL" >
+         <default> .false.
+         </default>
+         <info>
+calculate stress. It is set to .TRUE. automatically if
+<ref>calculation</ref> == &apos;vc-md&apos; or &apos;vc-relax&apos;
+         </info>
+      </var>
+      <var name="tprnfor" type="LOGICAL" >
+         <info>
+calculate forces. It is set to .TRUE. automatically if
+<ref>calculation</ref> == &apos;relax&apos;,&apos;md&apos;,&apos;vc-md&apos;
+         </info>
+      </var>
+      <var name="dt" type="REAL" >
+         <default> 20.D0
+         </default>
+         <info>
+time step for molecular dynamics, in Rydberg atomic units
+(1 a.u.=4.8378 * 10^-17 s : beware, the CP code uses
+ Hartree atomic units, half that much!!!)
+         </info>
+      </var>
+      <var name="outdir" type="CHARACTER" >
+         <default>
+value of the ESPRESSO_TMPDIR environment variable if set;
+current directory (&apos;./&apos;) otherwise
+         </default>
+         <info>
+input, temporary, output files are found in this directory,
+see also <ref>wfcdir</ref>
+         </info>
+      </var>
+      <var name="wfcdir" type="CHARACTER" >
+         <default> same as <ref>outdir</ref>
+         </default>
+         <info>
+This directory specifies where to store files generated by
+each processor (*.wfc{N}, *.igk{N}, etc.). Useful for
+machines without a parallel file system: set <ref>wfcdir</ref> to
+a local file system, while <ref>outdir</ref> should be a parallel
+or network file system, visible to all processors. Beware:
+in order to restart from interrupted runs, or to perform
+further calculations using the produced data files, you
+may need to copy files to <ref>outdir</ref>. Works only for pw.x.
+         </info>
+      </var>
+      <var name="prefix" type="CHARACTER" >
+         <default> &apos;pwscf&apos;
+         </default>
+         <info>
+prepended to input/output filenames:
+prefix.wfc, prefix.rho, etc.
+         </info>
+      </var>
+      <var name="lkpoint_dir" type="LOGICAL" >
+         <default> .true.
+         </default>
+         <info>
+If .false. a subdirectory for each k_point is not opened
+in the &quot;prefix&quot;.save directory; Kohn-Sham eigenvalues are
+stored instead in a single file for all k-points. Currently
+doesn&apos;t work together with <ref>wf_collect</ref>
+         </info>
+      </var>
+      <var name="max_seconds" type="REAL" >
+         <default> 1.D+7, or 150 days, i.e. no time limit
+         </default>
+         <info>
+Jobs stops after <ref>max_seconds</ref> CPU time. Use this option
+in conjunction with option <ref>restart_mode</ref> if you need to
+split a job too long to complete into shorter jobs that
+fit into your batch queues.
+         </info>
+      </var>
+      <var name="etot_conv_thr" type="REAL" >
+         <default> 1.0D-4
+         </default>
+         <info>
+Convergence threshold on total energy (a.u) for ionic
+minimization: the convergence criterion is satisfied
+when the total energy changes less than <ref>etot_conv_thr</ref>
+between two consecutive scf steps. Note that <ref>etot_conv_thr</ref>
+is extensive, like the total energy.
+See also <ref>forc_conv_thr</ref> - both criteria must be satisfied
+         </info>
+      </var>
+      <var name="forc_conv_thr" type="REAL" >
+         <default> 1.0D-3
+         </default>
+         <info>
+Convergence threshold on forces (a.u) for ionic minimization:
+the convergence criterion is satisfied when all components of
+all forces are smaller than <ref>forc_conv_thr</ref>.
+See also <ref>etot_conv_thr</ref> - both criteria must be satisfied
+         </info>
+      </var>
+      <var name="disk_io" type="CHARACTER" >
+         <default> see below
+         </default>
+         <options>
+            <info>
+Specifies the amount of disk I/O activity:
+            </info>
+            <opt val="'high'" >
+save all data to disk at each SCF step
+            </opt>
+            <opt val="'medium'" >
+save wavefunctions at each SCF step unless
+there is a single k-point per process (in which
+case the behavior is the same as &apos;low&apos;)
+            </opt>
+            <opt val="'low'" >
+store wfc in memory, save only at the end
+            </opt>
+            <opt val="'none'" >
+do not save anything, not even at the end
+(&apos;scf&apos;, &apos;nscf&apos;, &apos;bands&apos; calculations; some data
+may be written anyway for other calculations)
+            </opt>
+            <info>
+<b>Default</b> is <b>&apos;low&apos;</b> for the scf case, <b>&apos;medium&apos;</b> otherwise.
+Note that the needed RAM increases as disk I/O decreases!
+It is no longer needed to specify &apos;high&apos; in order to be able
+to restart from an interrupted calculation (see <ref>restart_mode</ref>)
+but you cannot restart in <ref>disk_io</ref>==&apos;none&apos;
+            </info>
+         </options>
+      </var>
+      <var name="pseudo_dir" type="CHARACTER" >
+         <default>
+value of the $ESPRESSO_PSEUDO environment variable if set;
+&apos;$HOME/espresso/pseudo/&apos; otherwise
+         </default>
+         <info>
+directory containing pseudopotential files
+         </info>
+      </var>
+      <var name="tefield" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. a saw-like potential simulating an electric field
+is added to the bare ionic potential. See variables <ref>edir</ref>,
+<ref>eamp</ref>, <ref>emaxpos</ref>, <ref>eopreg</ref> for the form and size of
+the added potential.
+         </info>
+      </var>
+      <var name="dipfield" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. and <ref>tefield</ref>==.TRUE. a dipole correction is also
+added to the bare ionic potential - implements the recipe
+of L. Bengtsson, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.59.12301">PRB 59, 12301 (1999)</a>. See variables <ref>edir</ref>,
+<ref>emaxpos</ref>, <ref>eopreg</ref> for the form of the correction. Must
+be used ONLY in a slab geometry, for surface calculations,
+with the discontinuity FALLING IN THE EMPTY SPACE.
+         </info>
+      </var>
+      <var name="lelfield" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. a homogeneous finite electric field described
+through the modern theory of the polarization is applied.
+This is different from <ref>tefield</ref> == .true. !
+         </info>
+      </var>
+      <var name="nberrycyc" type="INTEGER" >
+         <default> 1
+         </default>
+         <info>
+In the case of a finite electric field  ( <ref>lelfield</ref> == .TRUE. )
+it defines the number of iterations for converging the
+wavefunctions in the electric field Hamiltonian, for each
+external iteration on the charge density
+         </info>
+      </var>
+      <var name="lorbm" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If <b>.TRUE.</b> perform orbital magnetization calculation.
+If finite electric field is applied (<ref>lelfield</ref>==.true.) only Kubo terms are computed
+[for details see New J. Phys. 12, 053032 (2010), <a href="http://dx.doi.org/10.1088/1367-2630/12/5/053032">doi:10.1088/1367-2630/12/5/053032</a>].
+
+The type of calculation is <b>&apos;nscf&apos;</b> and should be performed on an automatically
+generated uniform grid of k points.
+
+Works ONLY with norm-conserving pseudopotentials.
+         </info>
+      </var>
+      <var name="lberry" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. perform a Berry phase calculation.
+See the header of PW/src/bp_c_phase.f90 for documentation.
+         </info>
+      </var>
+      <var name="gdir" type="INTEGER" >
+         <info>
+For Berry phase calculation: direction of the k-point
+strings in reciprocal space. Allowed values: 1, 2, 3
+1=first, 2=second, 3=third reciprocal lattice vector
+For calculations with finite electric fields
+(<ref>lelfield</ref>==.true.) &quot;gdir&quot; is the direction of the field.
+         </info>
+      </var>
+      <var name="nppstr" type="INTEGER" >
+         <info>
+For Berry phase calculation: number of k-points to be
+calculated along each symmetry-reduced string.
+The same for calculation with finite electric fields
+(<ref>lelfield</ref>==.true.).
+         </info>
+      </var>
+      <var name="lfcpopt" type="LOGICAL" >
+         <see> fcp_mu
+         </see>
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. perform a constant bias potential (constant-mu) calculation
+for a static system with ESM method. See the header of PW/src/fcp.f90
+for documentation.
+
+NB:
+- The total energy displayed in &apos;prefix.out&apos; includes the potentiostat
+  contribution (-mu*N).
+- <ref>calculation</ref> must be &apos;relax&apos;.
+- <ref>assume_isolated</ref> = &apos;esm&apos; and <ref>esm_bc</ref> = &apos;bc2&apos; or &apos;bc3&apos; must be set
+  in <ref>SYSTEM</ref> namelist.
+         </info>
+      </var>
+      <var name="gate" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <see> zgate, relaxz, block, block_1, block_2, block_height
+         </see>
+         <info>
+In the case of charged cells (<ref>tot_charge</ref> .ne. 0) setting gate = .TRUE.
+represents the counter charge (i.e. -tot_charge) not by a homogeneous
+background charge but with a charged plate, which is placed at <ref>zgate</ref>
+(see below). Details of the gate potential can be found in
+T. Brumme, M. Calandra, F. Mauri; <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.89.245406">PRB 89, 245406 (2014)</a>.
+Note, that in systems which are not symmetric with respect to the plate,
+one needs to enable the dipole correction! (<ref>dipfield</ref>=.true.).
+Currently, symmetry can be used with gate=.true. but carefully check
+that no symmetry is included which maps <i>z</i> to -<i>z</i> even if in principle one
+could still use them for symmetric systems (i.e. no dipole correction).
+For <ref>nosym</ref>=.false. verbosity is set to &apos;high&apos;.
+Note: this option was called &quot;monopole&quot; in v6.0 and 6.1 of pw.x
+         </info>
+      </var>
+   </namelist>
+   <namelist name="SYSTEM" >
+      <var name="ibrav" type="INTEGER" >
+         <status> REQUIRED
+         </status>
+         <info>
+  Bravais-lattice index. Optional only if space_group is set.
+  If ibrav /= 0, specify EITHER [ <ref>celldm</ref>(1)-<ref>celldm</ref>(6) ]
+  OR [ <ref>A</ref>, <ref>B</ref>, <ref>C</ref>, <ref>cosAB</ref>, <ref>cosAC</ref>, <ref>cosBC</ref> ]
+  but NOT both. The lattice parameter &quot;alat&quot; is set to
+  alat = celldm(1) (in a.u.) or alat = A (in Angstrom);
+  see below for the other parameters.
+  For ibrav=0 specify the lattice vectors in <ref>CELL_PARAMETERS</ref>,
+  optionally the lattice parameter alat = celldm(1) (in a.u.)
+  or = A (in Angstrom), or else it is taken from <ref>CELL_PARAMETERS</ref>
+
+ibrav      structure                   celldm(2)-celldm(6)
+                                     or: b,c,cosbc,cosac,cosab
+  0          free
+      crystal axis provided in input: see card <ref>CELL_PARAMETERS</ref>
+
+  1          cubic P (sc)
+      v1 = a(1,0,0),  v2 = a(0,1,0),  v3 = a(0,0,1)
+
+  2          cubic F (fcc)
+      v1 = (a/2)(-1,0,1),  v2 = (a/2)(0,1,1), v3 = (a/2)(-1,1,0)
+
+  3          cubic I (bcc)
+      v1 = (a/2)(1,1,1),  v2 = (a/2)(-1,1,1),  v3 = (a/2)(-1,-1,1)
+ -3          cubic I (bcc), more symmetric axis:
+      v1 = (a/2)(-1,1,1), v2 = (a/2)(1,-1,1),  v3 = (a/2)(1,1,-1)
+
+  4          Hexagonal and Trigonal P        celldm(3)=c/a
+      v1 = a(1,0,0),  v2 = a(-1/2,sqrt(3)/2,0),  v3 = a(0,0,c/a)
+
+  5          Trigonal R, 3fold axis c        celldm(4)=cos(gamma)
+      The crystallographic vectors form a three-fold star around
+      the z-axis, the primitive cell is a simple rhombohedron:
+      v1 = a(tx,-ty,tz),   v2 = a(0,2ty,tz),   v3 = a(-tx,-ty,tz)
+      where c=cos(gamma) is the cosine of the angle gamma between
+      any pair of crystallographic vectors, tx, ty, tz are:
+        tx=sqrt((1-c)/2), ty=sqrt((1-c)/6), tz=sqrt((1+2c)/3)
+ -5          Trigonal R, 3fold axis &lt;111&gt;    celldm(4)=cos(gamma)
+      The crystallographic vectors form a three-fold star around
+      &lt;111&gt;. Defining a&apos; = a/sqrt(3) :
+      v1 = a&apos; (u,v,v),   v2 = a&apos; (v,u,v),   v3 = a&apos; (v,v,u)
+      where u and v are defined as
+        u = tz - 2*sqrt(2)*ty,  v = tz + sqrt(2)*ty
+      and tx, ty, tz as for case ibrav=5
+      Note: if you prefer x,y,z as axis in the cubic limit,
+            set  u = tz + 2*sqrt(2)*ty,  v = tz - sqrt(2)*ty
+            See also the note in Modules/latgen.f90
+
+  6          Tetragonal P (st)               celldm(3)=c/a
+      v1 = a(1,0,0),  v2 = a(0,1,0),  v3 = a(0,0,c/a)
+
+  7          Tetragonal I (bct)              celldm(3)=c/a
+      v1=(a/2)(1,-1,c/a),  v2=(a/2)(1,1,c/a),  v3=(a/2)(-1,-1,c/a)
+
+  8          Orthorhombic P                  celldm(2)=b/a
+                                             celldm(3)=c/a
+      v1 = (a,0,0),  v2 = (0,b,0), v3 = (0,0,c)
+
+  9          Orthorhombic base-centered(bco) celldm(2)=b/a
+                                             celldm(3)=c/a
+      v1 = (a/2, b/2,0),  v2 = (-a/2,b/2,0),  v3 = (0,0,c)
+ -9          as 9, alternate description
+      v1 = (a/2,-b/2,0),  v2 = (a/2, b/2,0),  v3 = (0,0,c)
+ 91          Orthorhombic one-face base-centered A-type
+                                             celldm(2)=b/a
+                                             celldm(3)=c/a
+      v1 = (a, 0, 0),  v2 = (0,b/2,-c/2),  v3 = (0,b/2,c/2)
+
+ 10          Orthorhombic face-centered      celldm(2)=b/a
+                                             celldm(3)=c/a
+      v1 = (a/2,0,c/2),  v2 = (a/2,b/2,0),  v3 = (0,b/2,c/2)
+
+ 11          Orthorhombic body-centered      celldm(2)=b/a
+                                             celldm(3)=c/a
+      v1=(a/2,b/2,c/2),  v2=(-a/2,b/2,c/2),  v3=(-a/2,-b/2,c/2)
+
+ 12          Monoclinic P, unique axis c     celldm(2)=b/a
+                                             celldm(3)=c/a,
+                                             celldm(4)=cos(ab)
+      v1=(a,0,0), v2=(b*cos(gamma),b*sin(gamma),0),  v3 = (0,0,c)
+      where gamma is the angle between axis a and b.
+-12          Monoclinic P, unique axis b     celldm(2)=b/a
+                                             celldm(3)=c/a,
+                                             celldm(5)=cos(ac)
+      v1 = (a,0,0), v2 = (0,b,0), v3 = (c*cos(beta),0,c*sin(beta))
+      where beta is the angle between axis a and c
+
+ 13          Monoclinic base-centered        celldm(2)=b/a
+             (unique axis c)                 celldm(3)=c/a,
+                                             celldm(4)=cos(gamma)
+      v1 = (  a/2,         0,          -c/2),
+      v2 = (b*cos(gamma), b*sin(gamma), 0  ),
+      v3 = (  a/2,         0,           c/2),
+      where gamma=angle between axis a and b projected on xy plane
+
+-13          Monoclinic base-centered        celldm(2)=b/a
+             (unique axis b)                 celldm(3)=c/a,
+                                             celldm(5)=cos(beta)
+      v1 = (  a/2,      -b/2,             0),
+      v2 = (  a/2,       b/2,             0),
+      v3 = (c*cos(beta),   0,   c*sin(beta)),
+      where beta=angle between axis a and c projected on xz plane
+
+ 14          Triclinic                       celldm(2)= b/a,
+                                             celldm(3)= c/a,
+                                             celldm(4)= cos(bc),
+                                             celldm(5)= cos(ac),
+                                             celldm(6)= cos(ab)
+      v1 = (a, 0, 0),
+      v2 = (b*cos(gamma), b*sin(gamma), 0)
+      v3 = (c*cos(beta),  c*(cos(alpha)-cos(beta)cos(gamma))/sin(gamma),
+           c*sqrt( 1 + 2*cos(alpha)cos(beta)cos(gamma)
+                     - cos(alpha)^2-cos(beta)^2-cos(gamma)^2 )/sin(gamma) )
+      where alpha is the angle between axis b and c
+             beta is the angle between axis a and c
+            gamma is the angle between axis a and b
+         </info>
+      </var>
+      <group>
+         <label> Either:
+         </label>
+         <dimension name="celldm" start="1" end="6" type="REAL" >
+            <see> ibrav
+            </see>
+            <info>
+Crystallographic constants - see the <ref>ibrav</ref> variable.
+Specify either these OR <ref>A</ref>,<ref>B</ref>,<ref>C</ref>,<ref>cosAB</ref>,<ref>cosBC</ref>,<ref>cosAC</ref> NOT both.
+Only needed values (depending on &quot;ibrav&quot;) must be specified
+alat = <ref>celldm</ref>(1) is the lattice parameter &quot;a&quot; (in BOHR)
+If <ref>ibrav</ref>==0, only <ref>celldm</ref>(1) is used if present;
+cell vectors are read from card <ref>CELL_PARAMETERS</ref>
+            </info>
+         </dimension>
+         <label> Or:
+         </label>
+         <vargroup type="REAL" >
+            <var name="A" >
+            </var>
+            <var name="B" >
+            </var>
+            <var name="C" >
+            </var>
+            <var name="cosAB" >
+            </var>
+            <var name="cosAC" >
+            </var>
+            <var name="cosBC" >
+            </var>
+            <see> ibrav
+            </see>
+            <info>
+Traditional crystallographic constants:
+
+  a,b,c in ANGSTROM
+  cosAB = cosine of the angle between axis a and b (gamma)
+  cosAC = cosine of the angle between axis a and c (beta)
+  cosBC = cosine of the angle between axis b and c (alpha)
+
+The axis are chosen according to the value of <ref>ibrav</ref>.
+Specify either these OR <ref>celldm</ref> but NOT both.
+Only needed values (depending on <ref>ibrav</ref>) must be specified.
+
+The lattice parameter alat = A (in ANGSTROM ).
+
+If <ref>ibrav</ref> == 0, only A is used if present, and
+cell vectors are read from card <ref>CELL_PARAMETERS</ref>.
+            </info>
+         </vargroup>
+      </group>
+      <var name="nat" type="INTEGER" >
+         <status> REQUIRED
+         </status>
+         <info>
+number of atoms in the unit cell (ALL atoms, except if
+space_group is set, in which case, INEQUIVALENT atoms)
+         </info>
+      </var>
+      <var name="ntyp" type="INTEGER" >
+         <status> REQUIRED
+         </status>
+         <info>
+number of types of atoms in the unit cell
+         </info>
+      </var>
+      <var name="nbnd" type="INTEGER" >
+         <default>
+for an insulator, <ref>nbnd</ref> = number of valence bands
+(<ref>nbnd</ref> = # of electrons /2);
+<br/> for a metal, 20% more (minimum 4 more)
+         </default>
+         <info>
+Number of electronic states (bands) to be calculated.
+Note that in spin-polarized calculations the number of
+k-point, not the number of bands per k-point, is doubled
+         </info>
+      </var>
+      <var name="tot_charge" type="REAL" >
+         <default> 0.0
+         </default>
+         <info>
+Total charge of the system. Useful for simulations with charged cells.
+By default the unit cell is assumed to be neutral (tot_charge=0).
+tot_charge=+1 means one electron missing from the system,
+tot_charge=-1 means one additional electron, and so on.
+
+In a periodic calculation a compensating jellium background is
+inserted to remove divergences if the cell is not neutral.
+         </info>
+      </var>
+      <dimension name="starting_charge" start="1" end="ntyp" type="REAL" >
+         <default> 0.0
+         </default>
+         <info>
+starting charge on atomic type &apos;i&apos;,
+to create starting potential with <ref>startingpot</ref> = &apos;atomic&apos;.
+         </info>
+      </dimension>
+      <var name="tot_magnetization" type="REAL" >
+         <default> -1 [unspecified]
+         </default>
+         <info>
+Total majority spin charge - minority spin charge.
+Used to impose a specific total electronic magnetization.
+If unspecified then tot_magnetization variable is ignored and
+the amount of electronic magnetization is determined during
+the self-consistent cycle.
+         </info>
+      </var>
+      <dimension name="starting_magnetization" start="1" end="ntyp" type="REAL" >
+         <info>
+Starting spin polarization on atomic type &apos;i&apos; in a spin
+polarized calculation. Values range between -1 (all spins
+down for the valence electrons of atom type &apos;i&apos;) to 1
+(all spins up). Breaks the symmetry and provides a starting
+point for self-consistency. The default value is zero, BUT a
+value MUST be specified for AT LEAST one atomic type in spin
+polarized calculations, unless you constrain the magnetization
+(see <ref>tot_magnetization</ref> and <ref>constrained_magnetization</ref>).
+Note that if you start from zero initial magnetization, you
+will invariably end up in a nonmagnetic (zero magnetization)
+state. If you want to start from an antiferromagnetic state,
+you may need to define two different atomic species
+corresponding to sublattices of the same atomic type.
+starting_magnetization is ignored if you are performing a
+non-scf calculation, if you are restarting from a previous
+run, or restarting from an interrupted run.
+If you fix the magnetization with <ref>tot_magnetization</ref>,
+you should not specify starting_magnetization.
+In the spin-orbit case starting with zero
+starting_magnetization on all atoms imposes time reversal
+symmetry. The magnetization is never calculated and
+kept zero (the internal variable domag is .FALSE.).
+         </info>
+      </dimension>
+      <var name="ecutwfc" type="REAL" >
+         <status> REQUIRED
+         </status>
+         <info>
+kinetic energy cutoff (Ry) for wavefunctions
+         </info>
+      </var>
+      <var name="ecutrho" type="REAL" >
+         <default> 4 * <ref>ecutwfc</ref>
+         </default>
+         <info>
+Kinetic energy cutoff (Ry) for charge density and potential
+For norm-conserving pseudopotential you should stick to the
+default value, you can reduce it by a little but it will
+introduce noise especially on forces and stress.
+If there are ultrasoft PP, a larger value than the default is
+often desirable (ecutrho = 8 to 12 times <ref>ecutwfc</ref>, typically).
+PAW datasets can often be used at 4*<ref>ecutwfc</ref>, but it depends
+on the shape of augmentation charge: testing is mandatory.
+The use of gradient-corrected functional, especially in cells
+with vacuum, or for pseudopotential without non-linear core
+correction, usually requires an higher values of ecutrho
+to be accurately converged.
+         </info>
+      </var>
+      <var name="ecutfock" type="REAL" >
+         <default> ecutrho
+         </default>
+         <info>
+Kinetic energy cutoff (Ry) for the exact exchange operator in
+EXX type calculations. By default this is the same as <ref>ecutrho</ref>
+but in some EXX calculations significant speed-up can be found
+by reducing ecutfock, at the expense of some loss in accuracy.
+Must be .gt. <ref>ecutwfc</ref>. Not implemented for stress calculation.
+Use with care, especially in metals where it may give raise
+to instabilities.
+         </info>
+      </var>
+      <vargroup type="INTEGER" >
+         <var name="nr1" >
+         </var>
+         <var name="nr2" >
+         </var>
+         <var name="nr3" >
+         </var>
+         <info>
+Three-dimensional FFT mesh (hard grid) for charge
+density (and scf potential). If not specified
+the grid is calculated based on the cutoff for
+charge density (see also <ref>ecutrho</ref>)
+Note: you must specify all three dimensions for this setting to
+be used.
+         </info>
+      </vargroup>
+      <vargroup type="INTEGER" >
+         <var name="nr1s" >
+         </var>
+         <var name="nr2s" >
+         </var>
+         <var name="nr3s" >
+         </var>
+         <info>
+Three-dimensional mesh for wavefunction FFT and for the smooth
+part of charge density ( smooth grid ).
+Coincides with <ref>nr1</ref>, <ref>nr2</ref>, <ref>nr3</ref> if <ref>ecutrho</ref> = 4 * ecutwfc ( default )
+Note: you must specify all three dimensions for this setting to
+be used.
+         </info>
+      </vargroup>
+      <var name="nosym" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.TRUE.) symmetry is not used. Consequences:
+
+- if a list of k points is provided in input, it is used
+  &quot;as is&quot;: symmetry-inequivalent k-points are not generated,
+  and the charge density is not symmetrized;
+
+- if a uniform (Monkhorst-Pack) k-point grid is provided in
+  input, it is expanded to cover the entire Brillouin Zone,
+  irrespective of the crystal symmetry.
+  Time reversal symmetry is assumed so k and -k are considered
+  as equivalent unless <ref>noinv</ref>=.true. is specified.
+
+Do not use this option unless you know exactly what you want
+and what you get. May be useful in the following cases:
+- in low-symmetry large cells, if you cannot afford a k-point
+  grid with the correct symmetry
+- in MD simulations
+- in calculations for isolated atoms
+         </info>
+      </var>
+      <var name="nosym_evc" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.TRUE.) symmetry is not used, and k points are
+forced to have the symmetry of the Bravais lattice;
+an automatically generated Monkhorst-Pack grid will contain
+all points of the grid over the entire Brillouin Zone,
+plus the points rotated by the symmetries of the Bravais
+lattice which were not in the original grid. The same
+applies if a k-point list is provided in input instead
+of a Monkhorst-Pack grid. Time reversal symmetry is assumed
+so k and -k are equivalent unless <ref>noinv</ref>=.true. is specified.
+This option differs from <ref>nosym</ref> because it forces k-points
+in all cases to have the full symmetry of the Bravais lattice
+(not all uniform grids have such property!)
+         </info>
+      </var>
+      <var name="noinv" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.TRUE.) disable the usage of k =&gt; -k symmetry
+(time reversal) in k-point generation
+         </info>
+      </var>
+      <var name="no_t_rev" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.TRUE.) disable the usage of magnetic symmetry operations
+that consist in a rotation + time reversal.
+         </info>
+      </var>
+      <var name="force_symmorphic" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.TRUE.) force the symmetry group to be symmorphic by disabling
+symmetry operations having an associated fractionary translation
+         </info>
+      </var>
+      <var name="use_all_frac" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.TRUE.) do not discard symmetry operations with an
+associated fractionary translation that does not send the
+real-space FFT grid into itself. These operations are
+incompatible with real-space symmetrization but not with the
+new G-space symmetrization. BEWARE: do not use for phonons
+and for hybrid functionals! Both still use symmetrization
+in real space.
+         </info>
+      </var>
+      <var name="occupations" type="CHARACTER" >
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'smearing'" >
+gaussian smearing for metals;
+see variables <ref>smearing</ref> and <ref>degauss</ref>
+            </opt>
+            <opt val="'tetrahedra'" >
+Tetrahedron method, Bloechl&apos;s version:
+P.E. Bloechl, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.49.16223">PRB 49, 16223 (1994)</a>
+Requires uniform grid of k-points, to be
+automatically generated (see card <ref>K_POINTS</ref>).
+Well suited for calculation of DOS,
+less so (because not variational) for
+force/optimization/dynamics calculations.
+            </opt>
+            <opt val="'tetrahedra_lin'" >
+Original linear tetrahedron method.
+To be used only as a reference;
+the optimized tetrahedron method is more efficient.
+            </opt>
+            <opt val="'tetrahedra_opt'" >
+Optimized tetrahedron method:
+see M. Kawamura, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.89.094515">PRB 89, 094515 (2014)</a>.
+Can be used for phonon calculations as well.
+            </opt>
+            <opt val="'fixed'" >
+for insulators with a gap
+            </opt>
+            <opt val="'from_input'" >
+The occupation are read from input file,
+card <ref>OCCUPATIONS</ref>. Option valid only for a
+single k-point, requires <ref>nbnd</ref> to be set
+in input. Occupations should be consistent
+with the value of <ref>tot_charge</ref>.
+            </opt>
+         </options>
+      </var>
+      <var name="one_atom_occupations" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+This flag is used for isolated atoms (<ref>nat</ref>=1) together with
+<ref>occupations</ref>=&apos;from_input&apos;. If it is .TRUE., the wavefunctions
+are ordered as the atomic starting wavefunctions, independently
+from their eigenvalue. The occupations indicate which atomic
+states are filled.
+
+The order of the states is written inside the UPF pseudopotential file.
+In the scalar relativistic case:
+S -&gt; l=0, m=0
+P -&gt; l=1, z, x, y
+D -&gt; l=2, r^2-3z^2, xz, yz, xy, x^2-y^2
+
+In the noncollinear magnetic case (with or without spin-orbit),
+each group of states is doubled. For instance:
+P -&gt; l=1, z, x, y for spin up, l=1, z, x, y for spin down.
+Up and down is relative to the direction of the starting
+magnetization.
+
+In the case with spin-orbit and time-reversal
+(<ref>starting_magnetization</ref>=0.0) the atomic wavefunctions are
+radial functions multiplied by spin-angle functions.
+For instance:
+P -&gt; l=1, j=1/2, m_j=-1/2,1/2. l=1, j=3/2,
+     m_j=-3/2, -1/2, 1/2, 3/2.
+
+In the magnetic case with spin-orbit the atomic wavefunctions
+can be forced to be spin-angle functions by setting
+<ref>starting_spin_angle</ref> to .TRUE..
+         </info>
+      </var>
+      <var name="starting_spin_angle" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+In the spin-orbit case when <ref>domag</ref>=.TRUE., by default,
+the starting wavefunctions are initialized as in scalar
+relativistic noncollinear case without spin-orbit.
+
+By setting <ref>starting_spin_angle</ref>=.TRUE. this behaviour can
+be changed and the initial wavefunctions are radial
+functions multiplied by spin-angle functions.
+
+When <ref>domag</ref>=.FALSE. the initial wavefunctions are always
+radial functions multiplied by spin-angle functions
+independently from this flag.
+
+When <ref>lspinorb</ref> is .FALSE. this flag is not used.
+         </info>
+      </var>
+      <var name="degauss" type="REAL" >
+         <default> 0.D0 Ry
+         </default>
+         <info>
+value of the gaussian spreading (Ry) for brillouin-zone
+integration in metals.
+         </info>
+      </var>
+      <var name="smearing" type="CHARACTER" >
+         <default> &apos;gaussian&apos;
+         </default>
+         <options>
+            <info>
+Available options are:
+            </info>
+            <opt val="'gaussian', 'gauss'" >
+ordinary Gaussian spreading (Default)
+            </opt>
+            <opt val="'methfessel-paxton', 'm-p', 'mp'" >
+Methfessel-Paxton first-order spreading
+(see <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.40.3616">PRB 40, 3616 (1989)</a>).
+            </opt>
+            <opt val="'marzari-vanderbilt', 'cold', 'm-v', 'mv'" >
+Marzari-Vanderbilt cold smearing
+(see <a href="https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.82.3296">PRL 82, 3296 (1999)</a>)
+            </opt>
+            <opt val="'fermi-dirac', 'f-d', 'fd'" >
+smearing with Fermi-Dirac function
+            </opt>
+         </options>
+      </var>
+      <var name="nspin" type="INTEGER" >
+         <default> 1
+         </default>
+         <info>
+nspin = 1 :  non-polarized calculation (default)
+
+nspin = 2 :  spin-polarized calculation, LSDA
+             (magnetization along z axis)
+
+nspin = 4 :  spin-polarized calculation, noncollinear
+             (magnetization in generic direction)
+             DO NOT specify <ref>nspin</ref> in this case;
+             specify <ref>noncolin</ref>=.TRUE. instead
+         </info>
+      </var>
+      <var name="noncolin" type="LOGICAL" >
+         <default> .false.
+         </default>
+         <info>
+if .true. the program will perform a noncollinear calculation.
+         </info>
+      </var>
+      <var name="ecfixed" type="REAL" >
+         <default> 0.0
+         </default>
+         <see> q2sigma
+         </see>
+      </var>
+      <var name="qcutz" type="REAL" >
+         <default> 0.0
+         </default>
+         <see> q2sigma
+         </see>
+      </var>
+      <var name="q2sigma" type="REAL" >
+         <default> 0.1
+         </default>
+         <info>
+ecfixed, qcutz, q2sigma:  parameters for modified functional to be
+used in variable-cell molecular dynamics (or in stress calculation).
+&quot;ecfixed&quot; is the value (in Rydberg) of the constant-cutoff;
+&quot;qcutz&quot; and &quot;q2sigma&quot; are the height and the width (in Rydberg)
+of the energy step for reciprocal vectors whose square modulus
+is greater than &quot;ecfixed&quot;. In the kinetic energy, G^2 is
+replaced by G^2 + qcutz * (1 + erf ( (G^2 - ecfixed)/q2sigma) )
+See: M. Bernasconi et al, J. Phys. Chem. Solids 56, 501 (1995),
+<a href="http://dx.doi.org/10.1016/0022-3697(94)00228-2">doi:10.1016/0022-3697(94)00228-2</a>
+         </info>
+      </var>
+      <var name="input_dft" type="CHARACTER" >
+         <default> read from pseudopotential files
+         </default>
+         <info>
+Exchange-correlation functional: eg &apos;PBE&apos;, &apos;BLYP&apos; etc
+See Modules/funct.f90 for allowed values.
+Overrides the value read from pseudopotential files.
+Use with care and if you know what you are doing!
+         </info>
+      </var>
+      <var name="exx_fraction" type="REAL" >
+         <default> it depends on the specified functional
+         </default>
+         <info>
+Fraction of EXX for hybrid functional calculations. In the case of
+<ref>input_dft</ref>=&apos;PBE0&apos;, the default value is 0.25, while for <ref>input_dft</ref>=&apos;B3LYP&apos;
+the <ref>exx_fraction</ref> default value is 0.20.
+         </info>
+      </var>
+      <var name="screening_parameter" type="REAL" >
+         <default> 0.106
+         </default>
+         <info>
+screening_parameter for HSE like hybrid functionals.
+For more information, see:
+J. Chem. Phys. 118, 8207 (2003), <a href="http://dx.doi.org/10.1063/1.1564060">doi:10.1063/1.1564060</a>
+J. Chem. Phys. 124, 219906 (2006), <a href="http://dx.doi.org/10.1063/1.2204597">doi:10.1063/1.2204597</a>
+         </info>
+      </var>
+      <var name="exxdiv_treatment" type="CHARACTER" >
+         <default> &apos;gygi-baldereschi&apos;
+         </default>
+         <options>
+            <info>
+Specific for EXX. It selects the kind of approach to be used
+for treating the Coulomb potential divergencies at small q vectors.
+            </info>
+            <opt val="'gygi-baldereschi'" > appropriate for cubic and quasi-cubic supercells
+            </opt>
+            <opt val="'vcut_spherical'" > appropriate for cubic and quasi-cubic supercells
+            </opt>
+            <opt val="'vcut_ws'" > appropriate for strongly anisotropic supercells, see also <ref>ecutvcut</ref>.
+            </opt>
+            <opt val="'none'" > sets Coulomb potential at G,q=0 to 0.0 (required for GAU-PBE)
+            </opt>
+         </options>
+      </var>
+      <var name="x_gamma_extrapolation" type="LOGICAL" >
+         <default> .true.
+         </default>
+         <info>
+Specific for EXX. If .true., extrapolate the G=0 term of the
+potential (see README in examples/EXX_example for more)
+Set this to .false. for GAU-PBE.
+         </info>
+      </var>
+      <var name="ecutvcut" type="REAL" >
+         <default> 0.0 Ry
+         </default>
+         <see> exxdiv_treatment
+         </see>
+         <info>
+Reciprocal space cutoff for correcting Coulomb potential
+divergencies at small q vectors.
+         </info>
+      </var>
+      <vargroup type="INTEGER" >
+         <var name="nqx1" >
+         </var>
+         <var name="nqx2" >
+         </var>
+         <var name="nqx3" >
+         </var>
+         <info>
+Three-dimensional mesh for q (k1-k2) sampling of
+the Fock operator (EXX). Can be smaller than
+the number of k-points.
+
+Currently this defaults to the size of the k-point mesh used.
+In QE =&lt; 5.0.2 it defaulted to nqx1=nqx2=nqx3=1.
+         </info>
+      </vargroup>
+      <var name="lda_plus_u" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <status>
+DFT+U (formerly known as LDA+U) currently works only for
+a few selected elements. Modify <tt>Modules/set_hubbard_l.f90</tt> and
+<tt>PW/src/tabd.f90</tt> if you plan to use DFT+U with an element that
+is not configured there.
+         </status>
+         <info>
+Specify <ref>lda_plus_u</ref> = .TRUE. to enable DFT+U calculations
+See: Anisimov, Zaanen, and Andersen, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.44.943">PRB 44, 943 (1991)</a>;
+     Anisimov et al., <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.48.16929">PRB 48, 16929 (1993)</a>;
+     Liechtenstein, Anisimov, and Zaanen, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.52.R5467">PRB 52, R5467 (1994)</a>.
+You must specify, for each species with a U term, the value of
+U and (optionally) alpha, J of the Hubbard model (all in eV):
+see <ref>lda_plus_u_kind</ref>, <ref>Hubbard_U</ref>, <ref>Hubbard_alpha</ref>, <ref>Hubbard_J</ref>
+         </info>
+      </var>
+      <var name="lda_plus_u_kind" type="INTEGER" >
+         <default> 0
+         </default>
+         <info>
+Specifies the type of DFT+U calculation:
+
+   0   simplified version of Cococcioni and de Gironcoli,
+       <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.71.035105">PRB 71, 035105 (2005)</a>, using <ref>Hubbard_U</ref>
+
+   1   rotationally invariant scheme of Liechtenstein et al.,
+       using <ref>Hubbard_U</ref> and <ref>Hubbard_J</ref>
+         </info>
+      </var>
+      <dimension name="Hubbard_U" start="1" end="ntyp" type="REAL" >
+         <default> 0.D0 for all species
+         </default>
+         <info>
+Hubbard_U(i): U parameter (eV) for species i, DFT+U calculation
+         </info>
+      </dimension>
+      <dimension name="Hubbard_J0" start="1" end="ntype" type="REAL" >
+         <default> 0.D0 for all species
+         </default>
+         <info>
+Hubbard_J0(i): J0 parameter (eV) for species i, DFT+U+J calculation,
+see <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.84.115108">PRB 84, 115108 (2011)</a> for details.
+         </info>
+      </dimension>
+      <dimension name="Hubbard_alpha" start="1" end="ntyp" type="REAL" >
+         <default> 0.D0 for all species
+         </default>
+         <info>
+Hubbard_alpha(i) is the perturbation (on atom i, in eV)
+used to compute U with the linear-response method of
+Cococcioni and de Gironcoli, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.71.035105">PRB 71, 035105 (2005)</a>
+(only for <ref>lda_plus_u_kind</ref>=0)
+         </info>
+      </dimension>
+      <dimension name="Hubbard_beta" start="1" end="ntyp" type="REAL" >
+         <default> 0.D0 for all species
+         </default>
+         <info>
+Hubbard_beta(i) is the perturbation (on atom i, in eV)
+used to compute J0 with the linear-response method of
+Cococcioni and de Gironcoli, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.71.035105">PRB 71, 035105 (2005)</a>
+(only for <ref>lda_plus_u_kind</ref>=0). See also
+<a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.84.115108">PRB 84, 115108 (2011)</a>.
+         </info>
+      </dimension>
+      <var name="Hubbard_J(i,ityp)" >
+         <default> 0.D0 for all species
+         </default>
+         <info>
+Hubbard_J(i,ityp): J parameters (eV) for species ityp,
+used in DFT+U calculations (only for <ref>lda_plus_u_kind</ref>=1)
+For p orbitals:  J = Hubbard_J(1,ityp);
+For d orbitals:  J = Hubbard_J(1,ityp), B = Hubbard_J(2,ityp);
+For f orbitals:  J = Hubbard_J(1,ityp), E2 = Hubbard_J(2,ityp),
+                 E3= Hubbard_J(3,ityp).
+If B or E2 or E3 are not specified or set to 0 they will be
+calculated from J using atomic ratios.
+         </info>
+      </var>
+      <var name="starting_ns_eigenvalue(m,ispin,I)" type="REAL" >
+         <default> -1.d0 that means NOT SET
+         </default>
+         <info>
+In the first iteration of an DFT+U run it overwrites
+the m-th eigenvalue of the ns occupation matrix for the
+ispin component of atomic species I. Leave unchanged
+eigenvalues that are not set. This is useful to suggest
+the desired orbital occupations when the default choice
+takes another path.
+         </info>
+      </var>
+      <var name="U_projection_type" type="CHARACTER" >
+         <default> &apos;atomic&apos;
+         </default>
+         <options>
+            <info>
+Only active when <ref>lda_plus_U</ref> is .true., specifies the type
+of projector on localized orbital to be used in the DFT+U
+scheme.
+
+Currently available choices:
+            </info>
+            <opt val="'atomic'" > use atomic wfc&apos;s (as they are) to build the projector
+            </opt>
+            <opt val="'ortho-atomic'" > use Lowdin orthogonalized atomic wfc&apos;s
+            </opt>
+            <opt val="'norm-atomic'" >
+Lowdin normalization of atomic wfc. Keep in mind:
+atomic wfc are not orthogonalized in this case.
+This is a &quot;quick and dirty&quot; trick to be used when
+atomic wfc from the pseudopotential are not
+normalized (and thus produce occupation whose
+value exceeds unity). If orthogonalized wfc are
+not needed always try <b>&apos;atomic&apos;</b> first.
+            </opt>
+            <opt val="'file'" >
+use the information from file &quot;prefix&quot;.atwfc that must
+have been generated previously, for instance by pmw.x
+(see PP/src/poormanwannier.f90 for details).
+            </opt>
+            <opt val="'pseudo'" >
+use the pseudopotential projectors. The charge density
+outside the atomic core radii is excluded.
+N.B.: for atoms with +U, a pseudopotential with the
+all-electron atomic wavefunctions is required (i.e.,
+as generated by ld1.x with lsave_wfc flag).
+            </opt>
+            <info>
+NB: forces and stress currently implemented only for the
+&apos;atomic&apos; and &apos;pseudo&apos; choice.
+            </info>
+         </options>
+      </var>
+      <var name="edir" type="INTEGER" >
+         <info>
+The direction of the electric field or dipole correction is
+parallel to the bg(:,edir) reciprocal lattice vector, so the
+potential is constant in planes defined by FFT grid points;
+<ref>edir</ref> = 1, 2 or 3. Used only if <ref>tefield</ref> is .TRUE.
+         </info>
+      </var>
+      <var name="emaxpos" type="REAL" >
+         <default> 0.5D0
+         </default>
+         <info>
+Position of the maximum of the saw-like potential along crystal
+axis <ref>edir</ref>, within the  unit cell (see below), 0 &lt; emaxpos &lt; 1
+Used only if <ref>tefield</ref> is .TRUE.
+         </info>
+      </var>
+      <var name="eopreg" type="REAL" >
+         <default> 0.1D0
+         </default>
+         <info>
+Zone in the unit cell where the saw-like potential decreases.
+( see below, 0 &lt; eopreg &lt; 1 ). Used only if <ref>tefield</ref> is .TRUE.
+         </info>
+      </var>
+      <var name="eamp" type="REAL" >
+         <default> 0.001 a.u.
+         </default>
+         <info>
+Amplitude of the electric field, in ***Hartree*** a.u.;
+1 a.u. = 51.4220632*10^10 V/m. Used only if <ref>tefield</ref>==.TRUE.
+The saw-like potential increases with slope <ref>eamp</ref> in the
+region from (<ref>emaxpos</ref>+<ref>eopreg</ref>-1) to (<ref>emaxpos</ref>), then decreases
+to 0 until (<ref>emaxpos</ref>+<ref>eopreg</ref>), in units of the crystal
+vector <ref>edir</ref>. Important: the change of slope of this
+potential must be located in the empty region, or else
+unphysical forces will result.
+         </info>
+      </var>
+      <dimension name="angle1" start="1" end="ntyp" type="REAL" >
+         <info>
+The angle expressed in degrees between the initial
+magnetization and the z-axis. For noncollinear calculations
+only; index i runs over the atom types.
+         </info>
+      </dimension>
+      <dimension name="angle2" start="1" end="ntyp" type="REAL" >
+         <info>
+The angle expressed in degrees between the projection
+of the initial magnetization on x-y plane and the x-axis.
+For noncollinear calculations only.
+         </info>
+      </dimension>
+      <var name="lforcet" type="LOGICAL" >
+         <info>
+When starting a non collinear calculation using an existing density
+                      file from a collinear lsda calculation assumes previous density points in
+                      z direction and rotates is in the direction described by <ref>angle1</ref> and
+                      <ref>angle2</ref> variables for atomic type 1
+         </info>
+      </var>
+      <var name="constrained_magnetization" type="CHARACTER" >
+         <see> lambda, fixed_magnetization
+         </see>
+         <default> &apos;none&apos;
+         </default>
+         <options>
+            <info>
+Used to perform constrained calculations in magnetic systems.
+Currently available choices:
+            </info>
+            <opt val="'none'" >
+no constraint
+            </opt>
+            <opt val="'total'" >
+total magnetization is constrained by
+adding a penalty functional to the total energy:
+
+LAMBDA * SUM_{i} ( magnetization(i) - fixed_magnetization(i) )**2
+
+where the sum over i runs over the three components of
+the magnetization. Lambda is a real number (see below).
+Noncolinear case only. Use <ref>tot_magnetization</ref> for LSDA
+            </opt>
+            <opt val="'atomic'" >
+atomic magnetization are constrained to the defined
+starting magnetization adding a penalty:
+
+LAMBDA * SUM_{i,itype} ( magnetic_moment(i,itype) - mcons(i,itype) )**2
+
+where i runs over the cartesian components (or just z
+in the collinear case) and itype over the types (1-ntype).
+mcons(:,:) array is defined from starting_magnetization,
+(and angle1, angle2 in the non-collinear case). lambda is
+a real number
+            </opt>
+            <opt val="'total direction'" >
+the angle theta of the total magnetization
+with the z axis (theta = fixed_magnetization(3))
+is constrained:
+
+LAMBDA * ( arccos(magnetization(3)/mag_tot) - theta )**2
+
+where mag_tot is the modulus of the total magnetization.
+            </opt>
+            <opt val="'atomic direction'" >
+not all the components of the atomic
+magnetic moment are constrained but only the cosine
+of angle1, and the penalty functional is:
+
+LAMBDA * SUM_{itype} ( mag_mom(3,itype)/mag_mom_tot - cos(angle1(ityp)) )**2
+            </opt>
+            <info>
+N.B.: symmetrization may prevent to reach the desired orientation
+of the magnetization. Try not to start with very highly symmetric
+configurations or use the nosym flag (only as a last remedy)
+            </info>
+         </options>
+      </var>
+      <dimension name="fixed_magnetization" start="1" end="3" type="REAL" >
+         <see> constrained_magnetization
+         </see>
+         <default> 0.d0
+         </default>
+         <info>
+total magnetization vector (x,y,z components) to be kept
+fixed when <ref>constrained_magnetization</ref>==&apos;total&apos;
+         </info>
+      </dimension>
+      <var name="lambda" type="REAL" >
+         <see> constrained_magnetization
+         </see>
+         <default> 1.d0
+         </default>
+         <info>
+parameter used for constrained_magnetization calculations
+N.B.: if the scf calculation does not converge, try to reduce lambda
+      to obtain convergence, then restart the run with a larger lambda
+         </info>
+      </var>
+      <var name="report" type="INTEGER" >
+         <default> 100
+         </default>
+         <info>
+Number of iterations after which the program
+writes all the atomic magnetic moments.
+         </info>
+      </var>
+      <var name="lspinorb" type="LOGICAL" >
+         <info>
+if .TRUE. the noncollinear code can use a pseudopotential with
+spin-orbit.
+         </info>
+      </var>
+      <var name="assume_isolated" type="CHARACTER" >
+         <default> &apos;none&apos;
+         </default>
+         <options>
+            <info>
+Used to perform calculation assuming the system to be
+isolated (a molecule or a cluster in a 3D supercell).
+
+Currently available choices:
+            </info>
+            <opt val="'none'" >
+(default): regular periodic calculation w/o any correction.
+            </opt>
+            <opt val="'makov-payne', 'm-p', 'mp'" >
+the Makov-Payne correction to the
+total energy is computed. An estimate of the vacuum
+level is also calculated so that eigenvalues can be
+properly aligned. ONLY FOR CUBIC SYSTEMS (<ref>ibrav</ref>=1,2,3).
+Theory: G.Makov, and M.C.Payne,
+     &quot;Periodic boundary conditions in ab initio
+     calculations&quot; , <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.51.4014">PRB 51, 4014 (1995)</a>.
+            </opt>
+            <opt val="'martyna-tuckerman', 'm-t', 'mt'" >
+Martyna-Tuckerman correction
+to both total energy and scf potential. Adapted from:
+G.J. Martyna, and M.E. Tuckerman,
+&quot;A reciprocal space based method for treating long
+range interactions in ab-initio and force-field-based
+calculation in clusters&quot;, J. Chem. Phys. 110, 2810 (1999),
+<a href="http://dx.doi.org/10.1063/1.477923">doi:10.1063/1.477923</a>.
+            </opt>
+            <opt val="'esm'" >
+Effective Screening Medium Method.
+For polarized or charged slab calculation, embeds
+the simulation cell within an effective semi-
+infinite medium in the perpendicular direction
+(along z). Embedding regions can be vacuum or
+semi-infinite metal electrodes (use <ref>esm_bc</ref> to
+choose boundary conditions). If between two
+electrodes, an optional electric field
+(&apos;esm_efield&apos;) may be applied. Method described in
+M. Otani and O. Sugino, &quot;First-principles calculations
+of charged surfaces and interfaces: A plane-wave
+nonrepeated slab approach&quot;, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.73.115407">PRB 73, 115407 (2006)</a>.
+
+NB:
+   - Two dimensional (xy plane) average charge density
+     and electrostatic potentials are printed out to
+     &apos;prefix.esm1&apos;.
+
+   - Requires cell with a_3 lattice vector along z,
+     normal to the xy plane, with the slab centered
+     around z=0. Also requires symmetry checking to be
+     disabled along z, either by setting <ref>nosym</ref> = .TRUE.
+     or by very slight displacement (i.e., 5e-4 a.u.)
+     of the slab along z.
+
+   - Components of the total stress; sigma_xy, sigma_yz,
+     sigma_zz, sigma_zy, and sigma_zx are meaningless
+     because ESM stress routines calculate only
+     components of stress; sigma_xx, sigma_xy, sigma_yx,
+     and sigma_yy.
+
+   - In case of calculation=&apos;vc-relax&apos;, use
+     cell_dofree=&apos;2Dxy&apos; or other parameters so that
+     c-vector along z-axis should not be moved.
+
+See <ref>esm_bc</ref>, <ref>esm_efield</ref>, <ref>esm_w</ref>, <ref>esm_nfit</ref>.
+            </opt>
+            <opt val="'2D'" >
+        Truncation of the Coulomb interaction in the z direction
+        for structures periodic in the x-y plane. Total energy,
+        forces and stresses are computed in a two-dimensional framework.
+        Linear-response calculations () done on top of a self-consistent
+        calculation with this flag will automatically be performed in
+        the 2D framework as well. Please refer to:
+        Sohier, T., Calandra, M., &amp; Mauri, F. (2017), Density functional
+        perturbation theory for gated two-dimensional heterostructures:
+        Theoretical developments and application to flexural phonons in graphene.
+        Physical Review B, 96(7), 75448. <link>https://doi.org/10.1103/PhysRevB.96.075448</link>
+NB:
+           - The length of the unit-cell along the z direction should
+             be larger than twice the thickness of the 2D material
+             (including electrons). A reasonable estimate for a
+             layer&apos;s thickness could be the interlayer distance in the
+             corresponding layered bulk material. Otherwise,
+             the atomic thickness + 10 bohr should be a safe estimate.
+             There is also a lower limit of 20 bohr imposed by the cutoff
+             radius used to read pseudopotentials (see read_pseudo.f90 in Modules).
+
+           - As for ESM above, only in-plane stresses make sense and one
+             should use cell_dofree=&apos;2Dxy&apos; in a vc-relax calculation.
+            </opt>
+         </options>
+      </var>
+      <var name="esm_bc" type="CHARACTER" >
+         <see> assume_isolated
+         </see>
+         <default> &apos;pbc&apos;
+         </default>
+         <options>
+            <info>
+If <ref>assume_isolated</ref> = &apos;esm&apos;, determines the boundary
+conditions used for either side of the slab.
+
+Currently available choices:
+            </info>
+            <opt val="'pbc'" > (default): regular periodic calculation (no ESM).
+            </opt>
+            <opt val="'bc1'" > Vacuum-slab-vacuum (open boundary conditions).
+            </opt>
+            <opt val="'bc2'" >
+Metal-slab-metal (dual electrode configuration).
+See also <ref>esm_efield</ref>.
+            </opt>
+            <opt val="'bc3'" > Vacuum-slab-metal
+            </opt>
+         </options>
+      </var>
+      <var name="esm_w" type="REAL" >
+         <see> assume_isolated
+         </see>
+         <default> 0.d0
+         </default>
+         <info>
+If <ref>assume_isolated</ref> = &apos;esm&apos;, determines the position offset
+[in a.u.] of the start of the effective screening region,
+measured relative to the cell edge. (ESM region begins at
+z = +/- [L_z/2 + esm_w] ).
+         </info>
+      </var>
+      <var name="esm_efield" type="REAL" >
+         <see> assume_isolated
+         </see>
+         <default> 0.d0
+         </default>
+         <info>
+If <ref>assume_isolated</ref> = &apos;esm&apos; and <ref>esm_bc</ref> = &apos;bc2&apos;, gives the
+magnitude of the electric field [Ry/a.u.] to be applied
+between semi-infinite ESM electrodes.
+         </info>
+      </var>
+      <var name="esm_nfit" type="INTEGER" >
+         <see> assume_isolated
+         </see>
+         <default> 4
+         </default>
+         <info>
+If <ref>assume_isolated</ref> = &apos;esm&apos;, gives the number of z-grid points
+for the polynomial fit along the cell edge.
+         </info>
+      </var>
+      <var name="fcp_mu" type="REAL" >
+         <see> lfcpopt
+         </see>
+         <default> 0.d0
+         </default>
+         <info>
+If <ref>lfcpopt</ref> = .TRUE., gives the target Fermi energy [Ry]. One can start
+with appropriate total charge of the system by giving &apos;tot_charge&apos;.
+         </info>
+      </var>
+      <var name="vdw_corr" type="CHARACTER" >
+         <default> &apos;none&apos;
+         </default>
+         <see>
+london_s6, london_rcut, london_c6, london_rvdw,
+dftd3_version, dftd3_threebody, ts_vdw_econv_thr, ts_vdw_isolated, xdm_a1, xdm_a2
+         </see>
+         <options>
+            <info>
+Type of Van der Waals correction. Allowed values:
+            </info>
+            <opt val="'grimme-d2', 'Grimme-D2', 'DFT-D', 'dft-d', 'grimme-d3', 'Grimme-D3', 'DFT-D3', 'dft-d3' " >
+Semiempirical Grimme&apos;s DFT-D2 and DFT-D3.
+Optional variables for D2: <ref>london_s6</ref>, <ref>london_rcut</ref>, <ref>london_c6</ref>, <ref>london_rvdw</ref>,
+S. Grimme, J. Comp. Chem. 27, 1787 (2006), <a href="http://dx.doi.org/10.1002/jcc.20495">doi:10.1002/jcc.20495</a>
+V. Barone et al., J. Comp. Chem. 30, 934 (2009), <a href="http://dx.doi.org/10.1002/jcc.21112">doi:10.1002/jcc.21112</a>
+Optional variables for D3: <ref>dftd3_version</ref>, <ref>dftd3_threebody</ref>,
+S. Grimme et al, J. Chem. Phys 132, 154104 (2010)
+            </opt>
+            <opt val="'TS', 'ts', 'ts-vdw', 'ts-vdW', 'tkatchenko-scheffler'" >
+Tkatchenko-Scheffler dispersion corrections with first-principle derived
+C6 coefficients.
+Optional variables: <ref>ts_vdw_econv_thr</ref>, <ref>ts_vdw_isolated</ref>
+See A. Tkatchenko and M. Scheffler, <a href="https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.102.073005">PRL 102, 073005 (2009)</a>.
+            </opt>
+            <opt val="'XDM', 'xdm'" >
+Exchange-hole dipole-moment model. Optional variables: <ref>xdm_a1</ref>, <ref>xdm_a2</ref>
+A. D. Becke et al., J. Chem. Phys. 127, 154108 (2007), <a href="http://dx.doi.org/10.1063/1.2795701">doi:10.1063/1.2795701</a>
+A. Otero de la Roza et al., J. Chem. Phys. 136, 174109 (2012),
+<a href="http://dx.doi.org/10.1063/1.4705760">doi:10.1063/1.4705760</a>
+            </opt>
+            <info> Note that non-local functionals (eg vdw-DF) are NOT specified here but in <ref>input_dft</ref>
+            </info>
+         </options>
+      </var>
+      <var name="london" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <status>
+OBSOLESCENT, same as <ref>vdw_corr</ref>=&apos;DFT-D&apos;
+         </status>
+      </var>
+      <var name="london_s6" type="REAL" >
+         <default> 0.75
+         </default>
+         <info>
+global scaling parameter for DFT-D. Default is good for PBE.
+         </info>
+      </var>
+      <dimension name="london_c6" type="REAL" start="1" end="ntyp" >
+         <default> standard Grimme-D2 values
+         </default>
+         <info>
+atomic C6 coefficient of each atom type
+
+( if not specified default values from S. Grimme, J. Comp. Chem. 27, 1787 (2006),
+  <a href="http://dx.doi.org/10.1002/jcc.20495">doi:10.1002/jcc.20495</a> are used; see file Modules/mm_dispersion.f90 )
+         </info>
+      </dimension>
+      <dimension name="london_rvdw" type="REAL" start="1" end="ntyp" >
+         <default> standard Grimme-D2 values
+         </default>
+         <info>
+atomic vdw radii of each atom type
+
+( if not specified default values from S. Grimme, J. Comp. Chem. 27, 1787 (2006),
+  <a href="http://dx.doi.org/10.1002/jcc.20495">doi:10.1002/jcc.20495</a> are used; see file Modules/mm_dispersion.f90 )
+         </info>
+      </dimension>
+      <var name="london_rcut" type="REAL" >
+         <default> 200
+         </default>
+         <info>
+cutoff radius (a.u.) for dispersion interactions
+         </info>
+      </var>
+      <var name="dftd3_version" type="integer" >
+         <default> 3
+         </default>
+         <info>
+Version of Grimme implementation of Grimme-D3. Version=3 is Grimme-D3. Version=2
+is the original Grimme-D2 parametrization. NOTE: not all functionals are
+parametrized.
+         </info>
+      </var>
+      <var name="dftd3_threebody" type="LOGICAL" >
+         <default> TRUE
+         </default>
+         <info>
+Turn three-body terms in Grimme-D3 on. If .false. two-body contributions
+only are computed, using two-body parameters of Grimme-D3.
+If dftd3_version=2, three-body contribution is always disabled.
+         </info>
+      </var>
+      <var name="ts_vdw_econv_thr" type="REAL" >
+         <default> 1.D-6
+         </default>
+         <info>
+Optional: controls the convergence of the vdW energy (and forces). The default value
+is a safe choice, likely too safe, but you do not gain much in increasing it
+         </info>
+      </var>
+      <var name="ts_vdw_isolated" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+Optional: set it to .TRUE. when computing the Tkatchenko-Scheffler vdW energy
+for an isolated (non-periodic) system.
+         </info>
+      </var>
+      <var name="xdm" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <status>
+OBSOLESCENT, same as <ref>vdw_corr</ref>=&apos;xdm&apos;
+         </status>
+      </var>
+      <var name="xdm_a1" type="REAL" >
+         <default> 0.6836
+         </default>
+         <info>
+Damping function parameter a1 (adimensional). It is NOT necessary to give
+a value if the functional is one of B86bPBE, PW86PBE, PBE, BLYP. For functionals
+in this list, the coefficients are given in:
+   <link>http://schooner.chem.dal.ca/wiki/XDM</link>
+   A. Otero de la Roza, E. R. Johnson, J. Chem. Phys. 138, 204109 (2013),
+   <a href="http://dx.doi.org/10.1063/1.4705760">doi:10.1063/1.4705760</a>
+         </info>
+      </var>
+      <var name="xdm_a2" type="REAL" >
+         <default> 1.5045
+         </default>
+         <info>
+Damping function parameter a2 (angstrom). It is NOT necessary to give
+a value if the functional is one of B86bPBE, PW86PBE, PBE, BLYP. For functionals
+in this list, the coefficients are given in:
+   <link>http://schooner.chem.dal.ca/wiki/XDM</link>
+   A. Otero de la Roza, E. R. Johnson, J. Chem. Phys. 138, 204109 (2013),
+   <a href="http://dx.doi.org/10.1063/1.4705760">doi:10.1063/1.4705760</a>
+         </info>
+      </var>
+      <var name="space_group" type="INTEGER" >
+         <default> 0
+         </default>
+         <info>
+The number of the space group of the crystal, as given
+in the International Tables of Crystallography A (ITA).
+This allows to give in input only the inequivalent atomic
+positions. The positions of all the symmetry equivalent atoms
+are calculated by the code. Used only when the atomic positions
+are of type crystal_sg. See also <ref>uniqueb</ref>,
+<ref>origin_choice</ref>, <ref>rhombohedral</ref>
+         </info>
+      </var>
+      <var name="uniqueb" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+Used only for monoclinic lattices. If .TRUE. the b
+unique ibrav (-12 or -13) are used, and symmetry
+equivalent positions are chosen assuming that the
+two fold axis or the mirror normal is parallel to the
+b axis. If .FALSE. it is parallel to the c axis.
+         </info>
+      </var>
+      <var name="origin_choice" type="INTEGER" >
+         <default> 1
+         </default>
+         <info>
+Used only for space groups that in the ITA allow
+the use of two different origins. origin_choice=1,
+means the first origin, while origin_choice=2 is the
+second origin.
+         </info>
+      </var>
+      <var name="rhombohedral" type="LOGICAL" >
+         <default> .TRUE.
+         </default>
+         <info>
+Used only for rhombohedral space groups.
+When .TRUE. the coordinates of the inequivalent atoms are
+given with respect to the rhombohedral axes, when .FALSE.
+the coordinates of the inequivalent atoms are given with
+respect to the hexagonal axes. They are converted internally
+to the rhombohedral axes and <ref>ibrav</ref>=5 is used in both cases.
+         </info>
+      </var>
+      <group>
+         <label> variables used only if <ref>gate</ref> = .TRUE.
+         </label>
+         <var name="zgate" type="REAL" >
+            <default> 0.5
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE.
+Specifies the position of the charged plate which represents
+the counter charge in doped systems (<ref>tot_charge</ref> .ne. 0).
+In units of the unit cell length in <i>z</i> direction, <ref>zgate</ref> in ]0,1[
+Details of the gate potential can be found in
+T. Brumme, M. Calandra, F. Mauri; <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.89.245406">PRB 89, 245406 (2014)</a>.
+            </info>
+         </var>
+         <var name="relaxz" type="LOGICAL" >
+            <default> .FALSE.
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE.
+Allows the relaxation of the system towards the charged plate.
+Use carefully and utilize either a layer of fixed atoms or a
+potential barrier (<ref>block</ref>=.TRUE.) to avoid the atoms moving to
+the position of the plate or the dipole of the dipole
+correction (<ref>dipfield</ref>=.TRUE.).
+            </info>
+         </var>
+         <var name="block" type="LOGICAL" >
+            <default> .FALSE.
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE.
+Adds a potential barrier to the total potential seen by the
+electrons to mimic a dielectric in field effect configuration
+and/or to avoid electrons spilling into the vacuum region for
+electron doping. Potential barrier is from <ref>block_1</ref> to <ref>block_2</ref> and
+has a height of block_height.
+If <ref>dipfield</ref> = .TRUE. then <ref>eopreg</ref> is used for a smooth increase and
+decrease of the potential barrier.
+            </info>
+         </var>
+         <var name="block_1" type="REAL" >
+            <default> 0.45
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE. and <ref>block</ref> = .TRUE.
+lower beginning of the potential barrier, in units of the
+unit cell size along <i>z,</i> <ref>block_1</ref> in ]0,1[
+            </info>
+         </var>
+         <var name="block_2" type="REAL" >
+            <default> 0.55
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE. and <ref>block</ref> = .TRUE.
+upper beginning of the potential barrier, in units of the
+unit cell size along <i>z,</i> <ref>block_2</ref> in ]0,1[
+            </info>
+         </var>
+         <var name="block_height" type="REAL" >
+            <default> 0.1
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE. and <ref>block</ref> = .TRUE.
+Height of the potential barrier in Rydberg.
+            </info>
+         </var>
+      </group>
+   </namelist>
+   <namelist name="ELECTRONS" >
+      <var name="electron_maxstep" type="INTEGER" >
+         <default> 100
+         </default>
+         <info>
+maximum number of iterations in a scf step
+         </info>
+      </var>
+      <var name="scf_must_converge" type="LOGICAL" >
+         <default> .TRUE.
+         </default>
+         <info>
+If .false. do not stop molecular dynamics or ionic relaxation
+when electron_maxstep is reached. Use with care.
+         </info>
+      </var>
+      <var name="conv_thr" type="REAL" >
+         <default> 1.D-6
+         </default>
+         <info>
+Convergence threshold for selfconsistency:
+   estimated energy error &lt; conv_thr
+(note that conv_thr is extensive, like the total energy).
+
+For non-self-consistent calculations, conv_thr is used
+to set the default value of the threshold (ethr) for
+iterative diagonalizazion: see <ref>diago_thr_init</ref>
+         </info>
+      </var>
+      <var name="adaptive_thr" type="LOGICAL" >
+         <default> .FALSE
+         </default>
+         <info>
+If .TRUE. this turns on the use of an adaptive <ref>conv_thr</ref> for
+the inner scf loops when using EXX.
+         </info>
+      </var>
+      <var name="conv_thr_init" type="REAL" >
+         <default> 1.D-3
+         </default>
+         <info>
+When <ref>adaptive_thr</ref> = .TRUE. this is the convergence threshold
+used for the first scf cycle.
+         </info>
+      </var>
+      <var name="conv_thr_multi" type="REAL" >
+         <default> 1.D-1
+         </default>
+         <info>
+When <ref>adaptive_thr</ref> = .TRUE. the convergence threshold for
+each scf cycle is given by:
+max( <ref>conv_thr</ref>, <ref>conv_thr_multi</ref> * dexx )
+         </info>
+      </var>
+      <var name="mixing_mode" type="CHARACTER" >
+         <default> &apos;plain&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'plain'" > charge density Broyden mixing
+            </opt>
+            <opt val="'TF'" >
+as above, with simple Thomas-Fermi screening
+(for highly homogeneous systems)
+            </opt>
+            <opt val="'local-TF'" >
+as above, with local-density-dependent TF screening
+(for highly inhomogeneous systems)
+            </opt>
+         </options>
+      </var>
+      <var name="mixing_beta" type="REAL" >
+         <default> 0.7D0
+         </default>
+         <info>
+mixing factor for self-consistency
+         </info>
+      </var>
+      <var name="mixing_ndim" type="INTEGER" >
+         <default> 8
+         </default>
+         <info>
+number of iterations used in mixing scheme.
+If you are tight with memory, you may reduce it to 4 or so.
+         </info>
+      </var>
+      <var name="mixing_fixed_ns" type="INTEGER" >
+         <default> 0
+         </default>
+         <info>
+For DFT+U : number of iterations with fixed ns ( ns is the
+atomic density appearing in the Hubbard term ).
+         </info>
+      </var>
+      <var name="diagonalization" type="CHARACTER" >
+         <default> &apos;david&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'david'" >
+Davidson iterative diagonalization with overlap matrix
+(default). Fast, may in some rare cases fail.
+            </opt>
+            <opt val="'cg'" >
+Conjugate-gradient-like band-by-band diagonalization.
+Slower than &apos;david&apos; but uses less memory and is
+(a little bit) more robust.
+            </opt>
+            <opt val="'cg-serial', 'david-serial'" >
+OBSOLETE, use <b>-ndiag 1</b> instead.
+The subspace diagonalization in Davidson is performed
+by a fully distributed-memory parallel algorithm on
+4 or more processors, by default. The allocated memory
+scales down with the number of procs. Procs involved
+in diagonalization can be changed with command-line
+option <b>-ndiag</b> <i>N.</i> On multicore CPUs it is often
+convenient to let just one core per CPU to work
+on linear algebra.
+            </opt>
+         </options>
+      </var>
+      <var name="ortho_para" type="INTEGER" >
+         <default> 0
+         </default>
+         <status> OBSOLETE: use command-line option <tt>&quot;-ndiag XX&quot;</tt> instead
+         </status>
+      </var>
+      <var name="diago_thr_init" type="REAL" >
+         <info>
+Convergence threshold (ethr) for iterative diagonalization
+(the check is on eigenvalue convergence).
+
+For scf calculations: default is 1.D-2 if starting from a
+superposition of atomic orbitals; 1.D-5 if starting from a
+charge density. During self consistency the threshold
+is automatically reduced (but never below 1.D-13) when
+approaching convergence.
+
+For non-scf calculations: default is (<ref>conv_thr</ref>/N elec)/10.
+         </info>
+      </var>
+      <var name="diago_cg_maxiter" type="INTEGER" >
+         <info>
+For conjugate gradient diagonalization:  max number of iterations
+         </info>
+      </var>
+      <var name="diago_david_ndim" type="INTEGER" >
+         <default> 4
+         </default>
+         <info>
+For Davidson diagonalization: dimension of workspace
+(number of wavefunction packets, at least 2 needed).
+A larger value may yield a smaller number of iterations in
+the algorithm but uses more memory and more CPU time in
+subspace diagonalization.
+Try <ref>diago_david_ndim</ref>=2 if you are tight on memory or if
+the time spent in subspace diagonalization (cdiaghg/rdiaghg)
+is significant compared to the time spent in h_psi
+         </info>
+      </var>
+      <var name="diago_full_acc" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. all the empty states are diagonalized at the same level
+of accuracy of the occupied ones. Otherwise the empty states are
+diagonalized using a larger threshold (this should not affect
+total energy, forces, and other ground-state properties).
+         </info>
+      </var>
+      <var name="efield" type="REAL" >
+         <default> 0.D0
+         </default>
+         <info>
+Amplitude of the finite electric field (in Ry a.u.;
+1 a.u. = 36.3609*10^10 V/m). Used only if <ref>lelfield</ref>==.TRUE.
+and if k-points (<ref>K_POINTS</ref> card) are not automatic.
+         </info>
+      </var>
+      <dimension name="efield_cart" start="1" end="3" type="REAL" >
+         <default> (0.D0, 0.D0, 0.D0)
+         </default>
+         <info>
+Finite electric field (in Ry a.u.=36.3609*10^10 V/m) in
+cartesian axis. Used only if <ref>lelfield</ref>==.TRUE. and if
+k-points (<ref>K_POINTS</ref> card) are automatic.
+         </info>
+      </dimension>
+      <var name="efield_phase" type="CHARACTER" >
+         <default> &apos;none&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'read'" >
+set the zero of the electronic polarization (with <ref>lelfield</ref>==.true..)
+to the result of a previous calculation
+            </opt>
+            <opt val="'write'" >
+write on disk data on electronic polarization to be read in another
+calculation
+            </opt>
+            <opt val="'none'" >
+none of the above points
+            </opt>
+         </options>
+      </var>
+      <var name="startingpot" type="CHARACTER" >
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'atomic'" >
+starting potential from atomic charge superposition
+(default for scf, *relax, *md)
+            </opt>
+            <opt val="'file'" >
+start from existing &quot;charge-density.xml&quot; file in the
+directory specified by variables <ref>prefix</ref> and <ref>outdir</ref>
+For nscf and bands calculation this is the default
+and the only sensible possibility.
+            </opt>
+         </options>
+      </var>
+      <var name="startingwfc" type="CHARACTER" >
+         <default> &apos;atomic+random&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'atomic'" >
+Start from superposition of atomic orbitals.
+If not enough atomic orbitals are available,
+fill with random numbers the remaining wfcs
+The scf typically starts better with this option,
+but in some high-symmetry cases one can &quot;loose&quot;
+valence states, ending up in the wrong ground state.
+            </opt>
+            <opt val="'atomic+random'" >
+As above, plus a superimposed &quot;randomization&quot;
+of atomic orbitals. Prevents the &quot;loss&quot; of states
+mentioned above.
+            </opt>
+            <opt val="'random'" >
+Start from random wfcs. Slower start of scf but safe.
+It may also reduce memory usage in conjunction with
+<ref>diagonalization</ref>=&apos;cg&apos;.
+            </opt>
+            <opt val="'file'" >
+Start from an existing wavefunction file in the
+directory specified by variables <ref>prefix</ref> and <ref>outdir</ref>.
+            </opt>
+         </options>
+      </var>
+      <var name="tqr" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .true., use the real-space algorithm for augmentation
+charges in ultrasoft pseudopotentials.
+Must faster execution of ultrasoft-related calculations,
+but numerically less accurate than the default algorithm.
+Use with care and after testing!
+         </info>
+      </var>
+   </namelist>
+   <namelist name="IONS" >
+      <label>
+input this namelist only if <ref>calculation</ref> == &apos;relax&apos;, &apos;md&apos;, &apos;vc-relax&apos;, or &apos;vc-md&apos;
+      </label>
+      <var name="ion_dynamics" type="CHARACTER" >
+         <options>
+            <info>
+Specify the type of ionic dynamics.
+
+For different type of calculation different possibilities are
+allowed and different default values apply:
+
+<b>CASE</b> ( <ref>calculation</ref> == &apos;relax&apos; )
+            </info>
+            <opt val="'bfgs'" >
+<b>(default)</b>  use BFGS quasi-newton algorithm,
+based on the trust radius procedure,
+for structural relaxation
+            </opt>
+            <opt val="'damp'" >
+use damped (quick-min Verlet)
+dynamics for structural relaxation
+Can be used for constrained
+optimisation: see <ref>CONSTRAINTS</ref> card
+            </opt>
+            <info>
+<b>CASE</b> ( <ref>calculation</ref> == &apos;md&apos; )
+            </info>
+            <opt val="'verlet'" >
+<b>(default)</b>  use Verlet algorithm to integrate
+Newton&apos;s equation. For constrained
+dynamics, see <ref>CONSTRAINTS</ref> card
+            </opt>
+            <opt val="'langevin'" >
+ion dynamics is over-damped Langevin
+            </opt>
+            <opt val="'langevin-smc'" >
+over-damped Langevin with Smart Monte Carlo:
+see R.J. Rossky, JCP, 69, 4628 (1978), <a href="http://dx.doi.org/10.1063/1.436415">doi:10.1063/1.436415</a>
+            </opt>
+            <info>
+<b>CASE</b> ( <ref>calculation</ref> == &apos;vc-relax&apos; )
+            </info>
+            <opt val="'bfgs'" >
+<b>(default)</b>  use BFGS quasi-newton algorithm;
+cell_dynamics must be &apos;bfgs&apos; too
+            </opt>
+            <opt val="'damp'" >
+use damped (Beeman) dynamics for
+structural relaxation
+            </opt>
+            <info>
+<b>CASE</b> ( <ref>calculation</ref> == &apos;vc-md&apos; )
+            </info>
+            <opt val="'beeman'" >
+<b>(default)</b>  use Beeman algorithm to integrate
+Newton&apos;s equation
+            </opt>
+         </options>
+      </var>
+      <var name="ion_positions" type="CHARACTER" >
+         <default> &apos;default&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'default'" >
+if restarting, use atomic positions read from the
+restart file; in all other cases, use atomic
+positions from standard input.
+            </opt>
+            <opt val="'from_input'" >
+restart the simulation with atomic positions read
+from standard input, even if restarting.
+            </opt>
+         </options>
+      </var>
+      <var name="pot_extrapolation" type="CHARACTER" >
+         <default> &apos;atomic&apos;
+         </default>
+         <options>
+            <info>
+Used to extrapolate the potential from preceding ionic steps.
+            </info>
+            <opt val="'none'" > no extrapolation
+            </opt>
+            <opt val="'atomic'" >
+extrapolate the potential as if it was a sum of
+atomic-like orbitals
+            </opt>
+            <opt val="'first_order'" >
+extrapolate the potential with first-order
+formula
+            </opt>
+            <opt val="'second_order'" >
+as above, with second order formula
+            </opt>
+            <info>
+Note: &apos;first_order&apos; and &apos;second-order&apos; extrapolation make sense
+only for molecular dynamics calculations
+            </info>
+         </options>
+      </var>
+      <var name="wfc_extrapolation" type="CHARACTER" >
+         <default> &apos;none&apos;
+         </default>
+         <options>
+            <info>
+Used to extrapolate the wavefunctions from preceding ionic steps.
+            </info>
+            <opt val="'none'" > no extrapolation
+            </opt>
+            <opt val="'first_order'" >
+extrapolate the wave-functions with first-order formula.
+            </opt>
+            <opt val="'second_order'" >
+as above, with second order formula.
+            </opt>
+            <info>
+Note: <b>&apos;first_order&apos;</b> and <b>&apos;second-order&apos;</b> extrapolation make sense
+only for molecular dynamics calculations
+            </info>
+         </options>
+      </var>
+      <var name="remove_rigid_rot" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+This keyword is useful when simulating the dynamics and/or the
+thermodynamics of an isolated system. If set to true the total
+torque of the internal forces is set to zero by adding new forces
+that compensate the spurious interaction with the periodic
+images. This allows for the use of smaller supercells.
+
+BEWARE: since the potential energy is no longer consistent with
+the forces (it still contains the spurious interaction with the
+repeated images), the total energy is not conserved anymore.
+However the dynamical and thermodynamical properties should be
+in closer agreement with those of an isolated system.
+Also the final energy of a structural relaxation will be higher,
+but the relaxation itself should be faster.
+         </info>
+      </var>
+      <group>
+         <label>
+variables used for molecular dynamics
+         </label>
+         <var name="ion_temperature" type="CHARACTER" >
+            <default> &apos;not_controlled&apos;
+            </default>
+            <options>
+               <info> Available options are:
+               </info>
+               <opt val="'rescaling'" >
+control ionic temperature via velocity rescaling
+(first method) see parameters <ref>tempw</ref>, <ref>tolp</ref>, and
+<ref>nraise</ref> (for VC-MD only). This rescaling method
+is the only one currently implemented in VC-MD
+               </opt>
+               <opt val="'rescale-v'" >
+control ionic temperature via velocity rescaling
+(second method) see parameters <ref>tempw</ref> and <ref>nraise</ref>
+               </opt>
+               <opt val="'rescale-T'" >
+control ionic temperature via velocity rescaling
+(third method) see parameter <ref>delta_t</ref>
+               </opt>
+               <opt val="'reduce-T'" >
+reduce ionic temperature every <ref>nraise</ref> steps
+by the (negative) value <ref>delta_t</ref>
+               </opt>
+               <opt val="'berendsen'" >
+control ionic temperature using &quot;soft&quot; velocity
+rescaling - see parameters <ref>tempw</ref> and <ref>nraise</ref>
+               </opt>
+               <opt val="'andersen'" >
+control ionic temperature using Andersen thermostat
+see parameters <ref>tempw</ref> and <ref>nraise</ref>
+               </opt>
+               <opt val="'initial'" >
+initialize ion velocities to temperature <ref>tempw</ref>
+and leave uncontrolled further on
+               </opt>
+               <opt val="'not_controlled'" >
+(default) ionic temperature is not controlled
+               </opt>
+            </options>
+         </var>
+         <var name="tempw" type="REAL" >
+            <default> 300.D0
+            </default>
+            <info>
+Starting temperature (Kelvin) in MD runs
+target temperature for most thermostats.
+            </info>
+         </var>
+         <var name="tolp" type="REAL" >
+            <default> 100.D0
+            </default>
+            <info>
+Tolerance for velocity rescaling. Velocities are rescaled if
+the run-averaged and target temperature differ more than tolp.
+            </info>
+         </var>
+         <var name="delta_t" type="REAL" >
+            <default> 1.D0
+            </default>
+            <info>
+if <ref>ion_temperature</ref> == &apos;rescale-T&apos; :
+       at each step the instantaneous temperature is multiplied
+       by delta_t; this is done rescaling all the velocities.
+
+if <ref>ion_temperature</ref> == &apos;reduce-T&apos; :
+       every &apos;nraise&apos; steps the instantaneous temperature is
+       reduced by -<ref>delta_t</ref> (i.e. <ref>delta_t</ref> &lt; 0 is added to T)
+
+The instantaneous temperature is calculated at the end of
+every ionic move and BEFORE rescaling. This is the temperature
+reported in the main output.
+
+For <ref>delta_t</ref> &lt; 0, the actual average rate of heating or cooling
+should be roughly C*delta_t/(nraise*dt) (C=1 for an
+ideal gas, C=0.5 for a harmonic solid, theorem of energy
+equipartition between all quadratic degrees of freedom).
+            </info>
+         </var>
+         <var name="nraise" type="INTEGER" >
+            <default> 1
+            </default>
+            <info>
+if <ref>ion_temperature</ref> == &apos;reduce-T&apos; :
+       every <ref>nraise</ref> steps the instantaneous temperature is
+       reduced by -<ref>delta_t</ref> (i.e. <ref>delta_t</ref> is added to the temperature)
+
+if <ref>ion_temperature</ref> == &apos;rescale-v&apos; :
+       every <ref>nraise</ref> steps the average temperature, computed from
+       the last <ref>nraise</ref> steps, is rescaled to <ref>tempw</ref>
+
+if <ref>ion_temperature</ref> == &apos;rescaling&apos; and <ref>calculation</ref> == &apos;vc-md&apos; :
+       every <ref>nraise</ref> steps the instantaneous temperature
+       is rescaled to <ref>tempw</ref>
+
+if <ref>ion_temperature</ref> == &apos;berendsen&apos; :
+       the &quot;rise time&quot; parameter is given in units of the time step:
+       tau = nraise*dt, so dt/tau = 1/nraise
+
+if <ref>ion_temperature</ref> == &apos;andersen&apos; :
+       the &quot;collision frequency&quot; parameter is given as nu=1/tau
+       defined above, so nu*dt = 1/nraise
+            </info>
+         </var>
+         <var name="refold_pos" type="LOGICAL" >
+            <default> .FALSE.
+            </default>
+            <info>
+This keyword applies only in the case of molecular dynamics or
+damped dynamics. If true the ions are refolded at each step into
+the supercell.
+            </info>
+         </var>
+      </group>
+      <group>
+         <label>
+keywords used only in BFGS calculations
+         </label>
+         <var name="upscale" type="REAL" >
+            <default> 100.D0
+            </default>
+            <info>
+Max reduction factor for <ref>conv_thr</ref> during structural optimization
+<ref>conv_thr</ref> is automatically reduced when the relaxation
+approaches convergence so that forces are still accurate,
+but <ref>conv_thr</ref> will not be reduced to less that <ref>conv_thr</ref> / <ref>upscale</ref>.
+            </info>
+         </var>
+         <var name="bfgs_ndim" type="INTEGER" >
+            <default> 1
+            </default>
+            <info>
+Number of old forces and displacements vectors used in the
+PULAY mixing of the residual vectors obtained on the basis
+of the inverse hessian matrix given by the BFGS algorithm.
+When <ref>bfgs_ndim</ref> = 1, the standard quasi-Newton BFGS method is
+used.
+(bfgs only)
+            </info>
+         </var>
+         <var name="trust_radius_max" type="REAL" >
+            <default> 0.8D0
+            </default>
+            <info>
+Maximum ionic displacement in the structural relaxation.
+(bfgs only)
+            </info>
+         </var>
+         <var name="trust_radius_min" type="REAL" >
+            <default> 1.D-3
+            </default>
+            <info>
+Minimum ionic displacement in the structural relaxation
+BFGS is reset when <ref>trust_radius</ref> &lt; <ref>trust_radius_min</ref>.
+(bfgs only)
+            </info>
+         </var>
+         <var name="trust_radius_ini" type="REAL" >
+            <default> 0.5D0
+            </default>
+            <info>
+Initial ionic displacement in the structural relaxation.
+(bfgs only)
+            </info>
+         </var>
+         <var name="w_1" type="REAL" >
+            <default> 0.01D0
+            </default>
+            <see> w_2
+            </see>
+         </var>
+         <var name="w_2" type="REAL" >
+            <default> 0.5D0
+            </default>
+            <info>
+Parameters used in line search based on the Wolfe conditions.
+(bfgs only)
+            </info>
+         </var>
+      </group>
+   </namelist>
+   <namelist name="CELL" >
+      <label>
+input this namelist only if <ref>calculation</ref> == &apos;vc-relax&apos; or &apos;vc-md&apos;
+      </label>
+      <var name="cell_dynamics" type="CHARACTER" >
+         <options>
+            <info>
+Specify the type of dynamics for the cell.
+For different type of calculation different possibilities
+are allowed and different default values apply:
+
+<b>CASE</b> ( <ref>calculation</ref> == &apos;vc-relax&apos; )
+            </info>
+            <opt val="'none'" > no dynamics
+            </opt>
+            <opt val="'sd'" > steepest descent ( not implemented )
+            </opt>
+            <opt val="'damp-pr'" >
+damped (Beeman) dynamics of the Parrinello-Rahman extended lagrangian
+            </opt>
+            <opt val="'damp-w'" >
+damped (Beeman) dynamics of the new Wentzcovitch extended lagrangian
+            </opt>
+            <opt val="'bfgs'" >
+BFGS quasi-newton algorithm <b>(default)</b>
+<ref>ion_dynamics</ref> must be <b>&apos;bfgs&apos;</b> too
+            </opt>
+            <info>
+<b>CASE</b> ( <ref>calculation</ref> == &apos;vc-md&apos; )
+            </info>
+            <opt val="'none'" > no dynamics
+            </opt>
+            <opt val="'pr'" >
+(Beeman) molecular dynamics of the Parrinello-Rahman extended lagrangian
+            </opt>
+            <opt val="'w'" >
+(Beeman) molecular dynamics of the new Wentzcovitch extended lagrangian
+            </opt>
+         </options>
+      </var>
+      <var name="press" type="REAL" >
+         <default> 0.D0
+         </default>
+         <info>
+Target pressure [KBar] in a variable-cell md or relaxation run.
+         </info>
+      </var>
+      <var name="wmass" type="REAL" >
+         <default>
+0.75*Tot_Mass/pi**2 for Parrinello-Rahman MD;
+0.75*Tot_Mass/pi**2/Omega**(2/3) for Wentzcovitch MD
+         </default>
+         <info>
+Fictitious cell mass [amu] for variable-cell simulations
+(both &apos;vc-md&apos; and &apos;vc-relax&apos;)
+         </info>
+      </var>
+      <var name="cell_factor" type="REAL" >
+         <default> 2.0 for variable-cell calculations, 1.0 otherwise
+         </default>
+         <info>
+Used in the construction of the pseudopotential tables.
+It should exceed the maximum linear contraction of the
+cell during a simulation.
+         </info>
+      </var>
+      <var name="press_conv_thr" type="REAL" >
+         <default> 0.5D0 Kbar
+         </default>
+         <info>
+Convergence threshold on the pressure for variable cell
+relaxation (&apos;vc-relax&apos; : note that the other convergence
+            thresholds for ionic relaxation apply as well).
+         </info>
+      </var>
+      <var name="cell_dofree" type="CHARACTER" >
+         <default> &apos;all&apos;
+         </default>
+         <options>
+            <info>
+Select which of the cell parameters should be moved:
+            </info>
+            <opt val="'all'" > all axis and angles are moved
+            </opt>
+            <opt val="'x'" > only the x component of axis 1 (v1_x) is moved
+            </opt>
+            <opt val="'y'" > only the y component of axis 2 (v2_y) is moved
+            </opt>
+            <opt val="'z'" > only the z component of axis 3 (v3_z) is moved
+            </opt>
+            <opt val="'xy'" > only v1_x and v2_y are moved
+            </opt>
+            <opt val="'xz'" > only v1_x and v3_z are moved
+            </opt>
+            <opt val="'yz'" > only v2_y and v3_z are moved
+            </opt>
+            <opt val="'xyz'" > only v1_x, v2_y, v3_z are moved
+            </opt>
+            <opt val="'shape'" > all axis and angles, keeping the volume fixed
+            </opt>
+            <opt val="'volume'" > the volume changes, keeping all angles fixed (i.e. only celldm(1) changes)
+            </opt>
+            <opt val="'2Dxy'" > only x and y components are allowed to change
+            </opt>
+            <opt val="'2Dshape'" > as above, keeping the area in xy plane fixed
+            </opt>
+            <opt val="'epitaxial_ab'" > fix axis 1 and 2 while allowing axis 3 to move
+            </opt>
+            <opt val="'epitaxial_ac'" > fix axis 1 and 3 while allowing axis 2 to move
+            </opt>
+            <opt val="'epitaxial_bc'" > fix axis 2 and 3 while allowing axis 1 to move
+            </opt>
+            <info>
+BEWARE: if axis are not orthogonal, some of these options do not
+        work (symmetry is broken). If you are not happy with them,
+        edit subroutine init_dofree in file Modules/cell_base.f90
+            </info>
+         </options>
+      </var>
+   </namelist>
+   <card name="ATOMIC_SPECIES" >
+      <syntax>
+         <table name="atomic_species" >
+            <rows start="1" end="ntyp" >
+               <col name="X" type="CHARACTER" >
+                  <info>
+label of the atom. Acceptable syntax:
+chemical symbol X (1 or 2 characters, case-insensitive)
+or chemical symbol plus a number or a letter, as in
+&quot;Xn&quot; (e.g. Fe1) or &quot;X_*&quot; or &quot;X-*&quot; (e.g. C1, C_h;
+max total length cannot exceed 3 characters)
+                  </info>
+               </col>
+               <col name="Mass_X" type="REAL" >
+                  <info>
+mass of the atomic species [amu: mass of C = 12]
+Used only when performing Molecular Dynamics run
+or structural optimization runs using Damped MD.
+Not actually used in all other cases (but stored
+in data files, so phonon calculations will use
+these values unless other values are provided)
+                  </info>
+               </col>
+               <col name="PseudoPot_X" type="CHARACTER" >
+                  <info>
+File containing PP for this species.
+
+The pseudopotential file is assumed to be in the new UPF format.
+If it doesn&apos;t work, the pseudopotential format is determined by
+the file name:
+
+*.vdb or *.van     Vanderbilt US pseudopotential code
+*.RRKJ3            Andrea Dal Corso&apos;s code (old format)
+none of the above  old PWscf norm-conserving format
+                  </info>
+               </col>
+            </rows>
+         </table>
+      </syntax>
+   </card>
+   <card name="ATOMIC_POSITIONS" >
+      <flag name="atompos_unit" use="optional" >
+         <enum> alat | bohr | angstrom | crystal | crystal_sg
+         </enum>
+         <default> (DEPRECATED) alat
+         </default>
+         <options>
+            <info>
+Units for ATOMIC_POSITIONS:
+            </info>
+            <opt val="alat" >
+atomic positions are in cartesian coordinates, in
+units of the lattice parameter (either celldm(1)
+or A). If no option is specified, &apos;alat&apos; is assumed;
+not specifying units is DEPRECATED and will no
+longer be allowed in the future
+            </opt>
+            <opt val="bohr" >
+atomic positions are in cartesian coordinate,
+in atomic units (i.e. Bohr radii)
+            </opt>
+            <opt val="angstrom" >
+atomic positions are in cartesian coordinates, in Angstrom
+            </opt>
+            <opt val="crystal" >
+atomic positions are in crystal coordinates, i.e.
+in relative coordinates of the primitive lattice
+vectors as defined either in card <ref>CELL_PARAMETERS</ref>
+or via the ibrav + celldm / a,b,c... variables
+            </opt>
+            <opt val="crystal_sg" >
+atomic positions are in crystal coordinates, i.e.
+in relative coordinates of the primitive lattice.
+This option differs from the previous one because
+in this case only the symmetry inequivalent atoms
+are given. The variable <ref>space_group</ref> must indicate
+the space group number used to find the symmetry
+equivalent atoms. The other variables that control
+this option are uniqueb, origin_choice, and
+rhombohedral.
+            </opt>
+         </options>
+      </flag>
+      <choose>
+         <when test="calculation == 'bands' OR calculation == 'nscf'" >
+            <message>
+Specified atomic positions will be IGNORED and those from the
+previous scf calculation will be used instead !!!
+            </message>
+         </when>
+         <otherwise>
+            <syntax>
+               <table name="atomic_coordinates" >
+                  <rows start="1" end="nat" >
+                     <col name="X" type="CHARACTER" >
+                        <info> label of the atom as specified in <ref>ATOMIC_SPECIES</ref>
+                        </info>
+                     </col>
+                     <colgroup type="REAL" >
+                        <info>
+atomic positions
+
+NOTE: each atomic coordinate can also be specified as a simple algebraic expression.
+      To be interpreted correctly expression must NOT contain any blank
+      space and must NOT start with a &quot;+&quot; sign. The available expressions are:
+
+        + (plus), - (minus), / (division), * (multiplication), ^ (power)
+
+      All numerical constants included are considered as double-precision numbers;
+      i.e. 1/2 is 0.5, not zero. Other functions, such as sin, sqrt or exp are
+      not available, although sqrt can be replaced with ^(1/2).
+
+      Example:
+            C  1/3   1/2*3^(-1/2)   0
+
+      is equivalent to
+
+            C  0.333333  0.288675  0.000000
+
+      Please note that this feature is NOT supported by XCrysDen (which will
+      display a wrong structure, or nothing at all).
+
+      When atomic positions are of type crystal_sg coordinates can be given
+      in the following four forms (Wyckoff positions):
+         C  1a
+         C  8g   x
+         C  24m  x y
+         C  48n  x y z
+      The first form must be used when the Wyckoff letter determines uniquely
+      all three coordinates, forms 2,3,4 when the Wyckoff letter and 1,2,3
+      coordinates respectively are needed.
+
+      The forms:
+         C 8g  x  x  x
+         C 24m x  x  y
+      are not allowed, but
+         C x x x
+         C x x y
+         C x y z
+      are correct.
+                        </info>
+                        <col name="x" >
+                        </col>
+                        <col name="y" >
+                        </col>
+                        <col name="z" >
+                        </col>
+                     </colgroup>
+                     <optional>
+                        <colgroup type="INTEGER" >
+                           <info>
+component i of the force for this atom is multiplied by if_pos(i),
+which must be either 0 or 1.  Used to keep selected atoms and/or
+selected components fixed in MD dynamics or
+structural optimization run.
+
+With crystal_sg atomic coordinates the constraints are copied in all equivalent
+atoms.
+                           </info>
+                           <default> 1
+                           </default>
+                           <col name="if_pos(1)" >
+                           </col>
+                           <col name="if_pos(2)" >
+                           </col>
+                           <col name="if_pos(3)" >
+                           </col>
+                        </colgroup>
+                     </optional>
+                  </rows>
+               </table>
+            </syntax>
+         </otherwise>
+      </choose>
+   </card>
+   <card name="K_POINTS" >
+      <flag name="kpoint_type" use="optional" >
+         <enum> tpiba | automatic | crystal | gamma | tpiba_b | crystal_b | tpiba_c | crystal_c
+         </enum>
+         <default> tbipa
+         </default>
+         <options>
+            <info>
+K_POINTS options are:
+            </info>
+            <opt val="tpiba" >
+read k-points in cartesian coordinates,
+in units of 2 pi/a (default)
+            </opt>
+            <opt val="automatic" >
+automatically generated uniform grid of k-points, i.e,
+generates ( nk1, nk2, nk3 ) grid with ( sk1, sk2, sk3 ) offset.
+nk1, nk2, nk3 as in Monkhorst-Pack grids
+k1, k2, k3 must be 0 ( no offset ) or 1 ( grid displaced
+by half a grid step in the corresponding direction )
+BEWARE: only grids having the full symmetry of the crystal
+        work with tetrahedra. Some grids with offset may not work.
+            </opt>
+            <opt val="crystal" >
+read k-points in crystal coordinates, i.e. in relative
+coordinates of the reciprocal lattice vectors
+            </opt>
+            <opt val="gamma" >
+use k = 0 (no need to list k-point specifications after card)
+In this case wavefunctions can be chosen as real,
+and specialized subroutines optimized for calculations
+at the gamma point are used (memory and cpu requirements
+are reduced by approximately one half).
+            </opt>
+            <opt val="tpiba_b" >
+Used for band-structure plots.
+k-points are in units of  2 pi/a.
+nks points specify nks-1 lines in reciprocal space.
+Every couple of points identifies the initial and
+final point of a line. pw.x generates N intermediate
+points of the line where N is the weight of the first point.
+            </opt>
+            <opt val="crystal_b" >
+As tpiba_b, but k-points are in crystal coordinates.
+            </opt>
+            <opt val="tpiba_c" >
+Used for band-structure contour plots.
+k-points are in units of  2 <i>pi/a.</i> nks must be 3.
+3 k-points k_0, k_1, and k_2 specify a rectangle
+in reciprocal space of vertices k_0, k_1, k_2,
+k_1 + k_2 - k_0: k_0 + \alpha (k_1-k_0)+
+\beta (k_2-k_0) with 0 &lt;\alpha,\beta &lt; 1.
+The code produces a uniform mesh n1 x n2
+k points in this rectangle. n1 and n2 are
+the weights of k_1 and k_2. The weight of k_0
+is not used.
+            </opt>
+            <opt val="crystal_c" >
+As tpiba_c, but k-points are in crystal coordinates.
+            </opt>
+         </options>
+      </flag>
+      <choose>
+         <when test="tpiba  OR  crystal  OR  tpiba_b  OR  crystal_b OR tpiba_c OR crystal_c" >
+            <syntax flag="tpiba | crystal | tpiba_b | crystal_b | tpiba_c | crystal_c " >
+               <line>
+                  <var name="nks" type="INTEGER" >
+                     <info> Number of supplied special k-points.
+                     </info>
+                  </var>
+               </line>
+               <table name="kpoints" >
+                  <rows start="1" end="nks" >
+                     <colgroup type="REAL" >
+                        <col name="xk_x" >
+                        </col>
+                        <col name="xk_y" >
+                        </col>
+                        <col name="xk_z" >
+                        </col>
+                        <col name="wk" >
+                        </col>
+                        <info>
+Special k-points (xk_x/y/z) in the irreducible Brillouin Zone
+(IBZ) of the lattice (with all symmetries) and weights (wk)
+See the literature for lists of special points and
+the corresponding weights.
+
+If the symmetry is lower than the full symmetry
+of the lattice, additional points with appropriate
+weights are generated. Notice that such procedure
+assumes that ONLY k-points in the IBZ are provided in input
+
+In a non-scf calculation, weights do not affect the results.
+If you just need eigenvalues and eigenvectors (for instance,
+for a band-structure plot), weights can be set to any value
+(for instance all equal to 1).
+                        </info>
+                     </colgroup>
+                  </rows>
+               </table>
+            </syntax>
+         </when>
+         <elsewhen test="automatic" >
+            <syntax flag="automatic" >
+               <line>
+                  <vargroup type="INTEGER" >
+                     <var name="nk1" >
+                     </var>
+                     <var name="nk2" >
+                     </var>
+                     <var name="nk3" >
+                     </var>
+                     <info>
+These parameters specify the k-point grid
+(nk1 x nk2 x nk3) as in Monkhorst-Pack grids.
+                     </info>
+                  </vargroup>
+                  <vargroup type="INTEGER" >
+                     <var name="sk1" >
+                     </var>
+                     <var name="sk2" >
+                     </var>
+                     <var name="sk3" >
+                     </var>
+                     <info>
+The grid offsets;  sk1, sk2, sk3 must be
+0 ( no offset ) or 1 ( grid displaced by
+half a grid step in the corresponding direction ).
+                     </info>
+                  </vargroup>
+               </line>
+            </syntax>
+         </elsewhen>
+         <elsewhen test="gamma" >
+            <syntax flag="gamma" >
+            </syntax>
+         </elsewhen>
+      </choose>
+   </card>
+   <card name="CELL_PARAMETERS" >
+      <flag name="lattice_type" use="optional" >
+         <enum> alat | bohr | angstrom
+         </enum>
+         <info>
+Unit for lattice vectors; options are:
+
+<b>&apos;bohr&apos;</b> / <b>&apos;angstrom&apos;:</b>
+                     lattice vectors in bohr-radii / angstrom.
+                     In this case the lattice parameter alat = sqrt(v1*v1).
+
+<b>&apos;alat&apos;</b> / nothing specified:
+                     lattice vectors in units of the lattice parameter (either
+                     <ref>celldm</ref>(1) or <ref>A</ref>). Not specifying units is DEPRECATED
+                     and will not be allowed in the future.
+
+If neither unit nor lattice parameter are specified,
+&apos;bohr&apos; is assumed - DEPRECATED, will no longer be allowed
+         </info>
+      </flag>
+      <label>
+Optional card, needed only if <ref>ibrav</ref> == 0 is specified, ignored otherwise !
+      </label>
+      <syntax>
+         <table name="lattice" >
+            <cols start="1" end="3" >
+               <rowgroup type="REAL" >
+                  <info>
+Crystal lattice vectors (in cartesian axis):
+    v1(1)  v1(2)  v1(3)    ... 1st lattice vector
+    v2(1)  v2(2)  v2(3)    ... 2nd lattice vector
+    v3(1)  v3(2)  v3(3)    ... 3rd lattice vector
+                  </info>
+                  <row name="v1" >
+                  </row>
+                  <row name="v2" >
+                  </row>
+                  <row name="v3" >
+                  </row>
+               </rowgroup>
+            </cols>
+         </table>
+      </syntax>
+   </card>
+   <card name="CONSTRAINTS" >
+      <label>
+Optional card, used for constrained dynamics or constrained optimisations
+(only if <ref>ion_dynamics</ref>==&apos;damp&apos; or &apos;verlet&apos;, variable-cell excepted)
+      </label>
+      <message>
+When this card is present the SHAKE algorithm is automatically used.
+      </message>
+      <syntax>
+         <line>
+            <var name="nconstr" type="INTEGER" >
+               <info> Number of constraints.
+               </info>
+            </var>
+            <optional>
+               <var name="constr_tol" type="REAL" >
+                  <info> Tolerance for keeping the constraints satisfied.
+                  </info>
+               </var>
+            </optional>
+         </line>
+         <table name="constraints_table" >
+            <rows start="1" end="nconstr" >
+               <col name="constr_type" type="CHARACTER" >
+                  <options>
+                     <info>
+Type of constraint :
+                     </info>
+                     <opt val="'type_coord'" >
+constraint on global coordination-number, i.e. the
+average number of atoms of type B surrounding the
+atoms of type A. The coordination is defined by
+using a Fermi-Dirac.
+(four indexes must be specified).
+                     </opt>
+                     <opt val="'atom_coord'" >
+constraint on local coordination-number, i.e. the
+average number of atoms of type A surrounding a
+specific atom. The coordination is defined by
+using a Fermi-Dirac.
+(four indexes must be specified).
+                     </opt>
+                     <opt val="'distance'" >
+constraint on interatomic distance
+(two atom indexes must be specified).
+                     </opt>
+                     <opt val="'planar_angle'" >
+constraint on planar angle
+(three atom indexes must be specified).
+                     </opt>
+                     <opt val="'torsional_angle'" >
+constraint on torsional angle
+(four atom indexes must be specified).
+                     </opt>
+                     <opt val="'bennett_proj'" >
+constraint on the projection onto a given direction
+of the vector defined by the position of one atom
+minus the center of mass of the others.
+G. Roma, J.P. Crocombette: J. Nucl. Mater. 403, 32 (2010),
+<a href="http://dx.doi.org/10.1016/j.jnucmat.2010.06.001">doi:10.1016/j.jnucmat.2010.06.001</a>
+                     </opt>
+                  </options>
+               </col>
+               <colgroup>
+                  <col name="constr(1)" >
+                  </col>
+                  <col name="constr(2)" >
+                  </col>
+                  <conditional>
+                     <col name="constr(3)" >
+                     </col>
+                     <col name="constr(4)" >
+                     </col>
+                  </conditional>
+                  <info>
+These variables have different meanings for different constraint types:
+
+<b>&apos;type_coord&apos;</b> :
+               <i>constr(1)</i> is the first index of the atomic type involved
+               <i>constr(2)</i> is the second index of the atomic type involved
+               <i>constr(3)</i> is the cut-off radius for estimating the coordination
+               <i>constr(4)</i> is a smoothing parameter
+
+<b>&apos;atom_coord&apos;</b> :
+               <i>constr(1)</i> is the atom index of the atom with constrained coordination
+               <i>constr(2)</i> is the index of the atomic type involved in the coordination
+               <i>constr(3)</i> is the cut-off radius for estimating the coordination
+               <i>constr(4)</i> is a smoothing parameter
+
+<b>&apos;distance&apos;</b> :
+               atoms indices object of the constraint, as they appear in
+               the <ref>ATOMIC_POSITIONS</ref> card
+
+<b>&apos;planar_angle&apos;,</b> <b>&apos;torsional_angle&apos;</b> :
+               atoms indices object of the constraint, as they appear in the
+               <ref>ATOMIC_POSITIONS</ref> card (beware the order)
+
+<b>&apos;bennett_proj&apos;</b> :
+               <i>constr(1)</i> is the index of the atom whose position is constrained.
+               <i>constr(2:4)</i> are the three coordinates of the vector that specifies
+               the constraint direction.
+                  </info>
+               </colgroup>
+               <optional>
+                  <col name="constr_target" type="REAL" >
+                     <info>
+Target for the constrain ( angles are specified in degrees ).
+This variable is optional.
+                     </info>
+                  </col>
+               </optional>
+            </rows>
+         </table>
+      </syntax>
+   </card>
+   <card name="OCCUPATIONS" >
+      <label> Optional card, used only if <ref>occupations</ref> == &apos;from_input&apos;, ignored otherwise !
+      </label>
+      <syntax>
+         <table name="occupations_table" >
+            <cols start="1" end="nbnd" >
+               <row name="f_inp1" type="REAL" >
+                  <info>
+Occupations of individual states (MAX 10 PER ROW).
+For spin-polarized calculations, these are majority spin states.
+                  </info>
+               </row>
+               <conditional>
+                  <row name="f_inp2" type="REAL" >
+                     <info>
+Occupations of minority spin states (MAX 10 PER ROW)
+To be specified only for spin-polarized calculations.
+                     </info>
+                  </row>
+               </conditional>
+            </cols>
+         </table>
+      </syntax>
+   </card>
+   <card name="ATOMIC_FORCES" >
+      <label> Optional card used to specify external forces acting on atoms.
+      </label>
+      <message>
+BEWARE: if the sum of external forces is not zero, the center of mass of
+        the system will move
+      </message>
+      <syntax>
+         <table name="atomic_forces" >
+            <rows start="1" end="nat" >
+               <col name="X" type="CHARACTER" >
+                  <info> label of the atom as specified in <ref>ATOMIC_SPECIES</ref>
+                  </info>
+               </col>
+               <colgroup type="REAL" >
+                  <info>
+external force on atom X (cartesian components, Ry/a.u. units)
+                  </info>
+                  <col name="fx" >
+                  </col>
+                  <col name="fy" >
+                  </col>
+                  <col name="fz" >
+                  </col>
+               </colgroup>
+            </rows>
+         </table>
+      </syntax>
+   </card>
+</input_description>

--- a/aiida_quantumespresso/calculations/helpers/INPUT_PW-6.4.xml
+++ b/aiida_quantumespresso/calculations/helpers/INPUT_PW-6.4.xml
@@ -1,0 +1,3115 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml-stylesheet type="text/xsl" href="input_xx.xsl"?>
+<!-- FILE AUTOMATICALLY CREATED: DO NOT EDIT, CHANGES WILL BE LOST -->
+
+<input_description distribution="Quantum Espresso" package="PWscf" program="pw.x" >
+   <toc>
+   </toc>
+   <intro>
+<b>Input data format:</b> { } = optional, [ ] = it depends, | = or
+
+All quantities whose dimensions are not explicitly specified are in
+RYDBERG ATOMIC UNITS. Charge is &quot;number&quot; charge (i.e. not multiplied
+by e); potentials are in energy units (i.e. they are multiplied by e).
+
+<b>BEWARE:</b> TABS, DOS &lt;CR&gt;&lt;LF&gt; CHARACTERS ARE POTENTIAL SOURCES OF TROUBLE
+
+Namelists must appear in the order given below.
+Comment lines in <i>namelists</i> can be introduced by a &quot;!&quot;, exactly as in
+fortran code. Comments lines in <i>cards</i> can be introduced by
+either a &quot;!&quot; or a &quot;#&quot; character in the first position of a line.
+Do not start any line in <i>cards</i> with a &quot;/&quot; character.
+Leave a space between card names and card options, e.g.
+ATOMIC_POSITIONS (bohr), not ATOMIC_POSITIONS(bohr)
+Do not start any line in <i>cards</i> with a &quot;/&quot; character.
+
+
+<b>Structure of the input data:</b>
+===============================================================================
+
+<b>&amp;CONTROL</b>
+  ...
+<b>/</b>
+
+<b>&amp;SYSTEM</b>
+  ...
+<b>/</b>
+
+<b>&amp;ELECTRONS</b>
+  ...
+<b>/</b>
+
+[ <b>&amp;IONS</b>
+  ...
+ <b>/</b> ]
+
+[ <b>&amp;CELL</b>
+  ...
+ <b>/</b> ]
+
+<b>ATOMIC_SPECIES</b>
+ X  Mass_X  PseudoPot_X
+ Y  Mass_Y  PseudoPot_Y
+ Z  Mass_Z  PseudoPot_Z
+
+<b>ATOMIC_POSITIONS</b> { alat | bohr | crystal | angstrom | crystal_sg }
+  X 0.0  0.0  0.0  {if_pos(1) if_pos(2) if_pos(3)}
+  Y 0.5  0.0  0.0
+  Z O.0  0.2  0.2
+
+<b>K_POINTS</b> { tpiba | automatic | crystal | gamma | tpiba_b | crystal_b | tpiba_c | crystal_c }
+if (gamma)
+   nothing to read
+if (automatic)
+   nk1, nk2, nk3, k1, k2, k3
+if (not automatic)
+   nks
+   xk_x, xk_y, xk_z,  wk
+
+[ <b>CELL_PARAMETERS</b> { alat | bohr | angstrom }
+   v1(1) v1(2) v1(3)
+   v2(1) v2(2) v2(3)
+   v3(1) v3(2) v3(3) ]
+
+[ <b>OCCUPATIONS</b>
+   f_inp1(1)  f_inp1(2)  f_inp1(3) ... f_inp1(10)
+   f_inp1(11) f_inp1(12) ... f_inp1(nbnd)
+ [ f_inp2(1)  f_inp2(2)  f_inp2(3) ... f_inp2(10)
+   f_inp2(11) f_inp2(12) ... f_inp2(nbnd) ] ]
+
+[ <b>CONSTRAINTS</b>
+   nconstr  { constr_tol }
+   constr_type(.)   constr(1,.)   constr(2,.) [ constr(3,.)   constr(4,.) ] { constr_target(.) } ]
+
+[ <b>ATOMIC_FORCES</b>
+   label_1 Fx(1) Fy(1) Fz(1)
+   .....
+   label_n Fx(n) Fy(n) Fz(n) ]
+   </intro>
+   <namelist name="CONTROL" >
+      <var name="calculation" type="CHARACTER" >
+         <default> &apos;scf&apos;
+         </default>
+         <options>
+            <info>
+A string describing the task to be performed. Options are:
+            </info>
+            <opt val="'scf'" >
+            </opt>
+            <opt val="'nscf'" >
+            </opt>
+            <opt val="'bands'" >
+            </opt>
+            <opt val="'relax'" >
+            </opt>
+            <opt val="'md'" >
+            </opt>
+            <opt val="'vc-relax'" >
+            </opt>
+            <opt val="'vc-md'" >
+            </opt>
+            <info>
+(vc = variable-cell).
+            </info>
+         </options>
+      </var>
+      <var name="title" type="CHARACTER" >
+         <default> &apos; &apos;
+         </default>
+         <info>
+reprinted on output.
+         </info>
+      </var>
+      <var name="verbosity" type="CHARACTER" >
+         <default> &apos;low&apos;
+         </default>
+         <options>
+            <info>
+Currently two verbosity levels are implemented:
+            </info>
+            <opt val="'high'" >
+            </opt>
+            <opt val="'low'" >
+            </opt>
+            <info>
+<b>&apos;debug&apos;</b> and <b>&apos;medium&apos;</b> have the same effect as <b>&apos;high&apos;;</b>
+<b>&apos;default&apos;</b> and <b>&apos;minimal&apos;</b> as <b>&apos;low&apos;</b>
+            </info>
+         </options>
+      </var>
+      <var name="restart_mode" type="CHARACTER" >
+         <default> &apos;from_scratch&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'from_scratch'" >
+From scratch. This is the normal way to perform a PWscf calculation
+            </opt>
+            <opt val="'restart'" >
+From previous interrupted run. Use this switch only if you want to
+continue an interrupted calculation, not to start a new one, or to
+perform non-scf calculations.  Works only if the calculation was
+cleanly stopped using variable <ref>max_seconds</ref>, or by user request
+with an &quot;exit file&quot; (i.e.: create a file &quot;prefix&quot;.EXIT, in directory
+&quot;outdir&quot;; see variables <ref>prefix</ref>, <ref>outdir</ref>).  Overrides <ref>startingwfc</ref>
+and <ref>startingpot</ref>.
+            </opt>
+         </options>
+      </var>
+      <var name="wf_collect" type="LOGICAL" >
+         <default> .TRUE.
+         </default>
+         <info>
+This flag controls the way wavefunctions are stored to disk :
+
+.TRUE.  collect wavefunctions from all processors, store them
+        into the output data directory &quot;outdir&quot;/&quot;prefix&quot;.save
+        The resulting format is portable to a different number
+        of processor, or different kind of parallelization
+
+.FALSE. OBSOLETE - NO LONGER IMPLEMENTED
+        do not collect wavefunctions, leave them in temporary
+        local files (one per processor). The resulting format
+        is readable only on the same number of processors and
+        with the same kind of parallelization used to write it.
+
+Note that this flag has no effect on reading, only on writing.
+         </info>
+      </var>
+      <var name="nstep" type="INTEGER" >
+         <info>
+number of molecular-dynamics or structural optimization steps
+performed in this run
+         </info>
+         <default>
+1  if <ref>calculation</ref> == &apos;scf&apos;, &apos;nscf&apos;, &apos;bands&apos;;
+50 for the other cases
+         </default>
+      </var>
+      <var name="iprint" type="INTEGER" >
+         <default> write only at convergence
+         </default>
+         <info>
+band energies are written every <i>iprint</i> iterations
+         </info>
+      </var>
+      <var name="tstress" type="LOGICAL" >
+         <default> .false.
+         </default>
+         <info>
+calculate stress. It is set to .TRUE. automatically if
+<ref>calculation</ref> == &apos;vc-md&apos; or &apos;vc-relax&apos;
+         </info>
+      </var>
+      <var name="tprnfor" type="LOGICAL" >
+         <info>
+calculate forces. It is set to .TRUE. automatically if
+<ref>calculation</ref> == &apos;relax&apos;,&apos;md&apos;,&apos;vc-md&apos;
+         </info>
+      </var>
+      <var name="dt" type="REAL" >
+         <default> 20.D0
+         </default>
+         <info>
+time step for molecular dynamics, in Rydberg atomic units
+(1 a.u.=4.8378 * 10^-17 s : beware, the CP code uses
+ Hartree atomic units, half that much!!!)
+         </info>
+      </var>
+      <var name="outdir" type="CHARACTER" >
+         <default>
+value of the ESPRESSO_TMPDIR environment variable if set;
+current directory (&apos;./&apos;) otherwise
+         </default>
+         <info>
+input, temporary, output files are found in this directory,
+see also <ref>wfcdir</ref>
+         </info>
+      </var>
+      <var name="wfcdir" type="CHARACTER" >
+         <default> same as <ref>outdir</ref>
+         </default>
+         <info>
+This directory specifies where to store files generated by
+each processor (*.wfc{N}, *.igk{N}, etc.). Useful for
+machines without a parallel file system: set <ref>wfcdir</ref> to
+a local file system, while <ref>outdir</ref> should be a parallel
+or network file system, visible to all processors. Beware:
+in order to restart from interrupted runs, or to perform
+further calculations using the produced data files, you
+may need to copy files to <ref>outdir</ref>. Works only for pw.x.
+         </info>
+      </var>
+      <var name="prefix" type="CHARACTER" >
+         <default> &apos;pwscf&apos;
+         </default>
+         <info>
+prepended to input/output filenames:
+prefix.wfc, prefix.rho, etc.
+         </info>
+      </var>
+      <var name="lkpoint_dir" type="LOGICAL" >
+         <default> .true.
+         </default>
+         <info>
+If .false. a subdirectory for each k_point is not opened
+in the &quot;prefix&quot;.save directory; Kohn-Sham eigenvalues are
+stored instead in a single file for all k-points. Currently
+doesn&apos;t work together with <ref>wf_collect</ref>
+         </info>
+      </var>
+      <var name="max_seconds" type="REAL" >
+         <default> 1.D+7, or 150 days, i.e. no time limit
+         </default>
+         <info>
+Jobs stops after <ref>max_seconds</ref> CPU time. Use this option
+in conjunction with option <ref>restart_mode</ref> if you need to
+split a job too long to complete into shorter jobs that
+fit into your batch queues.
+         </info>
+      </var>
+      <var name="etot_conv_thr" type="REAL" >
+         <default> 1.0D-4
+         </default>
+         <info>
+Convergence threshold on total energy (a.u) for ionic
+minimization: the convergence criterion is satisfied
+when the total energy changes less than <ref>etot_conv_thr</ref>
+between two consecutive scf steps. Note that <ref>etot_conv_thr</ref>
+is extensive, like the total energy.
+See also <ref>forc_conv_thr</ref> - both criteria must be satisfied
+         </info>
+      </var>
+      <var name="forc_conv_thr" type="REAL" >
+         <default> 1.0D-3
+         </default>
+         <info>
+Convergence threshold on forces (a.u) for ionic minimization:
+the convergence criterion is satisfied when all components of
+all forces are smaller than <ref>forc_conv_thr</ref>.
+See also <ref>etot_conv_thr</ref> - both criteria must be satisfied
+         </info>
+      </var>
+      <var name="disk_io" type="CHARACTER" >
+         <default> see below
+         </default>
+         <options>
+            <info>
+Specifies the amount of disk I/O activity:
+            </info>
+            <opt val="'high'" >
+save all data to disk at each SCF step
+            </opt>
+            <opt val="'medium'" >
+save wavefunctions at each SCF step unless
+there is a single k-point per process (in which
+case the behavior is the same as &apos;low&apos;)
+            </opt>
+            <opt val="'low'" >
+store wfc in memory, save only at the end
+            </opt>
+            <opt val="'none'" >
+do not save anything, not even at the end
+(&apos;scf&apos;, &apos;nscf&apos;, &apos;bands&apos; calculations; some data
+may be written anyway for other calculations)
+            </opt>
+            <info>
+<b>Default</b> is <b>&apos;low&apos;</b> for the scf case, <b>&apos;medium&apos;</b> otherwise.
+Note that the needed RAM increases as disk I/O decreases!
+It is no longer needed to specify &apos;high&apos; in order to be able
+to restart from an interrupted calculation (see <ref>restart_mode</ref>)
+but you cannot restart in <ref>disk_io</ref>==&apos;none&apos;
+            </info>
+         </options>
+      </var>
+      <var name="pseudo_dir" type="CHARACTER" >
+         <default>
+value of the $ESPRESSO_PSEUDO environment variable if set;
+&apos;$HOME/espresso/pseudo/&apos; otherwise
+         </default>
+         <info>
+directory containing pseudopotential files
+         </info>
+      </var>
+      <var name="tefield" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. a saw-like potential simulating an electric field
+is added to the bare ionic potential. See variables <ref>edir</ref>,
+<ref>eamp</ref>, <ref>emaxpos</ref>, <ref>eopreg</ref> for the form and size of
+the added potential.
+         </info>
+      </var>
+      <var name="dipfield" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. and <ref>tefield</ref>==.TRUE. a dipole correction is also
+added to the bare ionic potential - implements the recipe
+of L. Bengtsson, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.59.12301">PRB 59, 12301 (1999)</a>. See variables <ref>edir</ref>,
+<ref>emaxpos</ref>, <ref>eopreg</ref> for the form of the correction. Must
+be used ONLY in a slab geometry, for surface calculations,
+with the discontinuity FALLING IN THE EMPTY SPACE.
+         </info>
+      </var>
+      <var name="lelfield" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. a homogeneous finite electric field described
+through the modern theory of the polarization is applied.
+This is different from <ref>tefield</ref> == .true. !
+         </info>
+      </var>
+      <var name="nberrycyc" type="INTEGER" >
+         <default> 1
+         </default>
+         <info>
+In the case of a finite electric field  ( <ref>lelfield</ref> == .TRUE. )
+it defines the number of iterations for converging the
+wavefunctions in the electric field Hamiltonian, for each
+external iteration on the charge density
+         </info>
+      </var>
+      <var name="lorbm" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If <b>.TRUE.</b> perform orbital magnetization calculation.
+If finite electric field is applied (<ref>lelfield</ref>==.true.) only Kubo terms are computed
+[for details see New J. Phys. 12, 053032 (2010), <a href="http://dx.doi.org/10.1088/1367-2630/12/5/053032">doi:10.1088/1367-2630/12/5/053032</a>].
+
+The type of calculation is <b>&apos;nscf&apos;</b> and should be performed on an automatically
+generated uniform grid of k points.
+
+Works ONLY with norm-conserving pseudopotentials.
+         </info>
+      </var>
+      <var name="lberry" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. perform a Berry phase calculation.
+See the header of PW/src/bp_c_phase.f90 for documentation.
+         </info>
+      </var>
+      <var name="gdir" type="INTEGER" >
+         <info>
+For Berry phase calculation: direction of the k-point
+strings in reciprocal space. Allowed values: 1, 2, 3
+1=first, 2=second, 3=third reciprocal lattice vector
+For calculations with finite electric fields
+(<ref>lelfield</ref>==.true.) &quot;gdir&quot; is the direction of the field.
+         </info>
+      </var>
+      <var name="nppstr" type="INTEGER" >
+         <info>
+For Berry phase calculation: number of k-points to be
+calculated along each symmetry-reduced string.
+The same for calculation with finite electric fields
+(<ref>lelfield</ref>==.true.).
+         </info>
+      </var>
+      <var name="lfcpopt" type="LOGICAL" >
+         <see> fcp_mu
+         </see>
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. perform a constant bias potential (constant-mu) calculation
+for a static system with ESM method. See the header of PW/src/fcp.f90
+for documentation.
+
+NB:
+- The total energy displayed in &apos;prefix.out&apos; includes the potentiostat
+  contribution (-mu*N).
+- <ref>calculation</ref> must be &apos;relax&apos;.
+- <ref>assume_isolated</ref> = &apos;esm&apos; and <ref>esm_bc</ref> = &apos;bc2&apos; or &apos;bc3&apos; must be set
+  in <ref>SYSTEM</ref> namelist.
+         </info>
+      </var>
+      <var name="gate" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <see> zgate, relaxz, block, block_1, block_2, block_height
+         </see>
+         <info>
+In the case of charged cells (<ref>tot_charge</ref> .ne. 0) setting gate = .TRUE.
+represents the counter charge (i.e. -tot_charge) not by a homogeneous
+background charge but with a charged plate, which is placed at <ref>zgate</ref>
+(see below). Details of the gate potential can be found in
+T. Brumme, M. Calandra, F. Mauri; <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.89.245406">PRB 89, 245406 (2014)</a>.
+Note, that in systems which are not symmetric with respect to the plate,
+one needs to enable the dipole correction! (<ref>dipfield</ref>=.true.).
+Currently, symmetry can be used with gate=.true. but carefully check
+that no symmetry is included which maps <i>z</i> to -<i>z</i> even if in principle one
+could still use them for symmetric systems (i.e. no dipole correction).
+For <ref>nosym</ref>=.false. verbosity is set to &apos;high&apos;.
+Note: this option was called &quot;monopole&quot; in v6.0 and 6.1 of pw.x
+         </info>
+      </var>
+   </namelist>
+   <namelist name="SYSTEM" >
+      <var name="ibrav" type="INTEGER" >
+         <status> REQUIRED
+         </status>
+         <info>
+  Bravais-lattice index. Optional only if space_group is set.
+  If ibrav /= 0, specify EITHER [ <ref>celldm</ref>(1)-<ref>celldm</ref>(6) ]
+  OR [ <ref>A</ref>, <ref>B</ref>, <ref>C</ref>, <ref>cosAB</ref>, <ref>cosAC</ref>, <ref>cosBC</ref> ]
+  but NOT both. The lattice parameter &quot;alat&quot; is set to
+  alat = celldm(1) (in a.u.) or alat = A (in Angstrom);
+  see below for the other parameters.
+  For ibrav=0 specify the lattice vectors in <ref>CELL_PARAMETERS</ref>,
+  optionally the lattice parameter alat = celldm(1) (in a.u.)
+  or = A (in Angstrom), or else it is taken from <ref>CELL_PARAMETERS</ref>
+
+ibrav      structure                   celldm(2)-celldm(6)
+                                     or: b,c,cosbc,cosac,cosab
+  0          free
+      crystal axis provided in input: see card <ref>CELL_PARAMETERS</ref>
+
+  1          cubic P (sc)
+      v1 = a(1,0,0),  v2 = a(0,1,0),  v3 = a(0,0,1)
+
+  2          cubic F (fcc)
+      v1 = (a/2)(-1,0,1),  v2 = (a/2)(0,1,1), v3 = (a/2)(-1,1,0)
+
+  3          cubic I (bcc)
+      v1 = (a/2)(1,1,1),  v2 = (a/2)(-1,1,1),  v3 = (a/2)(-1,-1,1)
+ -3          cubic I (bcc), more symmetric axis:
+      v1 = (a/2)(-1,1,1), v2 = (a/2)(1,-1,1),  v3 = (a/2)(1,1,-1)
+
+  4          Hexagonal and Trigonal P        celldm(3)=c/a
+      v1 = a(1,0,0),  v2 = a(-1/2,sqrt(3)/2,0),  v3 = a(0,0,c/a)
+
+  5          Trigonal R, 3fold axis c        celldm(4)=cos(gamma)
+      The crystallographic vectors form a three-fold star around
+      the z-axis, the primitive cell is a simple rhombohedron:
+      v1 = a(tx,-ty,tz),   v2 = a(0,2ty,tz),   v3 = a(-tx,-ty,tz)
+      where c=cos(gamma) is the cosine of the angle gamma between
+      any pair of crystallographic vectors, tx, ty, tz are:
+        tx=sqrt((1-c)/2), ty=sqrt((1-c)/6), tz=sqrt((1+2c)/3)
+ -5          Trigonal R, 3fold axis &lt;111&gt;    celldm(4)=cos(gamma)
+      The crystallographic vectors form a three-fold star around
+      &lt;111&gt;. Defining a&apos; = a/sqrt(3) :
+      v1 = a&apos; (u,v,v),   v2 = a&apos; (v,u,v),   v3 = a&apos; (v,v,u)
+      where u and v are defined as
+        u = tz - 2*sqrt(2)*ty,  v = tz + sqrt(2)*ty
+      and tx, ty, tz as for case ibrav=5
+      Note: if you prefer x,y,z as axis in the cubic limit,
+            set  u = tz + 2*sqrt(2)*ty,  v = tz - sqrt(2)*ty
+            See also the note in Modules/latgen.f90
+
+  6          Tetragonal P (st)               celldm(3)=c/a
+      v1 = a(1,0,0),  v2 = a(0,1,0),  v3 = a(0,0,c/a)
+
+  7          Tetragonal I (bct)              celldm(3)=c/a
+      v1=(a/2)(1,-1,c/a),  v2=(a/2)(1,1,c/a),  v3=(a/2)(-1,-1,c/a)
+
+  8          Orthorhombic P                  celldm(2)=b/a
+                                             celldm(3)=c/a
+      v1 = (a,0,0),  v2 = (0,b,0), v3 = (0,0,c)
+
+  9          Orthorhombic base-centered(bco) celldm(2)=b/a
+                                             celldm(3)=c/a
+      v1 = (a/2, b/2,0),  v2 = (-a/2,b/2,0),  v3 = (0,0,c)
+ -9          as 9, alternate description
+      v1 = (a/2,-b/2,0),  v2 = (a/2, b/2,0),  v3 = (0,0,c)
+ 91          Orthorhombic one-face base-centered A-type
+                                             celldm(2)=b/a
+                                             celldm(3)=c/a
+      v1 = (a, 0, 0),  v2 = (0,b/2,-c/2),  v3 = (0,b/2,c/2)
+
+ 10          Orthorhombic face-centered      celldm(2)=b/a
+                                             celldm(3)=c/a
+      v1 = (a/2,0,c/2),  v2 = (a/2,b/2,0),  v3 = (0,b/2,c/2)
+
+ 11          Orthorhombic body-centered      celldm(2)=b/a
+                                             celldm(3)=c/a
+      v1=(a/2,b/2,c/2),  v2=(-a/2,b/2,c/2),  v3=(-a/2,-b/2,c/2)
+
+ 12          Monoclinic P, unique axis c     celldm(2)=b/a
+                                             celldm(3)=c/a,
+                                             celldm(4)=cos(ab)
+      v1=(a,0,0), v2=(b*cos(gamma),b*sin(gamma),0),  v3 = (0,0,c)
+      where gamma is the angle between axis a and b.
+-12          Monoclinic P, unique axis b     celldm(2)=b/a
+                                             celldm(3)=c/a,
+                                             celldm(5)=cos(ac)
+      v1 = (a,0,0), v2 = (0,b,0), v3 = (c*cos(beta),0,c*sin(beta))
+      where beta is the angle between axis a and c
+
+ 13          Monoclinic base-centered        celldm(2)=b/a
+             (unique axis c)                 celldm(3)=c/a,
+                                             celldm(4)=cos(gamma)
+      v1 = (  a/2,         0,          -c/2),
+      v2 = (b*cos(gamma), b*sin(gamma), 0  ),
+      v3 = (  a/2,         0,           c/2),
+      where gamma=angle between axis a and b projected on xy plane
+
+-13          Monoclinic base-centered        celldm(2)=b/a
+             (unique axis b)                 celldm(3)=c/a,
+                                             celldm(5)=cos(beta)
+      v1 = (  a/2,      -b/2,             0),
+      v2 = (  a/2,       b/2,             0),
+      v3 = (c*cos(beta),   0,   c*sin(beta)),
+      where beta=angle between axis a and c projected on xz plane
+
+ 14          Triclinic                       celldm(2)= b/a,
+                                             celldm(3)= c/a,
+                                             celldm(4)= cos(bc),
+                                             celldm(5)= cos(ac),
+                                             celldm(6)= cos(ab)
+      v1 = (a, 0, 0),
+      v2 = (b*cos(gamma), b*sin(gamma), 0)
+      v3 = (c*cos(beta),  c*(cos(alpha)-cos(beta)cos(gamma))/sin(gamma),
+           c*sqrt( 1 + 2*cos(alpha)cos(beta)cos(gamma)
+                     - cos(alpha)^2-cos(beta)^2-cos(gamma)^2 )/sin(gamma) )
+      where alpha is the angle between axis b and c
+             beta is the angle between axis a and c
+            gamma is the angle between axis a and b
+         </info>
+      </var>
+      <group>
+         <label> Either:
+         </label>
+         <dimension name="celldm" start="1" end="6" type="REAL" >
+            <see> ibrav
+            </see>
+            <info>
+Crystallographic constants - see the <ref>ibrav</ref> variable.
+Specify either these OR <ref>A</ref>,<ref>B</ref>,<ref>C</ref>,<ref>cosAB</ref>,<ref>cosBC</ref>,<ref>cosAC</ref> NOT both.
+Only needed values (depending on &quot;ibrav&quot;) must be specified
+alat = <ref>celldm</ref>(1) is the lattice parameter &quot;a&quot; (in BOHR)
+If <ref>ibrav</ref>==0, only <ref>celldm</ref>(1) is used if present;
+cell vectors are read from card <ref>CELL_PARAMETERS</ref>
+            </info>
+         </dimension>
+         <label> Or:
+         </label>
+         <vargroup type="REAL" >
+            <var name="A" >
+            </var>
+            <var name="B" >
+            </var>
+            <var name="C" >
+            </var>
+            <var name="cosAB" >
+            </var>
+            <var name="cosAC" >
+            </var>
+            <var name="cosBC" >
+            </var>
+            <see> ibrav
+            </see>
+            <info>
+Traditional crystallographic constants:
+
+  a,b,c in ANGSTROM
+  cosAB = cosine of the angle between axis a and b (gamma)
+  cosAC = cosine of the angle between axis a and c (beta)
+  cosBC = cosine of the angle between axis b and c (alpha)
+
+The axis are chosen according to the value of <ref>ibrav</ref>.
+Specify either these OR <ref>celldm</ref> but NOT both.
+Only needed values (depending on <ref>ibrav</ref>) must be specified.
+
+The lattice parameter alat = A (in ANGSTROM ).
+
+If <ref>ibrav</ref> == 0, only A is used if present, and
+cell vectors are read from card <ref>CELL_PARAMETERS</ref>.
+            </info>
+         </vargroup>
+      </group>
+      <var name="nat" type="INTEGER" >
+         <status> REQUIRED
+         </status>
+         <info>
+number of atoms in the unit cell (ALL atoms, except if
+space_group is set, in which case, INEQUIVALENT atoms)
+         </info>
+      </var>
+      <var name="ntyp" type="INTEGER" >
+         <status> REQUIRED
+         </status>
+         <info>
+number of types of atoms in the unit cell
+         </info>
+      </var>
+      <var name="nbnd" type="INTEGER" >
+         <default>
+for an insulator, <ref>nbnd</ref> = number of valence bands
+(<ref>nbnd</ref> = # of electrons /2);
+<br/> for a metal, 20% more (minimum 4 more)
+         </default>
+         <info>
+Number of electronic states (bands) to be calculated.
+Note that in spin-polarized calculations the number of
+k-point, not the number of bands per k-point, is doubled
+         </info>
+      </var>
+      <var name="tot_charge" type="REAL" >
+         <default> 0.0
+         </default>
+         <info>
+Total charge of the system. Useful for simulations with charged cells.
+By default the unit cell is assumed to be neutral (tot_charge=0).
+tot_charge=+1 means one electron missing from the system,
+tot_charge=-1 means one additional electron, and so on.
+
+In a periodic calculation a compensating jellium background is
+inserted to remove divergences if the cell is not neutral.
+         </info>
+      </var>
+      <dimension name="starting_charge" start="1" end="ntyp" type="REAL" >
+         <default> 0.0
+         </default>
+         <info>
+starting charge on atomic type &apos;i&apos;,
+to create starting potential with <ref>startingpot</ref> = &apos;atomic&apos;.
+         </info>
+      </dimension>
+      <var name="tot_magnetization" type="REAL" >
+         <default> -1 [unspecified]
+         </default>
+         <info>
+Total majority spin charge - minority spin charge.
+Used to impose a specific total electronic magnetization.
+If unspecified then tot_magnetization variable is ignored and
+the amount of electronic magnetization is determined during
+the self-consistent cycle.
+         </info>
+      </var>
+      <dimension name="starting_magnetization" start="1" end="ntyp" type="REAL" >
+         <info>
+Starting spin polarization on atomic type &apos;i&apos; in a spin
+polarized calculation. Values range between -1 (all spins
+down for the valence electrons of atom type &apos;i&apos;) to 1
+(all spins up). Breaks the symmetry and provides a starting
+point for self-consistency. The default value is zero, BUT a
+value MUST be specified for AT LEAST one atomic type in spin
+polarized calculations, unless you constrain the magnetization
+(see <ref>tot_magnetization</ref> and <ref>constrained_magnetization</ref>).
+Note that if you start from zero initial magnetization, you
+will invariably end up in a nonmagnetic (zero magnetization)
+state. If you want to start from an antiferromagnetic state,
+you may need to define two different atomic species
+corresponding to sublattices of the same atomic type.
+starting_magnetization is ignored if you are performing a
+non-scf calculation, if you are restarting from a previous
+run, or restarting from an interrupted run.
+If you fix the magnetization with <ref>tot_magnetization</ref>,
+you should not specify starting_magnetization.
+In the spin-orbit case starting with zero
+starting_magnetization on all atoms imposes time reversal
+symmetry. The magnetization is never calculated and
+kept zero (the internal variable domag is .FALSE.).
+         </info>
+      </dimension>
+      <var name="ecutwfc" type="REAL" >
+         <status> REQUIRED
+         </status>
+         <info>
+kinetic energy cutoff (Ry) for wavefunctions
+         </info>
+      </var>
+      <var name="ecutrho" type="REAL" >
+         <default> 4 * <ref>ecutwfc</ref>
+         </default>
+         <info>
+Kinetic energy cutoff (Ry) for charge density and potential
+For norm-conserving pseudopotential you should stick to the
+default value, you can reduce it by a little but it will
+introduce noise especially on forces and stress.
+If there are ultrasoft PP, a larger value than the default is
+often desirable (ecutrho = 8 to 12 times <ref>ecutwfc</ref>, typically).
+PAW datasets can often be used at 4*<ref>ecutwfc</ref>, but it depends
+on the shape of augmentation charge: testing is mandatory.
+The use of gradient-corrected functional, especially in cells
+with vacuum, or for pseudopotential without non-linear core
+correction, usually requires an higher values of ecutrho
+to be accurately converged.
+         </info>
+      </var>
+      <var name="ecutfock" type="REAL" >
+         <default> ecutrho
+         </default>
+         <info>
+Kinetic energy cutoff (Ry) for the exact exchange operator in
+EXX type calculations. By default this is the same as <ref>ecutrho</ref>
+but in some EXX calculations significant speed-up can be found
+by reducing ecutfock, at the expense of some loss in accuracy.
+Must be .gt. <ref>ecutwfc</ref>. Not implemented for stress calculation.
+Use with care, especially in metals where it may give raise
+to instabilities.
+         </info>
+      </var>
+      <vargroup type="INTEGER" >
+         <var name="nr1" >
+         </var>
+         <var name="nr2" >
+         </var>
+         <var name="nr3" >
+         </var>
+         <info>
+Three-dimensional FFT mesh (hard grid) for charge
+density (and scf potential). If not specified
+the grid is calculated based on the cutoff for
+charge density (see also <ref>ecutrho</ref>)
+Note: you must specify all three dimensions for this setting to
+be used.
+         </info>
+      </vargroup>
+      <vargroup type="INTEGER" >
+         <var name="nr1s" >
+         </var>
+         <var name="nr2s" >
+         </var>
+         <var name="nr3s" >
+         </var>
+         <info>
+Three-dimensional mesh for wavefunction FFT and for the smooth
+part of charge density ( smooth grid ).
+Coincides with <ref>nr1</ref>, <ref>nr2</ref>, <ref>nr3</ref> if <ref>ecutrho</ref> = 4 * ecutwfc ( default )
+Note: you must specify all three dimensions for this setting to
+be used.
+         </info>
+      </vargroup>
+      <var name="nosym" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.TRUE.) symmetry is not used. Consequences:
+
+- if a list of k points is provided in input, it is used
+  &quot;as is&quot;: symmetry-inequivalent k-points are not generated,
+  and the charge density is not symmetrized;
+
+- if a uniform (Monkhorst-Pack) k-point grid is provided in
+  input, it is expanded to cover the entire Brillouin Zone,
+  irrespective of the crystal symmetry.
+  Time reversal symmetry is assumed so k and -k are considered
+  as equivalent unless <ref>noinv</ref>=.true. is specified.
+
+Do not use this option unless you know exactly what you want
+and what you get. May be useful in the following cases:
+- in low-symmetry large cells, if you cannot afford a k-point
+  grid with the correct symmetry
+- in MD simulations
+- in calculations for isolated atoms
+         </info>
+      </var>
+      <var name="nosym_evc" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.TRUE.) symmetry is not used, and k points are
+forced to have the symmetry of the Bravais lattice;
+an automatically generated Monkhorst-Pack grid will contain
+all points of the grid over the entire Brillouin Zone,
+plus the points rotated by the symmetries of the Bravais
+lattice which were not in the original grid. The same
+applies if a k-point list is provided in input instead
+of a Monkhorst-Pack grid. Time reversal symmetry is assumed
+so k and -k are equivalent unless <ref>noinv</ref>=.true. is specified.
+This option differs from <ref>nosym</ref> because it forces k-points
+in all cases to have the full symmetry of the Bravais lattice
+(not all uniform grids have such property!)
+         </info>
+      </var>
+      <var name="noinv" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.TRUE.) disable the usage of k =&gt; -k symmetry
+(time reversal) in k-point generation
+         </info>
+      </var>
+      <var name="no_t_rev" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.TRUE.) disable the usage of magnetic symmetry operations
+that consist in a rotation + time reversal.
+         </info>
+      </var>
+      <var name="force_symmorphic" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.TRUE.) force the symmetry group to be symmorphic by disabling
+symmetry operations having an associated fractionary translation
+         </info>
+      </var>
+      <var name="use_all_frac" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+if (.FALSE.) force real-space FFT grids to be commensurate with
+fractionary translations of non-symmorphic symmetry operations,
+if present (e.g.: if a fractional translation (0,0,c/4) exists,
+the FFT dimension along the c axis must be multiple of 4).
+if (.TRUE.) do not impose any constraints to FFT grids, even in
+the presence of non-symmorphic symmetry operations.
+BEWARE: use_all_frac=.TRUE. may lead to wrong results for
+hybrid functionals and phonon calculations. Both cases use
+symmetrization in real space that works for non-symmorphic
+operations only if the real-space FFT grids are commensurate.
+         </info>
+      </var>
+      <var name="occupations" type="CHARACTER" >
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'smearing'" >
+gaussian smearing for metals;
+see variables <ref>smearing</ref> and <ref>degauss</ref>
+            </opt>
+            <opt val="'tetrahedra'" >
+Tetrahedron method, Bloechl&apos;s version:
+P.E. Bloechl, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.49.16223">PRB 49, 16223 (1994)</a>
+Requires uniform grid of k-points, to be
+automatically generated (see card <ref>K_POINTS</ref>).
+Well suited for calculation of DOS,
+less so (because not variational) for
+force/optimization/dynamics calculations.
+            </opt>
+            <opt val="'tetrahedra_lin'" >
+Original linear tetrahedron method.
+To be used only as a reference;
+the optimized tetrahedron method is more efficient.
+            </opt>
+            <opt val="'tetrahedra_opt'" >
+Optimized tetrahedron method:
+see M. Kawamura, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.89.094515">PRB 89, 094515 (2014)</a>.
+Can be used for phonon calculations as well.
+            </opt>
+            <opt val="'fixed'" >
+for insulators with a gap
+            </opt>
+            <opt val="'from_input'" >
+The occupation are read from input file,
+card <ref>OCCUPATIONS</ref>. Option valid only for a
+single k-point, requires <ref>nbnd</ref> to be set
+in input. Occupations should be consistent
+with the value of <ref>tot_charge</ref>.
+            </opt>
+         </options>
+      </var>
+      <var name="one_atom_occupations" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+This flag is used for isolated atoms (<ref>nat</ref>=1) together with
+<ref>occupations</ref>=&apos;from_input&apos;. If it is .TRUE., the wavefunctions
+are ordered as the atomic starting wavefunctions, independently
+from their eigenvalue. The occupations indicate which atomic
+states are filled.
+
+The order of the states is written inside the UPF pseudopotential file.
+In the scalar relativistic case:
+S -&gt; l=0, m=0
+P -&gt; l=1, z, x, y
+D -&gt; l=2, r^2-3z^2, xz, yz, xy, x^2-y^2
+
+In the noncollinear magnetic case (with or without spin-orbit),
+each group of states is doubled. For instance:
+P -&gt; l=1, z, x, y for spin up, l=1, z, x, y for spin down.
+Up and down is relative to the direction of the starting
+magnetization.
+
+In the case with spin-orbit and time-reversal
+(<ref>starting_magnetization</ref>=0.0) the atomic wavefunctions are
+radial functions multiplied by spin-angle functions.
+For instance:
+P -&gt; l=1, j=1/2, m_j=-1/2,1/2. l=1, j=3/2,
+     m_j=-3/2, -1/2, 1/2, 3/2.
+
+In the magnetic case with spin-orbit the atomic wavefunctions
+can be forced to be spin-angle functions by setting
+<ref>starting_spin_angle</ref> to .TRUE..
+         </info>
+      </var>
+      <var name="starting_spin_angle" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+In the spin-orbit case when <ref>domag</ref>=.TRUE., by default,
+the starting wavefunctions are initialized as in scalar
+relativistic noncollinear case without spin-orbit.
+
+By setting <ref>starting_spin_angle</ref>=.TRUE. this behaviour can
+be changed and the initial wavefunctions are radial
+functions multiplied by spin-angle functions.
+
+When <ref>domag</ref>=.FALSE. the initial wavefunctions are always
+radial functions multiplied by spin-angle functions
+independently from this flag.
+
+When <ref>lspinorb</ref> is .FALSE. this flag is not used.
+         </info>
+      </var>
+      <var name="degauss" type="REAL" >
+         <default> 0.D0 Ry
+         </default>
+         <info>
+value of the gaussian spreading (Ry) for brillouin-zone
+integration in metals.
+         </info>
+      </var>
+      <var name="smearing" type="CHARACTER" >
+         <default> &apos;gaussian&apos;
+         </default>
+         <options>
+            <info>
+Available options are:
+            </info>
+            <opt val="'gaussian', 'gauss'" >
+ordinary Gaussian spreading (Default)
+            </opt>
+            <opt val="'methfessel-paxton', 'm-p', 'mp'" >
+Methfessel-Paxton first-order spreading
+(see <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.40.3616">PRB 40, 3616 (1989)</a>).
+            </opt>
+            <opt val="'marzari-vanderbilt', 'cold', 'm-v', 'mv'" >
+Marzari-Vanderbilt cold smearing
+(see <a href="https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.82.3296">PRL 82, 3296 (1999)</a>)
+            </opt>
+            <opt val="'fermi-dirac', 'f-d', 'fd'" >
+smearing with Fermi-Dirac function
+            </opt>
+         </options>
+      </var>
+      <var name="nspin" type="INTEGER" >
+         <default> 1
+         </default>
+         <info>
+nspin = 1 :  non-polarized calculation (default)
+
+nspin = 2 :  spin-polarized calculation, LSDA
+             (magnetization along z axis)
+
+nspin = 4 :  spin-polarized calculation, noncollinear
+             (magnetization in generic direction)
+             DO NOT specify <ref>nspin</ref> in this case;
+             specify <ref>noncolin</ref>=.TRUE. instead
+         </info>
+      </var>
+      <var name="noncolin" type="LOGICAL" >
+         <default> .false.
+         </default>
+         <info>
+if .true. the program will perform a noncollinear calculation.
+         </info>
+      </var>
+      <var name="ecfixed" type="REAL" >
+         <default> 0.0
+         </default>
+         <see> q2sigma
+         </see>
+      </var>
+      <var name="qcutz" type="REAL" >
+         <default> 0.0
+         </default>
+         <see> q2sigma
+         </see>
+      </var>
+      <var name="q2sigma" type="REAL" >
+         <default> 0.1
+         </default>
+         <info>
+ecfixed, qcutz, q2sigma:  parameters for modified functional to be
+used in variable-cell molecular dynamics (or in stress calculation).
+&quot;ecfixed&quot; is the value (in Rydberg) of the constant-cutoff;
+&quot;qcutz&quot; and &quot;q2sigma&quot; are the height and the width (in Rydberg)
+of the energy step for reciprocal vectors whose square modulus
+is greater than &quot;ecfixed&quot;. In the kinetic energy, G^2 is
+replaced by G^2 + qcutz * (1 + erf ( (G^2 - ecfixed)/q2sigma) )
+See: M. Bernasconi et al, J. Phys. Chem. Solids 56, 501 (1995),
+<a href="http://dx.doi.org/10.1016/0022-3697(94)00228-2">doi:10.1016/0022-3697(94)00228-2</a>
+         </info>
+      </var>
+      <var name="input_dft" type="CHARACTER" >
+         <default> read from pseudopotential files
+         </default>
+         <info>
+Exchange-correlation functional: eg &apos;PBE&apos;, &apos;BLYP&apos; etc
+See Modules/funct.f90 for allowed values.
+Overrides the value read from pseudopotential files.
+Use with care and if you know what you are doing!
+         </info>
+      </var>
+      <var name="exx_fraction" type="REAL" >
+         <default> it depends on the specified functional
+         </default>
+         <info>
+Fraction of EXX for hybrid functional calculations. In the case of
+<ref>input_dft</ref>=&apos;PBE0&apos;, the default value is 0.25, while for <ref>input_dft</ref>=&apos;B3LYP&apos;
+the <ref>exx_fraction</ref> default value is 0.20.
+         </info>
+      </var>
+      <var name="screening_parameter" type="REAL" >
+         <default> 0.106
+         </default>
+         <info>
+screening_parameter for HSE like hybrid functionals.
+For more information, see:
+J. Chem. Phys. 118, 8207 (2003), <a href="http://dx.doi.org/10.1063/1.1564060">doi:10.1063/1.1564060</a>
+J. Chem. Phys. 124, 219906 (2006), <a href="http://dx.doi.org/10.1063/1.2204597">doi:10.1063/1.2204597</a>
+         </info>
+      </var>
+      <var name="exxdiv_treatment" type="CHARACTER" >
+         <default> &apos;gygi-baldereschi&apos;
+         </default>
+         <options>
+            <info>
+Specific for EXX. It selects the kind of approach to be used
+for treating the Coulomb potential divergencies at small q vectors.
+            </info>
+            <opt val="'gygi-baldereschi'" > appropriate for cubic and quasi-cubic supercells
+            </opt>
+            <opt val="'vcut_spherical'" > appropriate for cubic and quasi-cubic supercells
+            </opt>
+            <opt val="'vcut_ws'" > appropriate for strongly anisotropic supercells, see also <ref>ecutvcut</ref>.
+            </opt>
+            <opt val="'none'" > sets Coulomb potential at G,q=0 to 0.0 (required for GAU-PBE)
+            </opt>
+         </options>
+      </var>
+      <var name="x_gamma_extrapolation" type="LOGICAL" >
+         <default> .true.
+         </default>
+         <info>
+Specific for EXX. If .true., extrapolate the G=0 term of the
+potential (see README in examples/EXX_example for more)
+Set this to .false. for GAU-PBE.
+         </info>
+      </var>
+      <var name="ecutvcut" type="REAL" >
+         <default> 0.0 Ry
+         </default>
+         <see> exxdiv_treatment
+         </see>
+         <info>
+Reciprocal space cutoff for correcting Coulomb potential
+divergencies at small q vectors.
+         </info>
+      </var>
+      <vargroup type="INTEGER" >
+         <var name="nqx1" >
+         </var>
+         <var name="nqx2" >
+         </var>
+         <var name="nqx3" >
+         </var>
+         <info>
+Three-dimensional mesh for q (k1-k2) sampling of
+the Fock operator (EXX). Can be smaller than
+the number of k-points.
+
+Currently this defaults to the size of the k-point mesh used.
+In QE =&lt; 5.0.2 it defaulted to nqx1=nqx2=nqx3=1.
+         </info>
+      </vargroup>
+      <var name="localization_thr" type="REAL" >
+         <default> 0.0
+         </default>
+         <info>
+Overlap threshold over which the exchange integral over a pair of localized orbitals
+is included in the evaluation of EXX operator. Any value greater than 0.0 triggers
+the SCDM localization and the evaluation on EXX using the localized orbitals.
+Very small value of the threshold should yield the same result as the default EXX
+evaluation
+         </info>
+      </var>
+      <var name="lda_plus_u" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <status>
+DFT+U (formerly known as LDA+U) currently works only for
+a few selected elements. Modify <tt>Modules/set_hubbard_l.f90</tt> and
+<tt>PW/src/tabd.f90</tt> if you plan to use DFT+U with an element that
+is not configured there.
+         </status>
+         <info>
+Specify <ref>lda_plus_u</ref> = .TRUE. to enable DFT+U calculations
+See: Anisimov, Zaanen, and Andersen, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.44.943">PRB 44, 943 (1991)</a>;
+     Anisimov et al., <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.48.16929">PRB 48, 16929 (1993)</a>;
+     Liechtenstein, Anisimov, and Zaanen, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.52.R5467">PRB 52, R5467 (1994)</a>.
+You must specify, for each species with a U term, the value of
+U and (optionally) alpha, J of the Hubbard model (all in eV):
+see <ref>lda_plus_u_kind</ref>, <ref>Hubbard_U</ref>, <ref>Hubbard_alpha</ref>, <ref>Hubbard_J</ref>
+         </info>
+      </var>
+      <var name="lda_plus_u_kind" type="INTEGER" >
+         <default> 0
+         </default>
+         <info>
+Specifies the type of DFT+U calculation:
+
+   0   simplified version of Cococcioni and de Gironcoli,
+       <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.71.035105">PRB 71, 035105 (2005)</a>, using <ref>Hubbard_U</ref>
+
+   1   rotationally invariant scheme of Liechtenstein et al.,
+       using <ref>Hubbard_U</ref> and <ref>Hubbard_J</ref>
+         </info>
+      </var>
+      <dimension name="Hubbard_U" start="1" end="ntyp" type="REAL" >
+         <default> 0.D0 for all species
+         </default>
+         <info>
+Hubbard_U(i): U parameter (eV) for species i, DFT+U calculation
+         </info>
+      </dimension>
+      <dimension name="Hubbard_J0" start="1" end="ntype" type="REAL" >
+         <default> 0.D0 for all species
+         </default>
+         <info>
+Hubbard_J0(i): J0 parameter (eV) for species i, DFT+U+J calculation,
+see <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.84.115108">PRB 84, 115108 (2011)</a> for details.
+         </info>
+      </dimension>
+      <dimension name="Hubbard_alpha" start="1" end="ntyp" type="REAL" >
+         <default> 0.D0 for all species
+         </default>
+         <info>
+Hubbard_alpha(i) is the perturbation (on atom i, in eV)
+used to compute U with the linear-response method of
+Cococcioni and de Gironcoli, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.71.035105">PRB 71, 035105 (2005)</a>
+(only for <ref>lda_plus_u_kind</ref>=0)
+         </info>
+      </dimension>
+      <dimension name="Hubbard_beta" start="1" end="ntyp" type="REAL" >
+         <default> 0.D0 for all species
+         </default>
+         <info>
+Hubbard_beta(i) is the perturbation (on atom i, in eV)
+used to compute J0 with the linear-response method of
+Cococcioni and de Gironcoli, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.71.035105">PRB 71, 035105 (2005)</a>
+(only for <ref>lda_plus_u_kind</ref>=0). See also
+<a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.84.115108">PRB 84, 115108 (2011)</a>.
+         </info>
+      </dimension>
+      <multidimension name="Hubbard_J" start="1,1" end="3,ntyp" indexes="i,ityp" type="REAL" >
+         <default> 0.D0 for all species
+         </default>
+         <info>
+Hubbard_J(i,ityp): J parameters (eV) for species ityp,
+used in DFT+U calculations (only for <ref>lda_plus_u_kind</ref>=1)
+For p orbitals:  J = Hubbard_J(1,ityp);
+For d orbitals:  J = Hubbard_J(1,ityp), B = Hubbard_J(2,ityp);
+For f orbitals:  J = Hubbard_J(1,ityp), E2 = Hubbard_J(2,ityp),
+                 E3= Hubbard_J(3,ityp).
+If B or E2 or E3 are not specified or set to 0 they will be
+calculated from J using atomic ratios.
+         </info>
+      </multidimension>
+      <multidimension name="starting_ns_eigenvalue" indexes="m,ispin,ityp" start="1,1,1" end="2*lmax+1,nspin or npol,ntyp" type="REAL" >
+         <default> -1.d0 that means NOT SET
+         </default>
+         <info>
+In the first iteration of an DFT+U run it overwrites
+the m-th eigenvalue of the ns occupation matrix for the
+ispin component of atomic species ityp.
+For the noncolin case the ispin index runs up to npol.
+The value lmax  is given by the maximum angular momentum
+number to which the Hubbard U is applied.
+Leave unchanged eigenvalues that are not set.
+This is useful to suggest the desired orbital occupations
+when the default choice takes another path.
+         </info>
+      </multidimension>
+      <var name="U_projection_type" type="CHARACTER" >
+         <default> &apos;atomic&apos;
+         </default>
+         <options>
+            <info>
+Only active when <ref>lda_plus_U</ref> is .true., specifies the type
+of projector on localized orbital to be used in the DFT+U
+scheme.
+
+Currently available choices:
+            </info>
+            <opt val="'atomic'" > use atomic wfc&apos;s (as they are) to build the projector
+            </opt>
+            <opt val="'ortho-atomic'" > use Lowdin orthogonalized atomic wfc&apos;s
+            </opt>
+            <opt val="'norm-atomic'" >
+Lowdin normalization of atomic wfc. Keep in mind:
+atomic wfc are not orthogonalized in this case.
+This is a &quot;quick and dirty&quot; trick to be used when
+atomic wfc from the pseudopotential are not
+normalized (and thus produce occupation whose
+value exceeds unity). If orthogonalized wfc are
+not needed always try <b>&apos;atomic&apos;</b> first.
+            </opt>
+            <opt val="'file'" >
+use the information from file &quot;prefix&quot;.atwfc that must
+have been generated previously, for instance by pmw.x
+(see PP/src/poormanwannier.f90 for details).
+            </opt>
+            <opt val="'pseudo'" >
+use the pseudopotential projectors. The charge density
+outside the atomic core radii is excluded.
+N.B.: for atoms with +U, a pseudopotential with the
+all-electron atomic wavefunctions is required (i.e.,
+as generated by ld1.x with lsave_wfc flag).
+            </opt>
+            <info>
+NB: forces and stress currently implemented only for the
+&apos;atomic&apos; and &apos;pseudo&apos; choice.
+            </info>
+         </options>
+      </var>
+      <var name="edir" type="INTEGER" >
+         <info>
+The direction of the electric field or dipole correction is
+parallel to the bg(:,edir) reciprocal lattice vector, so the
+potential is constant in planes defined by FFT grid points;
+<ref>edir</ref> = 1, 2 or 3. Used only if <ref>tefield</ref> is .TRUE.
+         </info>
+      </var>
+      <var name="emaxpos" type="REAL" >
+         <default> 0.5D0
+         </default>
+         <info>
+Position of the maximum of the saw-like potential along crystal
+axis <ref>edir</ref>, within the  unit cell (see below), 0 &lt; emaxpos &lt; 1
+Used only if <ref>tefield</ref> is .TRUE.
+         </info>
+      </var>
+      <var name="eopreg" type="REAL" >
+         <default> 0.1D0
+         </default>
+         <info>
+Zone in the unit cell where the saw-like potential decreases.
+( see below, 0 &lt; eopreg &lt; 1 ). Used only if <ref>tefield</ref> is .TRUE.
+         </info>
+      </var>
+      <var name="eamp" type="REAL" >
+         <default> 0.001 a.u.
+         </default>
+         <info>
+Amplitude of the electric field, in ***Hartree*** a.u.;
+1 a.u. = 51.4220632*10^10 V/m. Used only if <ref>tefield</ref>==.TRUE.
+The saw-like potential increases with slope <ref>eamp</ref> in the
+region from (<ref>emaxpos</ref>+<ref>eopreg</ref>-1) to (<ref>emaxpos</ref>), then decreases
+to 0 until (<ref>emaxpos</ref>+<ref>eopreg</ref>), in units of the crystal
+vector <ref>edir</ref>. Important: the change of slope of this
+potential must be located in the empty region, or else
+unphysical forces will result.
+         </info>
+      </var>
+      <dimension name="angle1" start="1" end="ntyp" type="REAL" >
+         <info>
+The angle expressed in degrees between the initial
+magnetization and the z-axis. For noncollinear calculations
+only; index i runs over the atom types.
+         </info>
+      </dimension>
+      <dimension name="angle2" start="1" end="ntyp" type="REAL" >
+         <info>
+The angle expressed in degrees between the projection
+of the initial magnetization on x-y plane and the x-axis.
+For noncollinear calculations only.
+         </info>
+      </dimension>
+      <var name="lforcet" type="LOGICAL" >
+         <info>
+When starting a non collinear calculation using an existing density
+file from a collinear lsda calculation assumes previous density points in
+<i>z</i> direction and rotates it in the direction described by <ref>angle1</ref> and
+<ref>angle2</ref> variables for atomic type 1
+         </info>
+      </var>
+      <var name="constrained_magnetization" type="CHARACTER" >
+         <see> lambda, fixed_magnetization
+         </see>
+         <default> &apos;none&apos;
+         </default>
+         <options>
+            <info>
+Used to perform constrained calculations in magnetic systems.
+Currently available choices:
+            </info>
+            <opt val="'none'" >
+no constraint
+            </opt>
+            <opt val="'total'" >
+total magnetization is constrained by
+adding a penalty functional to the total energy:
+
+LAMBDA * SUM_{i} ( magnetization(i) - fixed_magnetization(i) )**2
+
+where the sum over i runs over the three components of
+the magnetization. Lambda is a real number (see below).
+Noncolinear case only. Use <ref>tot_magnetization</ref> for LSDA
+            </opt>
+            <opt val="'atomic'" >
+atomic magnetization are constrained to the defined
+starting magnetization adding a penalty:
+
+LAMBDA * SUM_{i,itype} ( magnetic_moment(i,itype) - mcons(i,itype) )**2
+
+where i runs over the cartesian components (or just z
+in the collinear case) and itype over the types (1-ntype).
+mcons(:,:) array is defined from starting_magnetization,
+(and angle1, angle2 in the non-collinear case). lambda is
+a real number
+            </opt>
+            <opt val="'total direction'" >
+the angle theta of the total magnetization
+with the z axis (theta = fixed_magnetization(3))
+is constrained:
+
+LAMBDA * ( arccos(magnetization(3)/mag_tot) - theta )**2
+
+where mag_tot is the modulus of the total magnetization.
+            </opt>
+            <opt val="'atomic direction'" >
+not all the components of the atomic
+magnetic moment are constrained but only the cosine
+of angle1, and the penalty functional is:
+
+LAMBDA * SUM_{itype} ( mag_mom(3,itype)/mag_mom_tot - cos(angle1(ityp)) )**2
+            </opt>
+            <info>
+N.B.: symmetrization may prevent to reach the desired orientation
+of the magnetization. Try not to start with very highly symmetric
+configurations or use the nosym flag (only as a last remedy)
+            </info>
+         </options>
+      </var>
+      <dimension name="fixed_magnetization" start="1" end="3" type="REAL" >
+         <see> constrained_magnetization
+         </see>
+         <default> 0.d0
+         </default>
+         <info>
+total magnetization vector (x,y,z components) to be kept
+fixed when <ref>constrained_magnetization</ref>==&apos;total&apos;
+         </info>
+      </dimension>
+      <var name="lambda" type="REAL" >
+         <see> constrained_magnetization
+         </see>
+         <default> 1.d0
+         </default>
+         <info>
+parameter used for constrained_magnetization calculations
+N.B.: if the scf calculation does not converge, try to reduce lambda
+      to obtain convergence, then restart the run with a larger lambda
+         </info>
+      </var>
+      <var name="report" type="INTEGER" >
+         <default> 100
+         </default>
+         <info>
+Number of iterations after which the program
+writes all the atomic magnetic moments.
+         </info>
+      </var>
+      <var name="lspinorb" type="LOGICAL" >
+         <info>
+if .TRUE. the noncollinear code can use a pseudopotential with
+spin-orbit.
+         </info>
+      </var>
+      <var name="assume_isolated" type="CHARACTER" >
+         <default> &apos;none&apos;
+         </default>
+         <options>
+            <info>
+Used to perform calculation assuming the system to be
+isolated (a molecule or a cluster in a 3D supercell).
+
+Currently available choices:
+            </info>
+            <opt val="'none'" >
+(default): regular periodic calculation w/o any correction.
+            </opt>
+            <opt val="'makov-payne', 'm-p', 'mp'" >
+the Makov-Payne correction to the
+total energy is computed. An estimate of the vacuum
+level is also calculated so that eigenvalues can be
+properly aligned. ONLY FOR CUBIC SYSTEMS (<ref>ibrav</ref>=1,2,3).
+Theory: G.Makov, and M.C.Payne,
+     &quot;Periodic boundary conditions in ab initio
+     calculations&quot; , <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.51.4014">PRB 51, 4014 (1995)</a>.
+            </opt>
+            <opt val="'martyna-tuckerman', 'm-t', 'mt'" >
+Martyna-Tuckerman correction
+to both total energy and scf potential. Adapted from:
+G.J. Martyna, and M.E. Tuckerman,
+&quot;A reciprocal space based method for treating long
+range interactions in ab-initio and force-field-based
+calculation in clusters&quot;, J. Chem. Phys. 110, 2810 (1999),
+<a href="http://dx.doi.org/10.1063/1.477923">doi:10.1063/1.477923</a>.
+            </opt>
+            <opt val="'esm'" >
+Effective Screening Medium Method.
+For polarized or charged slab calculation, embeds
+the simulation cell within an effective semi-
+infinite medium in the perpendicular direction
+(along z). Embedding regions can be vacuum or
+semi-infinite metal electrodes (use <ref>esm_bc</ref> to
+choose boundary conditions). If between two
+electrodes, an optional electric field
+(&apos;esm_efield&apos;) may be applied. Method described in
+M. Otani and O. Sugino, &quot;First-principles calculations
+of charged surfaces and interfaces: A plane-wave
+nonrepeated slab approach&quot;, <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.73.115407">PRB 73, 115407 (2006)</a>.
+
+NB:
+   - Two dimensional (xy plane) average charge density
+     and electrostatic potentials are printed out to
+     &apos;prefix.esm1&apos;.
+
+   - Requires cell with a_3 lattice vector along z,
+     normal to the xy plane, with the slab centered
+     around z=0. Also requires symmetry checking to be
+     disabled along z, either by setting <ref>nosym</ref> = .TRUE.
+     or by very slight displacement (i.e., 5e-4 a.u.)
+     of the slab along z.
+
+   - Components of the total stress; sigma_xy, sigma_yz,
+     sigma_zz, sigma_zy, and sigma_zx are meaningless
+     because ESM stress routines calculate only
+     components of stress; sigma_xx, sigma_xy, sigma_yx,
+     and sigma_yy.
+
+   - In case of calculation=&apos;vc-relax&apos;, use
+     cell_dofree=&apos;2Dxy&apos; or other parameters so that
+     c-vector along z-axis should not be moved.
+
+See <ref>esm_bc</ref>, <ref>esm_efield</ref>, <ref>esm_w</ref>, <ref>esm_nfit</ref>.
+            </opt>
+            <opt val="'2D'" >
+Truncation of the Coulomb interaction in the z direction
+for structures periodic in the x-y plane. Total energy,
+forces and stresses are computed in a two-dimensional framework.
+Linear-response calculations () done on top of a self-consistent
+calculation with this flag will automatically be performed in
+the 2D framework as well. Please refer to:
+Sohier, T., Calandra, M., &amp; Mauri, F. (2017), Density functional
+perturbation theory for gated two-dimensional heterostructures:
+Theoretical developments and application to flexural phonons in graphene.
+Physical Review B, 96(7), 75448. <link>https://doi.org/10.1103/PhysRevB.96.075448</link>
+
+NB:
+   - The length of the unit-cell along the z direction should
+     be larger than twice the thickness of the 2D material
+     (including electrons). A reasonable estimate for a
+     layer&apos;s thickness could be the interlayer distance in the
+     corresponding layered bulk material. Otherwise,
+     the atomic thickness + 10 bohr should be a safe estimate.
+     There is also a lower limit of 20 bohr imposed by the cutoff
+     radius used to read pseudopotentials (see read_pseudo.f90 in Modules).
+
+   - As for ESM above, only in-plane stresses make sense and one
+     should use cell_dofree=&apos;2Dxy&apos; in a vc-relax calculation.
+            </opt>
+         </options>
+      </var>
+      <var name="esm_bc" type="CHARACTER" >
+         <see> assume_isolated
+         </see>
+         <default> &apos;pbc&apos;
+         </default>
+         <options>
+            <info>
+If <ref>assume_isolated</ref> = &apos;esm&apos;, determines the boundary
+conditions used for either side of the slab.
+
+Currently available choices:
+            </info>
+            <opt val="'pbc'" > (default): regular periodic calculation (no ESM).
+            </opt>
+            <opt val="'bc1'" > Vacuum-slab-vacuum (open boundary conditions).
+            </opt>
+            <opt val="'bc2'" >
+Metal-slab-metal (dual electrode configuration).
+See also <ref>esm_efield</ref>.
+            </opt>
+            <opt val="'bc3'" > Vacuum-slab-metal
+            </opt>
+         </options>
+      </var>
+      <var name="esm_w" type="REAL" >
+         <see> assume_isolated
+         </see>
+         <default> 0.d0
+         </default>
+         <info>
+If <ref>assume_isolated</ref> = &apos;esm&apos;, determines the position offset
+[in a.u.] of the start of the effective screening region,
+measured relative to the cell edge. (ESM region begins at
+z = +/- [L_z/2 + esm_w] ).
+         </info>
+      </var>
+      <var name="esm_efield" type="REAL" >
+         <see> assume_isolated
+         </see>
+         <default> 0.d0
+         </default>
+         <info>
+If <ref>assume_isolated</ref> = &apos;esm&apos; and <ref>esm_bc</ref> = &apos;bc2&apos;, gives the
+magnitude of the electric field [Ry/a.u.] to be applied
+between semi-infinite ESM electrodes.
+         </info>
+      </var>
+      <var name="esm_nfit" type="INTEGER" >
+         <see> assume_isolated
+         </see>
+         <default> 4
+         </default>
+         <info>
+If <ref>assume_isolated</ref> = &apos;esm&apos;, gives the number of z-grid points
+for the polynomial fit along the cell edge.
+         </info>
+      </var>
+      <var name="fcp_mu" type="REAL" >
+         <see> lfcpopt
+         </see>
+         <default> 0.d0
+         </default>
+         <info>
+If <ref>lfcpopt</ref> = .TRUE., gives the target Fermi energy [Ry]. One can start
+with appropriate total charge of the system by giving &apos;tot_charge&apos;.
+         </info>
+      </var>
+      <var name="vdw_corr" type="CHARACTER" >
+         <default> &apos;none&apos;
+         </default>
+         <see>
+london_s6, london_rcut, london_c6, london_rvdw,
+dftd3_version, dftd3_threebody, ts_vdw_econv_thr, ts_vdw_isolated, xdm_a1, xdm_a2
+         </see>
+         <options>
+            <info>
+Type of Van der Waals correction. Allowed values:
+            </info>
+            <opt val="'grimme-d2', 'Grimme-D2', 'DFT-D', 'dft-d'" >
+Semiempirical Grimme&apos;s DFT-D2. Optional variables:
+<ref>london_s6</ref>, <ref>london_rcut</ref>, <ref>london_c6</ref>, <ref>london_rvdw</ref>
+S. Grimme, J. Comp. Chem. 27, 1787 (2006), <a href="http://dx.doi.org/10.1002/jcc.20495">doi:10.1002/jcc.20495</a>
+V. Barone et al., J. Comp. Chem. 30, 934 (2009), <a href="http://dx.doi.org/10.1002/jcc.21112">doi:10.1002/jcc.21112</a>
+            </opt>
+            <opt val="'grimme-d3', 'Grimme-D3', 'DFT-D3', 'dft-d3' " >
+Semiempirical Grimme&apos;s DFT-D3. Optional variables:
+<ref>dftd3_version</ref>, <ref>dftd3_threebody</ref>
+S. Grimme et al, J. Chem. Phys 132, 154104 (2010), <a href="http://dx.doi.org/10.1002/jcc.20495">doi:10.1002/jcc.20495</a>
+            </opt>
+            <opt val="'TS', 'ts', 'ts-vdw', 'ts-vdW', 'tkatchenko-scheffler'" >
+Tkatchenko-Scheffler dispersion corrections with first-principle derived
+C6 coefficients.
+Optional variables: <ref>ts_vdw_econv_thr</ref>, <ref>ts_vdw_isolated</ref>
+See A. Tkatchenko and M. Scheffler, <a href="https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.102.073005">PRL 102, 073005 (2009)</a>.
+            </opt>
+            <opt val="'XDM', 'xdm'" >
+Exchange-hole dipole-moment model. Optional variables: <ref>xdm_a1</ref>, <ref>xdm_a2</ref>
+A. D. Becke et al., J. Chem. Phys. 127, 154108 (2007), <a href="http://dx.doi.org/10.1063/1.2795701">doi:10.1063/1.2795701</a>
+A. Otero de la Roza et al., J. Chem. Phys. 136, 174109 (2012),
+<a href="http://dx.doi.org/10.1063/1.4705760">doi:10.1063/1.4705760</a>
+            </opt>
+            <info> Note that non-local functionals (eg vdw-DF) are NOT specified here but in <ref>input_dft</ref>
+            </info>
+         </options>
+      </var>
+      <var name="london" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <status>
+OBSOLESCENT, same as <ref>vdw_corr</ref>=&apos;DFT-D&apos;
+         </status>
+      </var>
+      <var name="london_s6" type="REAL" >
+         <default> 0.75
+         </default>
+         <info>
+global scaling parameter for DFT-D. Default is good for PBE.
+         </info>
+      </var>
+      <dimension name="london_c6" type="REAL" start="1" end="ntyp" >
+         <default> standard Grimme-D2 values
+         </default>
+         <info>
+atomic C6 coefficient of each atom type
+
+( if not specified default values from S. Grimme, J. Comp. Chem. 27, 1787 (2006),
+  <a href="http://dx.doi.org/10.1002/jcc.20495">doi:10.1002/jcc.20495</a> are used; see file Modules/mm_dispersion.f90 )
+         </info>
+      </dimension>
+      <dimension name="london_rvdw" type="REAL" start="1" end="ntyp" >
+         <default> standard Grimme-D2 values
+         </default>
+         <info>
+atomic vdw radii of each atom type
+
+( if not specified default values from S. Grimme, J. Comp. Chem. 27, 1787 (2006),
+  <a href="http://dx.doi.org/10.1002/jcc.20495">doi:10.1002/jcc.20495</a> are used; see file Modules/mm_dispersion.f90 )
+         </info>
+      </dimension>
+      <var name="london_rcut" type="REAL" >
+         <default> 200
+         </default>
+         <info>
+cutoff radius (a.u.) for dispersion interactions
+         </info>
+      </var>
+      <var name="dftd3_version" type="integer" >
+         <default> 3
+         </default>
+         <options>
+            <info>
+Version of Grimme implementation of Grimme-D3:
+            </info>
+            <opt val="dftd3_version = 2" >
+Original Grimme-D2 parametrization
+            </opt>
+            <opt val="dftd3_version = 3" >
+Grimme-D3 (zero damping)
+            </opt>
+            <opt val="dftd3_version = 4" >
+Grimme-D3 (BJ damping)
+            </opt>
+            <opt val="dftd3_version = 5" >
+Grimme-D3M (zero damping)
+            </opt>
+            <opt val="dftd3_version = 6" >
+Grimme-D3M (BJ damping)
+            </opt>
+            <info>
+NOTE: not all functionals are parametrized.
+            </info>
+         </options>
+      </var>
+      <var name="dftd3_threebody" type="LOGICAL" >
+         <default> TRUE
+         </default>
+         <info>
+Turn three-body terms in Grimme-D3 on. If .false. two-body contributions
+only are computed, using two-body parameters of Grimme-D3.
+If dftd3_version=2, three-body contribution is always disabled.
+         </info>
+      </var>
+      <var name="ts_vdw_econv_thr" type="REAL" >
+         <default> 1.D-6
+         </default>
+         <info>
+Optional: controls the convergence of the vdW energy (and forces). The default value
+is a safe choice, likely too safe, but you do not gain much in increasing it
+         </info>
+      </var>
+      <var name="ts_vdw_isolated" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+Optional: set it to .TRUE. when computing the Tkatchenko-Scheffler vdW energy
+for an isolated (non-periodic) system.
+         </info>
+      </var>
+      <var name="xdm" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <status>
+OBSOLESCENT, same as <ref>vdw_corr</ref>=&apos;xdm&apos;
+         </status>
+      </var>
+      <var name="xdm_a1" type="REAL" >
+         <default> 0.6836
+         </default>
+         <info>
+Damping function parameter a1 (adimensional). It is NOT necessary to give
+a value if the functional is one of B86bPBE, PW86PBE, PBE, BLYP. For functionals
+in this list, the coefficients are given in:
+   <link>http://schooner.chem.dal.ca/wiki/XDM</link>
+   A. Otero de la Roza, E. R. Johnson, J. Chem. Phys. 138, 204109 (2013),
+   <a href="http://dx.doi.org/10.1063/1.4705760">doi:10.1063/1.4705760</a>
+         </info>
+      </var>
+      <var name="xdm_a2" type="REAL" >
+         <default> 1.5045
+         </default>
+         <info>
+Damping function parameter a2 (angstrom). It is NOT necessary to give
+a value if the functional is one of B86bPBE, PW86PBE, PBE, BLYP. For functionals
+in this list, the coefficients are given in:
+   <link>http://schooner.chem.dal.ca/wiki/XDM</link>
+   A. Otero de la Roza, E. R. Johnson, J. Chem. Phys. 138, 204109 (2013),
+   <a href="http://dx.doi.org/10.1063/1.4705760">doi:10.1063/1.4705760</a>
+         </info>
+      </var>
+      <var name="space_group" type="INTEGER" >
+         <default> 0
+         </default>
+         <info>
+The number of the space group of the crystal, as given
+in the International Tables of Crystallography A (ITA).
+This allows to give in input only the inequivalent atomic
+positions. The positions of all the symmetry equivalent atoms
+are calculated by the code. Used only when the atomic positions
+are of type crystal_sg. See also <ref>uniqueb</ref>,
+<ref>origin_choice</ref>, <ref>rhombohedral</ref>
+         </info>
+      </var>
+      <var name="uniqueb" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+Used only for monoclinic lattices. If .TRUE. the b
+unique ibrav (-12 or -13) are used, and symmetry
+equivalent positions are chosen assuming that the
+two fold axis or the mirror normal is parallel to the
+b axis. If .FALSE. it is parallel to the c axis.
+         </info>
+      </var>
+      <var name="origin_choice" type="INTEGER" >
+         <default> 1
+         </default>
+         <info>
+Used only for space groups that in the ITA allow
+the use of two different origins. origin_choice=1,
+means the first origin, while origin_choice=2 is the
+second origin.
+         </info>
+      </var>
+      <var name="rhombohedral" type="LOGICAL" >
+         <default> .TRUE.
+         </default>
+         <info>
+Used only for rhombohedral space groups.
+When .TRUE. the coordinates of the inequivalent atoms are
+given with respect to the rhombohedral axes, when .FALSE.
+the coordinates of the inequivalent atoms are given with
+respect to the hexagonal axes. They are converted internally
+to the rhombohedral axes and <ref>ibrav</ref>=5 is used in both cases.
+         </info>
+      </var>
+      <group>
+         <label> variables used only if <ref>gate</ref> = .TRUE.
+         </label>
+         <var name="zgate" type="REAL" >
+            <default> 0.5
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE.
+Specifies the position of the charged plate which represents
+the counter charge in doped systems (<ref>tot_charge</ref> .ne. 0).
+In units of the unit cell length in <i>z</i> direction, <ref>zgate</ref> in ]0,1[
+Details of the gate potential can be found in
+T. Brumme, M. Calandra, F. Mauri; <a href="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.89.245406">PRB 89, 245406 (2014)</a>.
+            </info>
+         </var>
+         <var name="relaxz" type="LOGICAL" >
+            <default> .FALSE.
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE.
+Allows the relaxation of the system towards the charged plate.
+Use carefully and utilize either a layer of fixed atoms or a
+potential barrier (<ref>block</ref>=.TRUE.) to avoid the atoms moving to
+the position of the plate or the dipole of the dipole
+correction (<ref>dipfield</ref>=.TRUE.).
+            </info>
+         </var>
+         <var name="block" type="LOGICAL" >
+            <default> .FALSE.
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE.
+Adds a potential barrier to the total potential seen by the
+electrons to mimic a dielectric in field effect configuration
+and/or to avoid electrons spilling into the vacuum region for
+electron doping. Potential barrier is from <ref>block_1</ref> to <ref>block_2</ref> and
+has a height of block_height.
+If <ref>dipfield</ref> = .TRUE. then <ref>eopreg</ref> is used for a smooth increase and
+decrease of the potential barrier.
+            </info>
+         </var>
+         <var name="block_1" type="REAL" >
+            <default> 0.45
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE. and <ref>block</ref> = .TRUE.
+lower beginning of the potential barrier, in units of the
+unit cell size along <i>z,</i> <ref>block_1</ref> in ]0,1[
+            </info>
+         </var>
+         <var name="block_2" type="REAL" >
+            <default> 0.55
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE. and <ref>block</ref> = .TRUE.
+upper beginning of the potential barrier, in units of the
+unit cell size along <i>z,</i> <ref>block_2</ref> in ]0,1[
+            </info>
+         </var>
+         <var name="block_height" type="REAL" >
+            <default> 0.1
+            </default>
+            <info>
+used only if <ref>gate</ref> = .TRUE. and <ref>block</ref> = .TRUE.
+Height of the potential barrier in Rydberg.
+            </info>
+         </var>
+      </group>
+   </namelist>
+   <namelist name="ELECTRONS" >
+      <var name="electron_maxstep" type="INTEGER" >
+         <default> 100
+         </default>
+         <info>
+maximum number of iterations in a scf step
+         </info>
+      </var>
+      <var name="scf_must_converge" type="LOGICAL" >
+         <default> .TRUE.
+         </default>
+         <info>
+If .false. do not stop molecular dynamics or ionic relaxation
+when electron_maxstep is reached. Use with care.
+         </info>
+      </var>
+      <var name="conv_thr" type="REAL" >
+         <default> 1.D-6
+         </default>
+         <info>
+Convergence threshold for selfconsistency:
+   estimated energy error &lt; conv_thr
+(note that conv_thr is extensive, like the total energy).
+
+For non-self-consistent calculations, conv_thr is used
+to set the default value of the threshold (ethr) for
+iterative diagonalizazion: see <ref>diago_thr_init</ref>
+         </info>
+      </var>
+      <var name="adaptive_thr" type="LOGICAL" >
+         <default> .FALSE
+         </default>
+         <info>
+If .TRUE. this turns on the use of an adaptive <ref>conv_thr</ref> for
+the inner scf loops when using EXX.
+         </info>
+      </var>
+      <var name="conv_thr_init" type="REAL" >
+         <default> 1.D-3
+         </default>
+         <info>
+When <ref>adaptive_thr</ref> = .TRUE. this is the convergence threshold
+used for the first scf cycle.
+         </info>
+      </var>
+      <var name="conv_thr_multi" type="REAL" >
+         <default> 1.D-1
+         </default>
+         <info>
+When <ref>adaptive_thr</ref> = .TRUE. the convergence threshold for
+each scf cycle is given by:
+max( <ref>conv_thr</ref>, <ref>conv_thr_multi</ref> * dexx )
+         </info>
+      </var>
+      <var name="mixing_mode" type="CHARACTER" >
+         <default> &apos;plain&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'plain'" > charge density Broyden mixing
+            </opt>
+            <opt val="'TF'" >
+as above, with simple Thomas-Fermi screening
+(for highly homogeneous systems)
+            </opt>
+            <opt val="'local-TF'" >
+as above, with local-density-dependent TF screening
+(for highly inhomogeneous systems)
+            </opt>
+         </options>
+      </var>
+      <var name="mixing_beta" type="REAL" >
+         <default> 0.7D0
+         </default>
+         <info>
+mixing factor for self-consistency
+         </info>
+      </var>
+      <var name="mixing_ndim" type="INTEGER" >
+         <default> 8
+         </default>
+         <info>
+number of iterations used in mixing scheme.
+If you are tight with memory, you may reduce it to 4 or so.
+         </info>
+      </var>
+      <var name="mixing_fixed_ns" type="INTEGER" >
+         <default> 0
+         </default>
+         <info>
+For DFT+U : number of iterations with fixed ns ( ns is the
+atomic density appearing in the Hubbard term ).
+         </info>
+      </var>
+      <var name="diagonalization" type="CHARACTER" >
+         <default> &apos;david&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'david'" >
+Davidson iterative diagonalization with overlap matrix
+(default). Fast, may in some rare cases fail.
+            </opt>
+            <opt val="'cg'" >
+Conjugate-gradient-like band-by-band diagonalization.
+Slower than &apos;david&apos; but uses less memory and is
+(a little bit) more robust.
+            </opt>
+            <opt val="'cg-serial', 'david-serial'" >
+OBSOLETE, use <b>-ndiag 1</b> instead.
+The subspace diagonalization in Davidson is performed
+by a fully distributed-memory parallel algorithm on
+4 or more processors, by default. The allocated memory
+scales down with the number of procs. Procs involved
+in diagonalization can be changed with command-line
+option <b>-ndiag</b> <i>N.</i> On multicore CPUs it is often
+convenient to let just one core per CPU to work
+on linear algebra.
+            </opt>
+         </options>
+      </var>
+      <var name="ortho_para" type="INTEGER" >
+         <default> 0
+         </default>
+         <status> OBSOLETE: use command-line option <tt>&quot;-ndiag XX&quot;</tt> instead
+         </status>
+      </var>
+      <var name="diago_thr_init" type="REAL" >
+         <info>
+Convergence threshold (ethr) for iterative diagonalization
+(the check is on eigenvalue convergence).
+
+For scf calculations: default is 1.D-2 if starting from a
+superposition of atomic orbitals; 1.D-5 if starting from a
+charge density. During self consistency the threshold
+is automatically reduced (but never below 1.D-13) when
+approaching convergence.
+
+For non-scf calculations: default is (<ref>conv_thr</ref>/N elec)/10.
+         </info>
+      </var>
+      <var name="diago_cg_maxiter" type="INTEGER" >
+         <info>
+For conjugate gradient diagonalization:  max number of iterations
+         </info>
+      </var>
+      <var name="diago_david_ndim" type="INTEGER" >
+         <default> 4
+         </default>
+         <info>
+For Davidson diagonalization: dimension of workspace
+(number of wavefunction packets, at least 2 needed).
+A larger value may yield a smaller number of iterations in
+the algorithm but uses more memory and more CPU time in
+subspace diagonalization.
+Try <ref>diago_david_ndim</ref>=2 if you are tight on memory or if
+the time spent in subspace diagonalization (cdiaghg/rdiaghg)
+is significant compared to the time spent in h_psi
+         </info>
+      </var>
+      <var name="diago_full_acc" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .TRUE. all the empty states are diagonalized at the same level
+of accuracy of the occupied ones. Otherwise the empty states are
+diagonalized using a larger threshold (this should not affect
+total energy, forces, and other ground-state properties).
+         </info>
+      </var>
+      <var name="efield" type="REAL" >
+         <default> 0.D0
+         </default>
+         <info>
+Amplitude of the finite electric field (in Ry a.u.;
+1 a.u. = 36.3609*10^10 V/m). Used only if <ref>lelfield</ref>==.TRUE.
+and if k-points (<ref>K_POINTS</ref> card) are not automatic.
+         </info>
+      </var>
+      <dimension name="efield_cart" start="1" end="3" type="REAL" >
+         <default> (0.D0, 0.D0, 0.D0)
+         </default>
+         <info>
+Finite electric field (in Ry a.u.=36.3609*10^10 V/m) in
+cartesian axis. Used only if <ref>lelfield</ref>==.TRUE. and if
+k-points (<ref>K_POINTS</ref> card) are automatic.
+         </info>
+      </dimension>
+      <var name="efield_phase" type="CHARACTER" >
+         <default> &apos;none&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'read'" >
+set the zero of the electronic polarization (with <ref>lelfield</ref>==.true..)
+to the result of a previous calculation
+            </opt>
+            <opt val="'write'" >
+write on disk data on electronic polarization to be read in another
+calculation
+            </opt>
+            <opt val="'none'" >
+none of the above points
+            </opt>
+         </options>
+      </var>
+      <var name="startingpot" type="CHARACTER" >
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'atomic'" >
+starting potential from atomic charge superposition
+(default for scf, *relax, *md)
+            </opt>
+            <opt val="'file'" >
+start from existing &quot;charge-density.xml&quot; file in the
+directory specified by variables <ref>prefix</ref> and <ref>outdir</ref>
+For nscf and bands calculation this is the default
+and the only sensible possibility.
+            </opt>
+         </options>
+      </var>
+      <var name="startingwfc" type="CHARACTER" >
+         <default> &apos;atomic+random&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'atomic'" >
+Start from superposition of atomic orbitals.
+If not enough atomic orbitals are available,
+fill with random numbers the remaining wfcs
+The scf typically starts better with this option,
+but in some high-symmetry cases one can &quot;loose&quot;
+valence states, ending up in the wrong ground state.
+            </opt>
+            <opt val="'atomic+random'" >
+As above, plus a superimposed &quot;randomization&quot;
+of atomic orbitals. Prevents the &quot;loss&quot; of states
+mentioned above.
+            </opt>
+            <opt val="'random'" >
+Start from random wfcs. Slower start of scf but safe.
+It may also reduce memory usage in conjunction with
+<ref>diagonalization</ref>=&apos;cg&apos;.
+            </opt>
+            <opt val="'file'" >
+Start from an existing wavefunction file in the
+directory specified by variables <ref>prefix</ref> and <ref>outdir</ref>.
+            </opt>
+         </options>
+      </var>
+      <var name="tqr" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .true., use a real-space algorithm for augmentation
+charges of ultrasoft pseudopotentials and PAWsets.
+Faster but numerically less accurate than the default
+G-space algorithm. Use with care and after testing!
+         </info>
+      </var>
+      <var name="real_space" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+If .true., exploit real-space localization to compute
+matrix elements for nonlocal projectors. Faster and in
+principle better scaling than the default G-space algorithm,
+but numerically less accurate, may lead to some loss of
+translational invariance. Use with care and after testing!
+         </info>
+      </var>
+   </namelist>
+   <namelist name="IONS" >
+      <label>
+input this namelist only if <ref>calculation</ref> == &apos;relax&apos;, &apos;md&apos;, &apos;vc-relax&apos;, or &apos;vc-md&apos;
+      </label>
+      <var name="ion_dynamics" type="CHARACTER" >
+         <options>
+            <info>
+Specify the type of ionic dynamics.
+
+For different type of calculation different possibilities are
+allowed and different default values apply:
+
+<b>CASE</b> ( <ref>calculation</ref> == &apos;relax&apos; )
+            </info>
+            <opt val="'bfgs'" >
+<b>(default)</b>  use BFGS quasi-newton algorithm,
+based on the trust radius procedure,
+for structural relaxation
+            </opt>
+            <opt val="'damp'" >
+use damped (quick-min Verlet)
+dynamics for structural relaxation
+Can be used for constrained
+optimisation: see <ref>CONSTRAINTS</ref> card
+            </opt>
+            <info>
+<b>CASE</b> ( <ref>calculation</ref> == &apos;md&apos; )
+            </info>
+            <opt val="'verlet'" >
+<b>(default)</b>  use Verlet algorithm to integrate
+Newton&apos;s equation. For constrained
+dynamics, see <ref>CONSTRAINTS</ref> card
+            </opt>
+            <opt val="'langevin'" >
+ion dynamics is over-damped Langevin
+            </opt>
+            <opt val="'langevin-smc'" >
+over-damped Langevin with Smart Monte Carlo:
+see R.J. Rossky, JCP, 69, 4628 (1978), <a href="http://dx.doi.org/10.1063/1.436415">doi:10.1063/1.436415</a>
+            </opt>
+            <info>
+<b>CASE</b> ( <ref>calculation</ref> == &apos;vc-relax&apos; )
+            </info>
+            <opt val="'bfgs'" >
+<b>(default)</b>  use BFGS quasi-newton algorithm;
+cell_dynamics must be &apos;bfgs&apos; too
+            </opt>
+            <opt val="'damp'" >
+use damped (Beeman) dynamics for
+structural relaxation
+            </opt>
+            <info>
+<b>CASE</b> ( <ref>calculation</ref> == &apos;vc-md&apos; )
+            </info>
+            <opt val="'beeman'" >
+<b>(default)</b>  use Beeman algorithm to integrate
+Newton&apos;s equation
+            </opt>
+         </options>
+      </var>
+      <var name="ion_positions" type="CHARACTER" >
+         <default> &apos;default&apos;
+         </default>
+         <options>
+            <info> Available options are:
+            </info>
+            <opt val="'default'" >
+if restarting, use atomic positions read from the
+restart file; in all other cases, use atomic
+positions from standard input.
+            </opt>
+            <opt val="'from_input'" >
+restart the simulation with atomic positions read
+from standard input, even if restarting.
+            </opt>
+         </options>
+      </var>
+      <var name="pot_extrapolation" type="CHARACTER" >
+         <default> &apos;atomic&apos;
+         </default>
+         <options>
+            <info>
+Used to extrapolate the potential from preceding ionic steps.
+            </info>
+            <opt val="'none'" > no extrapolation
+            </opt>
+            <opt val="'atomic'" >
+extrapolate the potential as if it was a sum of
+atomic-like orbitals
+            </opt>
+            <opt val="'first_order'" >
+extrapolate the potential with first-order
+formula
+            </opt>
+            <opt val="'second_order'" >
+as above, with second order formula
+            </opt>
+            <info>
+Note: &apos;first_order&apos; and &apos;second-order&apos; extrapolation make sense
+only for molecular dynamics calculations
+            </info>
+         </options>
+      </var>
+      <var name="wfc_extrapolation" type="CHARACTER" >
+         <default> &apos;none&apos;
+         </default>
+         <options>
+            <info>
+Used to extrapolate the wavefunctions from preceding ionic steps.
+            </info>
+            <opt val="'none'" > no extrapolation
+            </opt>
+            <opt val="'first_order'" >
+extrapolate the wave-functions with first-order formula.
+            </opt>
+            <opt val="'second_order'" >
+as above, with second order formula.
+            </opt>
+            <info>
+Note: <b>&apos;first_order&apos;</b> and <b>&apos;second-order&apos;</b> extrapolation make sense
+only for molecular dynamics calculations
+            </info>
+         </options>
+      </var>
+      <var name="remove_rigid_rot" type="LOGICAL" >
+         <default> .FALSE.
+         </default>
+         <info>
+This keyword is useful when simulating the dynamics and/or the
+thermodynamics of an isolated system. If set to true the total
+torque of the internal forces is set to zero by adding new forces
+that compensate the spurious interaction with the periodic
+images. This allows for the use of smaller supercells.
+
+BEWARE: since the potential energy is no longer consistent with
+the forces (it still contains the spurious interaction with the
+repeated images), the total energy is not conserved anymore.
+However the dynamical and thermodynamical properties should be
+in closer agreement with those of an isolated system.
+Also the final energy of a structural relaxation will be higher,
+but the relaxation itself should be faster.
+         </info>
+      </var>
+      <group>
+         <label>
+variables used for molecular dynamics
+         </label>
+         <var name="ion_temperature" type="CHARACTER" >
+            <default> &apos;not_controlled&apos;
+            </default>
+            <options>
+               <info> Available options are:
+               </info>
+               <opt val="'rescaling'" >
+control ionic temperature via velocity rescaling
+(first method) see parameters <ref>tempw</ref>, <ref>tolp</ref>, and
+<ref>nraise</ref> (for VC-MD only). This rescaling method
+is the only one currently implemented in VC-MD
+               </opt>
+               <opt val="'rescale-v'" >
+control ionic temperature via velocity rescaling
+(second method) see parameters <ref>tempw</ref> and <ref>nraise</ref>
+               </opt>
+               <opt val="'rescale-T'" >
+control ionic temperature via velocity rescaling
+(third method) see parameter <ref>delta_t</ref>
+               </opt>
+               <opt val="'reduce-T'" >
+reduce ionic temperature every <ref>nraise</ref> steps
+by the (negative) value <ref>delta_t</ref>
+               </opt>
+               <opt val="'berendsen'" >
+control ionic temperature using &quot;soft&quot; velocity
+rescaling - see parameters <ref>tempw</ref> and <ref>nraise</ref>
+               </opt>
+               <opt val="'andersen'" >
+control ionic temperature using Andersen thermostat
+see parameters <ref>tempw</ref> and <ref>nraise</ref>
+               </opt>
+               <opt val="'initial'" >
+initialize ion velocities to temperature <ref>tempw</ref>
+and leave uncontrolled further on
+               </opt>
+               <opt val="'not_controlled'" >
+(default) ionic temperature is not controlled
+               </opt>
+            </options>
+         </var>
+         <var name="tempw" type="REAL" >
+            <default> 300.D0
+            </default>
+            <info>
+Starting temperature (Kelvin) in MD runs
+target temperature for most thermostats.
+            </info>
+         </var>
+         <var name="tolp" type="REAL" >
+            <default> 100.D0
+            </default>
+            <info>
+Tolerance for velocity rescaling. Velocities are rescaled if
+the run-averaged and target temperature differ more than tolp.
+            </info>
+         </var>
+         <var name="delta_t" type="REAL" >
+            <default> 1.D0
+            </default>
+            <info>
+if <ref>ion_temperature</ref> == &apos;rescale-T&apos; :
+       at each step the instantaneous temperature is multiplied
+       by delta_t; this is done rescaling all the velocities.
+
+if <ref>ion_temperature</ref> == &apos;reduce-T&apos; :
+       every &apos;nraise&apos; steps the instantaneous temperature is
+       reduced by -<ref>delta_t</ref> (i.e. <ref>delta_t</ref> &lt; 0 is added to T)
+
+The instantaneous temperature is calculated at the end of
+every ionic move and BEFORE rescaling. This is the temperature
+reported in the main output.
+
+For <ref>delta_t</ref> &lt; 0, the actual average rate of heating or cooling
+should be roughly C*delta_t/(nraise*dt) (C=1 for an
+ideal gas, C=0.5 for a harmonic solid, theorem of energy
+equipartition between all quadratic degrees of freedom).
+            </info>
+         </var>
+         <var name="nraise" type="INTEGER" >
+            <default> 1
+            </default>
+            <info>
+if <ref>ion_temperature</ref> == &apos;reduce-T&apos; :
+       every <ref>nraise</ref> steps the instantaneous temperature is
+       reduced by -<ref>delta_t</ref> (i.e. <ref>delta_t</ref> is added to the temperature)
+
+if <ref>ion_temperature</ref> == &apos;rescale-v&apos; :
+       every <ref>nraise</ref> steps the average temperature, computed from
+       the last <ref>nraise</ref> steps, is rescaled to <ref>tempw</ref>
+
+if <ref>ion_temperature</ref> == &apos;rescaling&apos; and <ref>calculation</ref> == &apos;vc-md&apos; :
+       every <ref>nraise</ref> steps the instantaneous temperature
+       is rescaled to <ref>tempw</ref>
+
+if <ref>ion_temperature</ref> == &apos;berendsen&apos; :
+       the &quot;rise time&quot; parameter is given in units of the time step:
+       tau = nraise*dt, so dt/tau = 1/nraise
+
+if <ref>ion_temperature</ref> == &apos;andersen&apos; :
+       the &quot;collision frequency&quot; parameter is given as nu=1/tau
+       defined above, so nu*dt = 1/nraise
+            </info>
+         </var>
+         <var name="refold_pos" type="LOGICAL" >
+            <default> .FALSE.
+            </default>
+            <info>
+This keyword applies only in the case of molecular dynamics or
+damped dynamics. If true the ions are refolded at each step into
+the supercell.
+            </info>
+         </var>
+      </group>
+      <group>
+         <label>
+keywords used only in BFGS calculations
+         </label>
+         <var name="upscale" type="REAL" >
+            <default> 100.D0
+            </default>
+            <info>
+Max reduction factor for <ref>conv_thr</ref> during structural optimization
+<ref>conv_thr</ref> is automatically reduced when the relaxation
+approaches convergence so that forces are still accurate,
+but <ref>conv_thr</ref> will not be reduced to less that <ref>conv_thr</ref> / <ref>upscale</ref>.
+            </info>
+         </var>
+         <var name="bfgs_ndim" type="INTEGER" >
+            <default> 1
+            </default>
+            <info>
+Number of old forces and displacements vectors used in the
+PULAY mixing of the residual vectors obtained on the basis
+of the inverse hessian matrix given by the BFGS algorithm.
+When <ref>bfgs_ndim</ref> = 1, the standard quasi-Newton BFGS method is
+used.
+(bfgs only)
+            </info>
+         </var>
+         <var name="trust_radius_max" type="REAL" >
+            <default> 0.8D0
+            </default>
+            <info>
+Maximum ionic displacement in the structural relaxation.
+(bfgs only)
+            </info>
+         </var>
+         <var name="trust_radius_min" type="REAL" >
+            <default> 1.D-3
+            </default>
+            <info>
+Minimum ionic displacement in the structural relaxation
+BFGS is reset when <ref>trust_radius</ref> &lt; <ref>trust_radius_min</ref>.
+(bfgs only)
+            </info>
+         </var>
+         <var name="trust_radius_ini" type="REAL" >
+            <default> 0.5D0
+            </default>
+            <info>
+Initial ionic displacement in the structural relaxation.
+(bfgs only)
+            </info>
+         </var>
+         <var name="w_1" type="REAL" >
+            <default> 0.01D0
+            </default>
+            <see> w_2
+            </see>
+         </var>
+         <var name="w_2" type="REAL" >
+            <default> 0.5D0
+            </default>
+            <info>
+Parameters used in line search based on the Wolfe conditions.
+(bfgs only)
+            </info>
+         </var>
+      </group>
+   </namelist>
+   <namelist name="CELL" >
+      <label>
+input this namelist only if <ref>calculation</ref> == &apos;vc-relax&apos; or &apos;vc-md&apos;
+      </label>
+      <var name="cell_dynamics" type="CHARACTER" >
+         <options>
+            <info>
+Specify the type of dynamics for the cell.
+For different type of calculation different possibilities
+are allowed and different default values apply:
+
+<b>CASE</b> ( <ref>calculation</ref> == &apos;vc-relax&apos; )
+            </info>
+            <opt val="'none'" > no dynamics
+            </opt>
+            <opt val="'sd'" > steepest descent ( not implemented )
+            </opt>
+            <opt val="'damp-pr'" >
+damped (Beeman) dynamics of the Parrinello-Rahman extended lagrangian
+            </opt>
+            <opt val="'damp-w'" >
+damped (Beeman) dynamics of the new Wentzcovitch extended lagrangian
+            </opt>
+            <opt val="'bfgs'" >
+BFGS quasi-newton algorithm <b>(default)</b>
+<ref>ion_dynamics</ref> must be <b>&apos;bfgs&apos;</b> too
+            </opt>
+            <info>
+<b>CASE</b> ( <ref>calculation</ref> == &apos;vc-md&apos; )
+            </info>
+            <opt val="'none'" > no dynamics
+            </opt>
+            <opt val="'pr'" >
+(Beeman) molecular dynamics of the Parrinello-Rahman extended lagrangian
+            </opt>
+            <opt val="'w'" >
+(Beeman) molecular dynamics of the new Wentzcovitch extended lagrangian
+            </opt>
+         </options>
+      </var>
+      <var name="press" type="REAL" >
+         <default> 0.D0
+         </default>
+         <info>
+Target pressure [KBar] in a variable-cell md or relaxation run.
+         </info>
+      </var>
+      <var name="wmass" type="REAL" >
+         <default>
+0.75*Tot_Mass/pi**2 for Parrinello-Rahman MD;
+0.75*Tot_Mass/pi**2/Omega**(2/3) for Wentzcovitch MD
+         </default>
+         <info>
+Fictitious cell mass [amu] for variable-cell simulations
+(both &apos;vc-md&apos; and &apos;vc-relax&apos;)
+         </info>
+      </var>
+      <var name="cell_factor" type="REAL" >
+         <default> 2.0 for variable-cell calculations, 1.0 otherwise
+         </default>
+         <info>
+Used in the construction of the pseudopotential tables.
+It should exceed the maximum linear contraction of the
+cell during a simulation.
+         </info>
+      </var>
+      <var name="press_conv_thr" type="REAL" >
+         <default> 0.5D0 Kbar
+         </default>
+         <info>
+Convergence threshold on the pressure for variable cell
+relaxation (&apos;vc-relax&apos; : note that the other convergence
+            thresholds for ionic relaxation apply as well).
+         </info>
+      </var>
+      <var name="cell_dofree" type="CHARACTER" >
+         <default> &apos;all&apos;
+         </default>
+         <options>
+            <info>
+Select which of the cell parameters should be moved:
+            </info>
+            <opt val="'all'" > all axis and angles are moved
+            </opt>
+            <opt val="'ibrav'" > all axis and angles are moved, but the lattice but be representable with the initial ibrav choice
+            </opt>
+            <opt val="'x'" > only the x component of axis 1 (v1_x) is moved
+            </opt>
+            <opt val="'y'" > only the y component of axis 2 (v2_y) is moved
+            </opt>
+            <opt val="'z'" > only the z component of axis 3 (v3_z) is moved
+            </opt>
+            <opt val="'xy'" > only v1_x and v2_y are moved
+            </opt>
+            <opt val="'xz'" > only v1_x and v3_z are moved
+            </opt>
+            <opt val="'yz'" > only v2_y and v3_z are moved
+            </opt>
+            <opt val="'xyz'" > only v1_x, v2_y, v3_z are moved
+            </opt>
+            <opt val="'shape'" > all axis and angles, keeping the volume fixed
+            </opt>
+            <opt val="'volume'" > the volume changes, keeping all angles fixed (i.e. only celldm(1) changes)
+            </opt>
+            <opt val="'2Dxy'" > only x and y components are allowed to change
+            </opt>
+            <opt val="'2Dshape'" > as above, keeping the area in xy plane fixed
+            </opt>
+            <opt val="'epitaxial_ab'" > fix axis 1 and 2 while allowing axis 3 to move
+            </opt>
+            <opt val="'epitaxial_ac'" > fix axis 1 and 3 while allowing axis 2 to move
+            </opt>
+            <opt val="'epitaxial_bc'" > fix axis 2 and 3 while allowing axis 1 to move
+            </opt>
+            <info>
+BEWARE: if axis are not orthogonal, some of these options do not
+        work (symmetry is broken). If you are not happy with them,
+        edit subroutine init_dofree in file Modules/cell_base.f90
+            </info>
+         </options>
+      </var>
+   </namelist>
+   <card name="ATOMIC_SPECIES" >
+      <syntax>
+         <table name="atomic_species" >
+            <rows start="1" end="ntyp" >
+               <col name="X" type="CHARACTER" >
+                  <info>
+label of the atom. Acceptable syntax:
+chemical symbol X (1 or 2 characters, case-insensitive)
+or chemical symbol plus a number or a letter, as in
+&quot;Xn&quot; (e.g. Fe1) or &quot;X_*&quot; or &quot;X-*&quot; (e.g. C1, C_h;
+max total length cannot exceed 3 characters)
+                  </info>
+               </col>
+               <col name="Mass_X" type="REAL" >
+                  <info>
+mass of the atomic species [amu: mass of C = 12]
+Used only when performing Molecular Dynamics run
+or structural optimization runs using Damped MD.
+Not actually used in all other cases (but stored
+in data files, so phonon calculations will use
+these values unless other values are provided)
+                  </info>
+               </col>
+               <col name="PseudoPot_X" type="CHARACTER" >
+                  <info>
+File containing PP for this species.
+
+The pseudopotential file is assumed to be in the new UPF format.
+If it doesn&apos;t work, the pseudopotential format is determined by
+the file name:
+
+*.vdb or *.van     Vanderbilt US pseudopotential code
+*.RRKJ3            Andrea Dal Corso&apos;s code (old format)
+none of the above  old PWscf norm-conserving format
+                  </info>
+               </col>
+            </rows>
+         </table>
+      </syntax>
+   </card>
+   <card name="ATOMIC_POSITIONS" >
+      <flag name="atompos_unit" use="optional" >
+         <enum> alat | bohr | angstrom | crystal | crystal_sg
+         </enum>
+         <default> (DEPRECATED) alat
+         </default>
+         <options>
+            <info>
+Units for ATOMIC_POSITIONS:
+            </info>
+            <opt val="alat" >
+atomic positions are in cartesian coordinates, in
+units of the lattice parameter (either celldm(1)
+or A). If no option is specified, &apos;alat&apos; is assumed;
+not specifying units is DEPRECATED and will no
+longer be allowed in the future
+            </opt>
+            <opt val="bohr" >
+atomic positions are in cartesian coordinate,
+in atomic units (i.e. Bohr radii)
+            </opt>
+            <opt val="angstrom" >
+atomic positions are in cartesian coordinates, in Angstrom
+            </opt>
+            <opt val="crystal" >
+atomic positions are in crystal coordinates, i.e.
+in relative coordinates of the primitive lattice
+vectors as defined either in card <ref>CELL_PARAMETERS</ref>
+or via the ibrav + celldm / a,b,c... variables
+            </opt>
+            <opt val="crystal_sg" >
+atomic positions are in crystal coordinates, i.e.
+in relative coordinates of the primitive lattice.
+This option differs from the previous one because
+in this case only the symmetry inequivalent atoms
+are given. The variable <ref>space_group</ref> must indicate
+the space group number used to find the symmetry
+equivalent atoms. The other variables that control
+this option are uniqueb, origin_choice, and
+rhombohedral.
+            </opt>
+         </options>
+      </flag>
+      <choose>
+         <when test="calculation == 'bands' OR calculation == 'nscf'" >
+            <message>
+Specified atomic positions will be IGNORED and those from the
+previous scf calculation will be used instead !!!
+            </message>
+         </when>
+         <otherwise>
+            <syntax>
+               <table name="atomic_coordinates" >
+                  <rows start="1" end="nat" >
+                     <col name="X" type="CHARACTER" >
+                        <info> label of the atom as specified in <ref>ATOMIC_SPECIES</ref>
+                        </info>
+                     </col>
+                     <colgroup type="REAL" >
+                        <info>
+atomic positions
+
+NOTE: each atomic coordinate can also be specified as a simple algebraic expression.
+      To be interpreted correctly expression must NOT contain any blank
+      space and must NOT start with a &quot;+&quot; sign. The available expressions are:
+
+        + (plus), - (minus), / (division), * (multiplication), ^ (power)
+
+      All numerical constants included are considered as double-precision numbers;
+      i.e. 1/2 is 0.5, not zero. Other functions, such as sin, sqrt or exp are
+      not available, although sqrt can be replaced with ^(1/2).
+
+      Example:
+            C  1/3   1/2*3^(-1/2)   0
+
+      is equivalent to
+
+            C  0.333333  0.288675  0.000000
+
+      Please note that this feature is NOT supported by XCrysDen (which will
+      display a wrong structure, or nothing at all).
+
+      When atomic positions are of type crystal_sg coordinates can be given
+      in the following four forms (Wyckoff positions):
+         C  1a
+         C  8g   x
+         C  24m  x y
+         C  48n  x y z
+      The first form must be used when the Wyckoff letter determines uniquely
+      all three coordinates, forms 2,3,4 when the Wyckoff letter and 1,2,3
+      coordinates respectively are needed.
+
+      The forms:
+         C 8g  x  x  x
+         C 24m x  x  y
+      are not allowed, but
+         C x x x
+         C x x y
+         C x y z
+      are correct.
+                        </info>
+                        <col name="x" >
+                        </col>
+                        <col name="y" >
+                        </col>
+                        <col name="z" >
+                        </col>
+                     </colgroup>
+                     <optional>
+                        <colgroup type="INTEGER" >
+                           <info>
+component i of the force for this atom is multiplied by if_pos(i),
+which must be either 0 or 1.  Used to keep selected atoms and/or
+selected components fixed in MD dynamics or
+structural optimization run.
+
+With crystal_sg atomic coordinates the constraints are copied in all equivalent
+atoms.
+                           </info>
+                           <default> 1
+                           </default>
+                           <col name="if_pos(1)" >
+                           </col>
+                           <col name="if_pos(2)" >
+                           </col>
+                           <col name="if_pos(3)" >
+                           </col>
+                        </colgroup>
+                     </optional>
+                  </rows>
+               </table>
+            </syntax>
+         </otherwise>
+      </choose>
+   </card>
+   <card name="K_POINTS" >
+      <flag name="kpoint_type" use="optional" >
+         <enum> tpiba | automatic | crystal | gamma | tpiba_b | crystal_b | tpiba_c | crystal_c
+         </enum>
+         <default> tbipa
+         </default>
+         <options>
+            <info>
+K_POINTS options are:
+            </info>
+            <opt val="tpiba" >
+read k-points in cartesian coordinates,
+in units of 2 pi/a (default)
+            </opt>
+            <opt val="automatic" >
+automatically generated uniform grid of k-points, i.e,
+generates ( nk1, nk2, nk3 ) grid with ( sk1, sk2, sk3 ) offset.
+nk1, nk2, nk3 as in Monkhorst-Pack grids
+k1, k2, k3 must be 0 ( no offset ) or 1 ( grid displaced
+by half a grid step in the corresponding direction )
+BEWARE: only grids having the full symmetry of the crystal
+        work with tetrahedra. Some grids with offset may not work.
+            </opt>
+            <opt val="crystal" >
+read k-points in crystal coordinates, i.e. in relative
+coordinates of the reciprocal lattice vectors
+            </opt>
+            <opt val="gamma" >
+use k = 0 (no need to list k-point specifications after card)
+In this case wavefunctions can be chosen as real,
+and specialized subroutines optimized for calculations
+at the gamma point are used (memory and cpu requirements
+are reduced by approximately one half).
+            </opt>
+            <opt val="tpiba_b" >
+Used for band-structure plots.
+k-points are in units of  2 pi/a.
+nks points specify nks-1 lines in reciprocal space.
+Every couple of points identifies the initial and
+final point of a line. pw.x generates N intermediate
+points of the line where N is the weight of the first point.
+            </opt>
+            <opt val="crystal_b" >
+As tpiba_b, but k-points are in crystal coordinates.
+            </opt>
+            <opt val="tpiba_c" >
+Used for band-structure contour plots.
+k-points are in units of  2 <i>pi/a.</i> nks must be 3.
+3 k-points k_0, k_1, and k_2 specify a rectangle
+in reciprocal space of vertices k_0, k_1, k_2,
+k_1 + k_2 - k_0: k_0 + \alpha (k_1-k_0)+
+\beta (k_2-k_0) with 0 &lt;\alpha,\beta &lt; 1.
+The code produces a uniform mesh n1 x n2
+k points in this rectangle. n1 and n2 are
+the weights of k_1 and k_2. The weight of k_0
+is not used.
+            </opt>
+            <opt val="crystal_c" >
+As tpiba_c, but k-points are in crystal coordinates.
+            </opt>
+         </options>
+      </flag>
+      <choose>
+         <when test="tpiba  OR  crystal  OR  tpiba_b  OR  crystal_b OR tpiba_c OR crystal_c" >
+            <syntax flag="tpiba | crystal | tpiba_b | crystal_b | tpiba_c | crystal_c " >
+               <line>
+                  <var name="nks" type="INTEGER" >
+                     <info> Number of supplied special k-points.
+                     </info>
+                  </var>
+               </line>
+               <table name="kpoints" >
+                  <rows start="1" end="nks" >
+                     <colgroup type="REAL" >
+                        <col name="xk_x" >
+                        </col>
+                        <col name="xk_y" >
+                        </col>
+                        <col name="xk_z" >
+                        </col>
+                        <col name="wk" >
+                        </col>
+                        <info>
+Special k-points (xk_x/y/z) in the irreducible Brillouin Zone
+(IBZ) of the lattice (with all symmetries) and weights (wk)
+See the literature for lists of special points and
+the corresponding weights.
+
+If the symmetry is lower than the full symmetry
+of the lattice, additional points with appropriate
+weights are generated. Notice that such procedure
+assumes that ONLY k-points in the IBZ are provided in input
+
+In a non-scf calculation, weights do not affect the results.
+If you just need eigenvalues and eigenvectors (for instance,
+for a band-structure plot), weights can be set to any value
+(for instance all equal to 1).
+                        </info>
+                     </colgroup>
+                  </rows>
+               </table>
+            </syntax>
+         </when>
+         <elsewhen test="automatic" >
+            <syntax flag="automatic" >
+               <line>
+                  <vargroup type="INTEGER" >
+                     <var name="nk1" >
+                     </var>
+                     <var name="nk2" >
+                     </var>
+                     <var name="nk3" >
+                     </var>
+                     <info>
+These parameters specify the k-point grid
+(nk1 x nk2 x nk3) as in Monkhorst-Pack grids.
+                     </info>
+                  </vargroup>
+                  <vargroup type="INTEGER" >
+                     <var name="sk1" >
+                     </var>
+                     <var name="sk2" >
+                     </var>
+                     <var name="sk3" >
+                     </var>
+                     <info>
+The grid offsets;  sk1, sk2, sk3 must be
+0 ( no offset ) or 1 ( grid displaced by
+half a grid step in the corresponding direction ).
+                     </info>
+                  </vargroup>
+               </line>
+            </syntax>
+         </elsewhen>
+         <elsewhen test="gamma" >
+            <syntax flag="gamma" >
+            </syntax>
+         </elsewhen>
+      </choose>
+   </card>
+   <card name="CELL_PARAMETERS" >
+      <flag name="lattice_type" use="optional" >
+         <enum> alat | bohr | angstrom
+         </enum>
+         <info>
+Unit for lattice vectors; options are:
+
+<b>&apos;bohr&apos;</b> / <b>&apos;angstrom&apos;:</b>
+                     lattice vectors in bohr-radii / angstrom.
+                     In this case the lattice parameter alat = sqrt(v1*v1).
+
+<b>&apos;alat&apos;</b> / nothing specified:
+                     lattice vectors in units of the lattice parameter (either
+                     <ref>celldm</ref>(1) or <ref>A</ref>). Not specifying units is DEPRECATED
+                     and will not be allowed in the future.
+
+If neither unit nor lattice parameter are specified,
+&apos;bohr&apos; is assumed - DEPRECATED, will no longer be allowed
+         </info>
+      </flag>
+      <label>
+Optional card, needed only if <ref>ibrav</ref> == 0 is specified, ignored otherwise !
+      </label>
+      <syntax>
+         <table name="lattice" >
+            <cols start="1" end="3" >
+               <rowgroup type="REAL" >
+                  <info>
+Crystal lattice vectors (in cartesian axis):
+    v1(1)  v1(2)  v1(3)    ... 1st lattice vector
+    v2(1)  v2(2)  v2(3)    ... 2nd lattice vector
+    v3(1)  v3(2)  v3(3)    ... 3rd lattice vector
+                  </info>
+                  <row name="v1" >
+                  </row>
+                  <row name="v2" >
+                  </row>
+                  <row name="v3" >
+                  </row>
+               </rowgroup>
+            </cols>
+         </table>
+      </syntax>
+   </card>
+   <card name="CONSTRAINTS" >
+      <label>
+Optional card, used for constrained dynamics or constrained optimisations
+(only if <ref>ion_dynamics</ref>==&apos;damp&apos; or &apos;verlet&apos;, variable-cell excepted)
+      </label>
+      <message>
+When this card is present the SHAKE algorithm is automatically used.
+      </message>
+      <syntax>
+         <line>
+            <var name="nconstr" type="INTEGER" >
+               <info> Number of constraints.
+               </info>
+            </var>
+            <optional>
+               <var name="constr_tol" type="REAL" >
+                  <info> Tolerance for keeping the constraints satisfied.
+                  </info>
+               </var>
+            </optional>
+         </line>
+         <table name="constraints_table" >
+            <rows start="1" end="nconstr" >
+               <col name="constr_type" type="CHARACTER" >
+                  <options>
+                     <info>
+Type of constraint :
+                     </info>
+                     <opt val="'type_coord'" >
+constraint on global coordination-number, i.e. the
+average number of atoms of type B surrounding the
+atoms of type A. The coordination is defined by
+using a Fermi-Dirac.
+(four indexes must be specified).
+                     </opt>
+                     <opt val="'atom_coord'" >
+constraint on local coordination-number, i.e. the
+average number of atoms of type A surrounding a
+specific atom. The coordination is defined by
+using a Fermi-Dirac.
+(four indexes must be specified).
+                     </opt>
+                     <opt val="'distance'" >
+constraint on interatomic distance
+(two atom indexes must be specified).
+                     </opt>
+                     <opt val="'planar_angle'" >
+constraint on planar angle
+(three atom indexes must be specified).
+                     </opt>
+                     <opt val="'torsional_angle'" >
+constraint on torsional angle
+(four atom indexes must be specified).
+                     </opt>
+                     <opt val="'bennett_proj'" >
+constraint on the projection onto a given direction
+of the vector defined by the position of one atom
+minus the center of mass of the others.
+G. Roma, J.P. Crocombette: J. Nucl. Mater. 403, 32 (2010),
+<a href="http://dx.doi.org/10.1016/j.jnucmat.2010.06.001">doi:10.1016/j.jnucmat.2010.06.001</a>
+                     </opt>
+                  </options>
+               </col>
+               <colgroup>
+                  <col name="constr(1)" >
+                  </col>
+                  <col name="constr(2)" >
+                  </col>
+                  <conditional>
+                     <col name="constr(3)" >
+                     </col>
+                     <col name="constr(4)" >
+                     </col>
+                  </conditional>
+                  <info>
+These variables have different meanings for different constraint types:
+
+<b>&apos;type_coord&apos;</b> :
+               <i>constr(1)</i> is the first index of the atomic type involved
+               <i>constr(2)</i> is the second index of the atomic type involved
+               <i>constr(3)</i> is the cut-off radius for estimating the coordination
+               <i>constr(4)</i> is a smoothing parameter
+
+<b>&apos;atom_coord&apos;</b> :
+               <i>constr(1)</i> is the atom index of the atom with constrained coordination
+               <i>constr(2)</i> is the index of the atomic type involved in the coordination
+               <i>constr(3)</i> is the cut-off radius for estimating the coordination
+               <i>constr(4)</i> is a smoothing parameter
+
+<b>&apos;distance&apos;</b> :
+               atoms indices object of the constraint, as they appear in
+               the <ref>ATOMIC_POSITIONS</ref> card
+
+<b>&apos;planar_angle&apos;,</b> <b>&apos;torsional_angle&apos;</b> :
+               atoms indices object of the constraint, as they appear in the
+               <ref>ATOMIC_POSITIONS</ref> card (beware the order)
+
+<b>&apos;bennett_proj&apos;</b> :
+               <i>constr(1)</i> is the index of the atom whose position is constrained.
+               <i>constr(2:4)</i> are the three coordinates of the vector that specifies
+               the constraint direction.
+                  </info>
+               </colgroup>
+               <optional>
+                  <col name="constr_target" type="REAL" >
+                     <info>
+Target for the constrain ( angles are specified in degrees ).
+This variable is optional.
+                     </info>
+                  </col>
+               </optional>
+            </rows>
+         </table>
+      </syntax>
+   </card>
+   <card name="OCCUPATIONS" >
+      <label> Optional card, used only if <ref>occupations</ref> == &apos;from_input&apos;, ignored otherwise !
+      </label>
+      <syntax>
+         <table name="occupations_table" >
+            <cols start="1" end="nbnd" >
+               <row name="f_inp1" type="REAL" >
+                  <info>
+Occupations of individual states (MAX 10 PER ROW).
+For spin-polarized calculations, these are majority spin states.
+                  </info>
+               </row>
+               <conditional>
+                  <row name="f_inp2" type="REAL" >
+                     <info>
+Occupations of minority spin states (MAX 10 PER ROW)
+To be specified only for spin-polarized calculations.
+                     </info>
+                  </row>
+               </conditional>
+            </cols>
+         </table>
+      </syntax>
+   </card>
+   <card name="ATOMIC_FORCES" >
+      <label> Optional card used to specify external forces acting on atoms.
+      </label>
+      <message>
+BEWARE: if the sum of external forces is not zero, the center of mass of
+        the system will move
+      </message>
+      <syntax>
+         <table name="atomic_forces" >
+            <rows start="1" end="nat" >
+               <col name="X" type="CHARACTER" >
+                  <info> label of the atom as specified in <ref>ATOMIC_SPECIES</ref>
+                  </info>
+               </col>
+               <colgroup type="REAL" >
+                  <info>
+external force on atom X (cartesian components, Ry/a.u. units)
+                  </info>
+                  <col name="fx" >
+                  </col>
+                  <col name="fy" >
+                  </col>
+                  <col name="fz" >
+                  </col>
+               </colgroup>
+            </rows>
+         </table>
+      </syntax>
+   </card>
+</input_description>

--- a/tests/calculations/test_helpers.py
+++ b/tests/calculations/test_helpers.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument
+"""Tests for the calculation input helper utilities."""
+from __future__ import absolute_import
+
+import pytest
+
+from aiida_quantumespresso.calculations.helpers import pw_input_helper, QEInputValidationError
+
+
+def test_pw_helper_multidimensional(fixture_database, fixture_computer_localhost, generate_structure):
+    """Test the helper for parameters containing a multidimensional parameter."""
+    structure = generate_structure('Si')
+    parameters = {
+        'CONTROL': {
+            'calculation': 'scf'
+        },
+        'SYSTEM': {
+            'ecutwfc': 30,
+            'starting_ns_eigenvalue': [[1, 2, 'Si', 4]],
+            'hubbard_j': [[1, 'Si', 15.7]]
+        }
+    }
+
+    result = pw_input_helper(parameters, structure, version='6.4')
+
+    assert result['CONTROL'] == parameters['CONTROL']
+    assert result['SYSTEM'] == parameters['SYSTEM']
+
+    with pytest.raises(QEInputValidationError):
+        parameters['SYSTEM']['hubbard_j'] = [[1, 2, 15.7]]  # Second element is not a kind name
+        pw_input_helper(parameters, structure, version='6.4')
+
+    with pytest.raises(QEInputValidationError):
+        parameters['SYSTEM']['hubbard_j'] = [[1, 'Ge', 15.7]]  # Second element is a non-existing structure kind name
+        pw_input_helper(parameters, structure, version='6.4')


### PR DESCRIPTION
Fixes #188 

From Quantum ESPRESSO v6.4, the XML input spec for pw.x will contain
support for multimensional parameters through the tag `multidimension`.
This allows to properly define and validate multidimensional variables
such as `Hubbard_J` and `starting_ns_eigenvalues`. This commit
implements support for validating input dictionaries against the spec
with these new tags.