### PR TITLE
`PwParser`: fix sorting bug in parser of new XML format

### DIFF
--- a/aiida_quantumespresso/parsers/parse_xml/pw/parse.py
+++ b/aiida_quantumespresso/parsers/parse_xml/pw/parse.py
@@ -407,7 +407,7 @@ def parse_pw_xml_post_6_2(xml, include_deprecated_v2_keys=False):
         'lattice_symmetries': lattice_symmetries,
         'do_not_use_time_reversal': xml_dictionary['input']['symmetry_flags']['noinv'],
         'spin_orbit_domag': xml_dictionary['output']['magnetization']['do_magnetization'],
-        'fft_grid': list(xml_dictionary['output']['basis_set']['fft_grid'].values()),
+        'fft_grid': [value for _, value in sorted(xml_dictionary['output']['basis_set']['fft_grid'].items())],
         'lsda': lsda,
         'number_of_spin_components': nspin,
         'no_time_rev_operations': xml_dictionary['input']['symmetry_flags']['no_t_rev'],
@@ -417,7 +417,7 @@ def parse_pw_xml_post_6_2(xml, include_deprecated_v2_keys=False):
         'number_of_symmetries': nsym,          # crystal symmetries
         'wfc_cutoff': xml_dictionary['input']['basis']['ecutwfc'] * hartree_to_ev,
         'rho_cutoff': xml_dictionary['output']['basis_set']['ecutrho'] * hartree_to_ev, # not always printed in input->basis
-        'smooth_fft_grid': list(xml_dictionary['output']['basis_set']['fft_smooth'].values()),
+        'smooth_fft_grid': [value for _, value in sorted(xml_dictionary['output']['basis_set']['fft_smooth'].items())],
         'dft_exchange_correlation': xml_dictionary['input']['dft']['functional'],  # TODO: also parse optional elements of 'dft' tag
             # WARNING: this is different between old XML and new XML
         'spin_orbit_calculation': spin_orbit_calculation,

--- a/tests/parsers/fixtures/pw/default_xml_new/data-file-schema.xml
+++ b/tests/parsers/fixtures/pw/default_xml_new/data-file-schema.xml
@@ -627,8 +627,8 @@
       <gamma_only>false</gamma_only>
       <ecutwfc>1.500000000000000e1</ecutwfc>
       <ecutrho>1.200000000000000e2</ecutrho>
-      <fft_grid nr1="36" nr2="36" nr3="36"/>
-      <fft_smooth nr1="25" nr2="25" nr3="25"/>
+      <fft_grid nr1="48" nr2="36" nr3="36"/>
+      <fft_smooth nr1="32" nr2="25" nr3="25"/>
       <ngm>16889</ngm>
       <ngms>5985</ngms>
       <npwx>754</npwx>

--- a/tests/parsers/test_pw/test_pw_default_xml_new.yml
+++ b/tests/parsers/test_pw/test_pw_default_xml_new.yml
@@ -54,7 +54,7 @@ output_parameters:
   exit_status: 0
   fermi_energy_units: eV
   fft_grid:
-  - 36
+  - 48
   - 36
   - 36
   format_name: QEXSD
@@ -99,7 +99,7 @@ output_parameters:
   rho_cutoff_units: eV
   scf_iterations: 5
   smooth_fft_grid:
-  - 25
+  - 32
   - 25
   - 25
   spin_orbit_calculation: false


### PR DESCRIPTION
Fixes #410 

The `fft_grid` and `fft_smooth` fields in the `output_parameters` were
built from the dictionary returned by the raw parser. The dictionary
was turned into a list without taking the order into account, however
the ordering of the dictionary do have meaning. To guarantee a correct
and consistent order we sort the dictionary before building the list.