### PR TITLE
bump version to 3.0.0a5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,12 @@
     entry: python ./.ci/validate_version_number.py
     args: ['version']
     language: system
-    files: '^(setup.json)'
+    files: >-
+      (?x)^(
+        setup.json|
+        aiida_quantumespresso/__init__.py|
+        ./.ci/validate_version_number.py|
+      )$
     pass_filenames: false
 
 - repo: https://github.com/python-modernize/python-modernize.git

--- a/aiida_quantumespresso/__init__.py
+++ b/aiida_quantumespresso/__init__.py
@@ -1,2 +1,2 @@
 """The official AiiDA plugin for Quantum ESPRESSO."""
-__version__ = '3.0.0a4'
+__version__ = '3.0.0a5'

--- a/setup.json
+++ b/setup.json
@@ -83,5 +83,5 @@
     "license": "MIT License",
     "name": "aiida_quantumespresso",
     "url": "https://github.com/aiidateam/aiida-quantumespresso",
-    "version": "3.0.0a4"
+    "version": "3.0.0a5"
 }

--- a/tests/parsers/test_ph/test_ph_default.yml
+++ b/tests/parsers/test_ph/test_ph_default.yml
@@ -47,8 +47,8 @@ number_of_atoms: 2
 number_of_irr_representations_for_each_q:
 - 2
 number_of_qpoints: 1
-parser_info: aiida-quantumespresso parser ph.x v3.0.0a4
-parser_version: 3.0.0a4
+parser_info: aiida-quantumespresso parser ph.x v3.0.0a5
+parser_version: 3.0.0a5
 parser_warnings: []
 wall_time: '        15.25s '
 wall_time_seconds: 15.25

--- a/tests/parsers/test_ph/test_ph_not_converged.yml
+++ b/tests/parsers/test_ph/test_ph_not_converged.yml
@@ -3,8 +3,8 @@ number_of_irr_representations_for_each_q:
 - 2
 - 4
 number_of_qpoints: 8
-parser_info: aiida-quantumespresso parser ph.x v3.0.0a4
-parser_version: 3.0.0a4
+parser_info: aiida-quantumespresso parser ph.x v3.0.0a5
+parser_version: 3.0.0a5
 parser_warnings: []
 wall_time: '     3m21.58s '
 wall_time_seconds: 201.57999999999998

--- a/tests/parsers/test_ph/test_ph_out_of_walltime.yml
+++ b/tests/parsers/test_ph/test_ph_out_of_walltime.yml
@@ -3,8 +3,8 @@ number_of_irr_representations_for_each_q:
 - 2
 - 4
 number_of_qpoints: 3
-parser_info: aiida-quantumespresso parser ph.x v3.0.0a4
-parser_version: 3.0.0a4
+parser_info: aiida-quantumespresso parser ph.x v3.0.0a5
+parser_version: 3.0.0a5
 parser_warnings: []
 wall_time: '         7.13s '
 wall_time_seconds: 7.13

--- a/tests/parsers/test_pw/test_pw_default.yml
+++ b/tests/parsers/test_pw/test_pw_default.yml
@@ -76,8 +76,8 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.0.0a4
-  parser_version: 3.0.0a4
+  parser_info: aiida-quantumespresso parser pw.x v3.0.0a5
+  parser_version: 3.0.0a5
   parser_warnings: []
   pp_check_flag: true
   q_real_space: false

--- a/tests/parsers/test_pw/test_pw_default_xml_new.yml
+++ b/tests/parsers/test_pw/test_pw_default_xml_new.yml
@@ -91,8 +91,8 @@ output_parameters:
   number_of_spin_components: 1
   number_of_symmetries: 48
   occupations: fixed
-  parser_info: aiida-quantumespresso parser pw.x v3.0.0a4
-  parser_version: 3.0.0a4
+  parser_info: aiida-quantumespresso parser pw.x v3.0.0a5
+  parser_version: 3.0.0a5
   parser_warnings: []
   q_real_space: false
   rho_cutoff: 3265.366014072

--- a/tests/parsers/test_pw/test_pw_failed_interrupted.yml
+++ b/tests/parsers/test_pw/test_pw_failed_interrupted.yml
@@ -21,8 +21,8 @@ number_of_atoms: 2
 number_of_bands: 4
 number_of_k_points: 3
 number_of_species: 1
-parser_info: aiida-quantumespresso parser pw.x v3.0.0a4
-parser_version: 3.0.0a4
+parser_info: aiida-quantumespresso parser pw.x v3.0.0a5
+parser_version: 3.0.0a5
 parser_warnings: []
 scf_iterations: 5
 smooth_fft_grid:

