### PR TITLE
Soften monotonicity requiremnts occupations in `get_highest_occupied_band`

### DIFF
--- a/aiida_quantumespresso/utils/bands.py
+++ b/aiida_quantumespresso/utils/bands.py
@@ -3,17 +3,31 @@
 from __future__ import absolute_import
 
 
-def get_highest_occupied_band(bands, threshold=0.01):
+def get_highest_occupied_band(bands, threshold=0.005):
     """Retun the index of the highest-occupied molecular orbital.
 
     The expected structure of the bands node is the following:
+
+        * an array called `occupations`
+        * with 3 dimensions if spin polarized, otherwise 2 dimensions
+        * dimensions loop over, spin channel, kpoints, bands
+
+    .. note::
+
+        The threshold is used both as a limit below which a band is considered as unoccupied as well as a measure of
+        numerical noise in the occupancies. The first band to have an occupancy below the threshold at all kpoints is
+        marked as the LUMO. All subsequent bands are then expected to have an occupation that is less than twice the
+        threshold. The reason for the factor two is that in the worst case when the LUMO has an occupation exactly equal
+        to the threshold and a subsequent has twice that value, we can still consider that as not to break the
+        requirement of all bands above the LUMO to be empty. It can be considered as having the exact same value (equal
+        to the threshold) plus an numerical error also equal to the threshold.
 
     :param bands: the `BandsData` node
     :param threshold: raise a `ValueError` if the last band has an occupation above this threshold at any k-point
     :raises ValueError: if `bands` is not a `BandsData` node
     :raises ValueError: if `bands` does not contain the array `occupations`
     :raises ValueError: if `occupations` array has an invalid shape
-    :raises ValueError: if the occupations are not monotonically decreasing at all k-points between LUMO and HOMO
+    :raises ValueError: if any occupation above LUMO exceeds `2 * threshold`
     :raises ValueError: if the last band has an occupation above the threshold
     """
     from numpy import shape
@@ -45,13 +59,18 @@ def get_highest_occupied_band(bands, threshold=0.01):
 
             for n, occupation in enumerate(kpoint):  # pylint: disable=invalid-name
                 if lumo_index is not None:
-                    if occupation > lumo_occupation:
+
+                    # If the occupation of this band exceeds twice that of the threshold, it is considered to be not
+                    # empty and since it comes after the LUMO, we raise
+                    if occupation > 2 * threshold:
                         warning_args = [occupation, n, lumo_occupation, lumo_index, l, k]
                         raise ValueError('Occupation of {} at n={} after lumo lkn<{},{},{}>'.format(*warning_args))
+
                 elif occupation < threshold:
                     lumo_index = n
                     lumo_occupation = occupation
                     lumo_indices.append(lumo_index)
+
             else:  # pylint: disable=useless-else-on-loop
                 if kpoint[-1] >= threshold:
                     warning_args = [kpoint[-1], l, k, len(kpoint)]

--- a/tests/utils/test_bands.py
+++ b/tests/utils/test_bands.py
@@ -34,6 +34,28 @@ class TestGetHighestOccupiedBand(object):
         with pytest.raises(ValueError):
             get_highest_occupied_band(node)
 
+    def test_threshold(self, fixture_database):
+        """Test the `threshold` parameter."""
+        from aiida.orm import BandsData
+
+        threshold = 0.002
+
+        bands = BandsData()
+        bands.set_array('occupations', numpy.array([[2., 2., 2., 2., 0.001, 0.0015]]))
+        bands.store()
+
+        # All bands above the LUMO (occupation of 0.001) are below `2 * threshold`
+        homo = get_highest_occupied_band(bands, threshold=threshold)
+        assert homo == 4
+
+        bands = BandsData()
+        bands.set_array('occupations', numpy.array([[2., 2., 2., 2., 0.001, 0.003]]))
+        bands.store()
+
+        # A band above the LUMO (occupation of 0.001) has an occupation above `2 * threshold`
+        with pytest.raises(ValueError):
+            get_highest_occupied_band(bands, threshold=threshold)
+
     def test_spin_unpolarized(self, fixture_database):
         """Test the function for a non spin-polarized calculation meaning there will be a single spin channel."""
         from aiida.orm import BandsData


### PR DESCRIPTION
Fixes #399 

The utility function, in addition to determining the HOMO, also checked
that the occupations are monotonically decreasing, since when broken, it
is a hint of non-sensical band structures. However, the check was that
once the LUMO was found, all subsequent bands had to have an occupation
that was lower. This gave problems for band structures that have
negative occupations just below the fermi level. This can happen with
both Methfessel-Paxton and Marzari-Vanderbilt smearing. The LUMO would
be marked as the band with negative occupations and any subsequent band
with occupation of zero, would trigger the exception. Although
physically meaningless, negative occupations are well-known effects of
these smearing methods and need to be accepted. The solution is to
change the criterion to compare unoccupied bands not to the occupation
of the LUMO but to the specified threshold. As long as all unoccupied
bands have an occupation less than twice the threshold (where the factor
two accounts for numerical noise) the monotonicity is preserved within
the bounds of numerical noise.