### PR TITLE
Added SCF convergence trajectory to the pw parser

### DIFF
--- a/aiida_quantumespresso/parsers/parse_raw/pw.py
+++ b/aiida_quantumespresso/parsers/parse_raw/pw.py
@@ -843,7 +843,7 @@ def parse_stdout(stdout, input_parameters, parser_options=None, parsed_xml=None)
         warning = 'scf_iterations and scf_accuracy arrays are not consistent'
         if len(trajectory_data['scf_iterations']) + 1 != len(trajectory_data['scf_accuracy_index']):
             logs.warning.append(warning)
-        value = trajectory_data['scf_accuracy'][0]
+        value = trajectory_data['scf_accuracy_index'][0]
         for i, j in zip(trajectory_data['scf_iterations'], trajectory_data['scf_accuracy_index'][1:]):
             value += i
             if value != j:

--- a/aiida_quantumespresso/parsers/parse_raw/pw.py
+++ b/aiida_quantumespresso/parsers/parse_raw/pw.py
@@ -508,13 +508,12 @@ def parse_stdout(stdout, input_parameters, parser_options=None, parsed_xml=None)
     # now I create a bunch of arrays for every step.
 
     # initialize the scf_index counter for the next cycle
-    scf_index = 0
     for data_step in relax_steps:
         trajectory_frame = {}
-        try:
-            trajectory_data['scf_accuracy_index'].append(scf_index)
-        except KeyError:
-            trajectory_data['scf_accuracy_index'] = [0]
+
+        current_index = len(trajectory_data.get('scf_accuracy', []))
+        trajectory_data.setdefault('scf_accuracy_index', []).append(current_index)
+
         for count, line in enumerate(data_step):
 
             if 'CELL_PARAMETERS' in line:
@@ -613,8 +612,6 @@ def parse_stdout(stdout, input_parameters, parser_options=None, parsed_xml=None)
             elif 'estimated scf accuracy' in line:
                 try:
                     value = float(line.split()[-2])* ry_to_ev
-                    scf_index += 1
-                    trajectory_data['scf_accuracy_index'][-1] += 1
                     try:
                         trajectory_data['scf_accuracy'].append(value)
                     except KeyError:

--- a/tests/parsers/test_pw/test_pw_default.yml
+++ b/tests/parsers/test_pw/test_pw_default.yml
@@ -225,7 +225,7 @@ output_trajectory:
   array|scf_accuracy:
   - 5
   array|scf_accuracy_index:
-  - 1
+  - 2
   array|scf_iterations:
   - 1
   array|steps:

--- a/tests/parsers/test_pw/test_pw_default.yml
+++ b/tests/parsers/test_pw/test_pw_default.yml
@@ -222,6 +222,10 @@ output_trajectory:
   - 1
   - 2
   - 3
+  array|scf_accuracy:
+  - 5
+  array|scf_accuracy_index:
+  - 1
   array|scf_iterations:
   - 1
   array|steps:

--- a/tests/parsers/test_pw/test_pw_default_xml_new.yml
+++ b/tests/parsers/test_pw/test_pw_default_xml_new.yml
@@ -236,6 +236,10 @@ output_trajectory:
   - 1
   - 2
   - 3
+  array|scf_accuracy:
+  - 5
+  array|scf_accuracy_index:
+  - 1
   array|scf_iterations:
   - 1
   array|steps:

--- a/tests/parsers/test_pw/test_pw_default_xml_new.yml
+++ b/tests/parsers/test_pw/test_pw_default_xml_new.yml
@@ -239,7 +239,7 @@ output_trajectory:
   array|scf_accuracy:
   - 5
   array|scf_accuracy_index:
-  - 1
+  - 2
   array|scf_iterations:
   - 1
   array|steps:

--- a/tests/parsers/test_pw/test_pw_failed_out_of_walltime.yml
+++ b/tests/parsers/test_pw/test_pw_failed_out_of_walltime.yml
@@ -51,6 +51,7 @@ output_parameters:
   q_real_space: false
   rho_cutoff: 3265.366014072
   rho_cutoff_units: eV
+  scf_iterations: 12
   smooth_fft_grid:
   - 25
   - 25
@@ -178,6 +179,8 @@ output_trajectory:
   array|scf_accuracy:
   - 12
   array|scf_accuracy_index:
+  - 2
+  array|scf_iterations:
   - 1
   array|steps:
   - 1