--- a/tests/parsers/test_pw/test_pw_failed_interrupted_stdout.yml
+++ b/tests/parsers/test_pw/test_pw_failed_interrupted_stdout.yml
@@ -56,8 +56,8 @@ number_of_k_points: 3
 number_of_species: 1
 number_of_spin_components: 1
 number_of_symmetries: 48
-parser_info: aiida-quantumespresso parser pw.x v3.0.0a4
-parser_version: 3.0.0a4
+parser_info: aiida-quantumespresso parser pw.x v3.0.0a5
+parser_version: 3.0.0a5
 parser_warnings: []
 pp_check_flag: true
 q_real_space: false

--- a/tests/parsers/test_pw/test_pw_failed_interrupted_xml.yml
+++ b/tests/parsers/test_pw/test_pw_failed_interrupted_xml.yml
@@ -21,8 +21,8 @@ number_of_atoms: 2
 number_of_bands: 4
 number_of_k_points: 3
 number_of_species: 1
-parser_info: aiida-quantumespresso parser pw.x v3.0.0a4
-parser_version: 3.0.0a4
+parser_info: aiida-quantumespresso parser pw.x v3.0.0a5
+parser_version: 3.0.0a5
 parser_warnings: []
 scf_iterations: 5
 smooth_fft_grid:

--- a/tests/parsers/test_pw/test_pw_failed_out_of_walltime.yml
+++ b/tests/parsers/test_pw/test_pw_failed_out_of_walltime.yml
@@ -44,8 +44,8 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.0.0a4
-  parser_version: 3.0.0a4
+  parser_info: aiida-quantumespresso parser pw.x v3.0.0a5
+  parser_version: 3.0.0a5
   parser_warnings: []
   pp_check_flag: false
   q_real_space: false

--- a/tests/parsers/test_pw/test_pw_failed_scf_not_converged.yml
+++ b/tests/parsers/test_pw/test_pw_failed_scf_not_converged.yml
@@ -45,8 +45,8 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.0.0a4
-  parser_version: 3.0.0a4
+  parser_info: aiida-quantumespresso parser pw.x v3.0.0a5
+  parser_version: 3.0.0a5
   parser_warnings: []
   pp_check_flag: false
   q_real_space: false

--- a/tests/parsers/test_pw/test_pw_relax_success.yml
+++ b/tests/parsers/test_pw/test_pw_relax_success.yml
@@ -77,8 +77,8 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.0.0a4
-  parser_version: 3.0.0a4
+  parser_info: aiida-quantumespresso parser pw.x v3.0.0a5
+  parser_version: 3.0.0a5
   parser_warnings: []
   pp_check_flag: true
   q_real_space: false

--- a/tests/parsers/test_pw/test_pw_vcrelax_fractional_success.yml
+++ b/tests/parsers/test_pw/test_pw_vcrelax_fractional_success.yml
@@ -79,8 +79,8 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.0.0a4
-  parser_version: 3.0.0a4
+  parser_info: aiida-quantumespresso parser pw.x v3.0.0a5
+  parser_version: 3.0.0a5
   parser_warnings: []
   pointgroup_international: m-3m
   pointgroup_schoenflies: O_h

--- a/tests/parsers/test_pw/test_pw_vcrelax_success.yml
+++ b/tests/parsers/test_pw/test_pw_vcrelax_success.yml
@@ -79,8 +79,8 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.0.0a4
-  parser_version: 3.0.0a4
+  parser_info: aiida-quantumespresso parser pw.x v3.0.0a5
+  parser_version: 3.0.0a5
   parser_warnings: []
   pp_check_flag: true
   q_real_space: false

--- a/tests/parsers/test_pw2wannier90/test_pw2wannier90_default.yml
+++ b/tests/parsers/test_pw2wannier90/test_pw2wannier90_default.yml
@@ -1,7 +1,7 @@
 parameters:
   code_version: v.6.4.1
-  parser_info: aiida-quantumespresso parser simple v3.0.0a4
-  parser_version: 3.0.0a4
+  parser_info: aiida-quantumespresso parser simple v3.0.0a5
+  parser_version: 3.0.0a5
   parser_warnings: []
   wall_time: 2.18s
   wall_time_seconds: 2.18


### PR DESCRIPTION
partial fix to #395 

bump version number to 3.0.0a5 for new release.
also let version consistency pre-commit hook trigger when
aiida_quantumespresso/__init__.py is changed.