### PR TITLE
pw base workchain - restart from previous calculation if pw error = 410

### DIFF
--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -438,10 +438,11 @@ def _handle_electronic_convergence_not_achieved(self, calculation):
         mixing_beta = self.ctx.inputs.parameters.get('ELECTRONS', {}).get('mixing_beta', self.defaults.qe.mixing_beta)
         mixing_beta_new = mixing_beta * factor
 
-        self.ctx.restart_calc = None
+        self.ctx.restart_calc = calculation
         self.ctx.inputs.parameters.setdefault('ELECTRONS', {})['mixing_beta'] = mixing_beta_new
 
-        action = 'reduced beta mixing from {} to {} and restarting from scratch'.format(mixing_beta, mixing_beta_new)
+        action = 'reduced beta mixing from {} to {} and restarting from the last ' \
+            'calculation'.format(mixing_beta, mixing_beta_new)
         self.report_error_handled(calculation, action)
         return ErrorHandlerReport(True, True)
 


### PR DESCRIPTION
Fixes #402
 Currently, when a ``quantumespresso.pw`` calculation return a 410 exit_status, the ``quantumespresso.pw.base`` workchain decreases the beta mixing parameters in ELECTRONS and restart the calculation from scratch.
A more effective solution is to restart the calculation from the previous charge density. 

I tested this strategy for 181 failing workflows, and the new strategy resulted in achieved convergence in 50% of the cases.
The same strategy was also applied to workchains that were successful after one or more the contained  ``quantumespresso.pw`` returned a 410 error. I observed failure in only 1 case out of 55 cases; the number of steps required to achieve convergence was also improved in 51 out of 54 cases.