--- a/tests/parsers/test_pw/test_pw_failed_out_of_walltime.yml
+++ b/tests/parsers/test_pw/test_pw_failed_out_of_walltime.yml
@@ -175,6 +175,10 @@ output_trajectory:
   - 1
   - 2
   - 3
+  array|scf_accuracy:
+  - 12
+  array|scf_accuracy_index:
+  - 1
   array|steps:
   - 1
   symbols:

--- a/tests/parsers/test_pw/test_pw_failed_scf_not_converged.yml
+++ b/tests/parsers/test_pw/test_pw_failed_scf_not_converged.yml
@@ -182,7 +182,7 @@ output_trajectory:
   array|scf_accuracy:
   - 3
   array|scf_accuracy_index:
-  - 1
+  - 2
   array|scf_iterations:
   - 1
   array|steps:

--- a/tests/parsers/test_pw/test_pw_failed_scf_not_converged.yml
+++ b/tests/parsers/test_pw/test_pw_failed_scf_not_converged.yml
@@ -179,6 +179,10 @@ output_trajectory:
   - 1
   - 2
   - 3
+  array|scf_accuracy:
+  - 3
+  array|scf_accuracy_index:
+  - 1
   array|scf_iterations:
   - 1
   array|steps:

--- a/tests/parsers/test_pw/test_pw_relax_success.yml
+++ b/tests/parsers/test_pw/test_pw_relax_success.yml
@@ -267,6 +267,10 @@ output_trajectory:
   - 1
   - 2
   - 3
+  array|scf_accuracy:
+  - 5
+  array|scf_accuracy_index:
+  - 1
   array|scf_iterations:
   - 1
   array|steps:

--- a/tests/parsers/test_pw/test_pw_relax_success.yml
+++ b/tests/parsers/test_pw/test_pw_relax_success.yml
@@ -270,7 +270,7 @@ output_trajectory:
   array|scf_accuracy:
   - 5
   array|scf_accuracy_index:
-  - 1
+  - 2
   array|scf_iterations:
   - 1
   array|steps:

--- a/tests/parsers/test_pw/test_pw_vcrelax_fractional_success.yml
+++ b/tests/parsers/test_pw/test_pw_vcrelax_fractional_success.yml
@@ -272,6 +272,10 @@ output_trajectory:
   - 4
   - 2
   - 3
+  array|scf_accuracy:
+  - 33
+  array|scf_accuracy_index:
+  - 5
   array|scf_iterations:
   - 5
   array|steps:

--- a/tests/parsers/test_pw/test_pw_vcrelax_fractional_success.yml
+++ b/tests/parsers/test_pw/test_pw_vcrelax_fractional_success.yml
@@ -275,7 +275,7 @@ output_trajectory:
   array|scf_accuracy:
   - 33
   array|scf_accuracy_index:
-  - 5
+  - 6
   array|scf_iterations:
   - 5
   array|steps:

--- a/tests/parsers/test_pw/test_pw_vcrelax_success.yml
+++ b/tests/parsers/test_pw/test_pw_vcrelax_success.yml
@@ -273,7 +273,7 @@ output_trajectory:
   array|scf_accuracy:
   - 29
   array|scf_accuracy_index:
-  - 5
+  - 6
   array|scf_iterations:
   - 5
   array|steps:

--- a/tests/parsers/test_pw/test_pw_vcrelax_success.yml
+++ b/tests/parsers/test_pw/test_pw_vcrelax_success.yml
@@ -270,6 +270,10 @@ output_trajectory:
   - 4
   - 2
   - 3
+  array|scf_accuracy:
+  - 29
+  array|scf_accuracy_index:
+  - 5
   array|scf_iterations:
   - 5
   array|steps:


### PR DESCRIPTION
Fixes #403

The pw parser now look for the SCF convergence in each SCF cycle of
a relaxation. The data is saved in two arrays of the output_trajectory. 

- ``scf_accuracy`` is a 1D array containing all the estimated errors
  found in the output;
- ``scf_accuracy_index`` acts as an index to identify different relax steps
  in ``scf_accuracy``. Each entry is the index of the last item of a specific relax step;
  i.e. the relaxation convergence in the latest relax step might be extracted to 
  the array ``xscf`` as:
```
  i1 = scf_accuracy_index[-2]
  i2 = scf_accuracy_index[-1]
  xscf = scf_accuracy[i1+1: i2]
```
The separation is two array is to avoid inhomogeneous arrays, see
https://github.com/aiidateam/aiida-core/issues/3411

Parsing of these quantities will allow for more complex logic in the workflows. 