### PR TITLE
Update dependency requirement `aiida-core==1.0.0b6`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -75,7 +75,7 @@
         ]
     },
     "install_requires": [
-        "aiida_core[atomic_tools]>=1.0.0b5",
+        "aiida_core[atomic_tools]>=1.0.0b6",
         "matplotlib<3.0.0; python_version<'3'",
         "qe-tools==1.1.3",
         "xmlschema==1.0.13"


### PR DESCRIPTION
This should fix the problems on RTD as the latest release of `aiida-core` no longer requires a clashing version of `qe-tools`