### PR TITLE
Extend BaseRestartWorkChain to CalcJob+WorkChain

### DIFF
--- a/aiida_quantumespresso/common/workchain/base/restart.py
+++ b/aiida_quantumespresso/common/workchain/base/restart.py
@@ -58,8 +58,8 @@ class BaseRestartWorkChain(WorkChain):
     def __init__(self, *args, **kwargs):
         super(BaseRestartWorkChain, self).__init__(*args, **kwargs)
 
-        if self._calculation_class is None or not issubclass(self._calculation_class, CalcJob):
-            raise ValueError('no valid CalcJob class defined for `_calculation_class` attribute')
+        if self._calculation_class is None or not issubclass(self._calculation_class, (CalcJob, WorkChain)):
+            raise ValueError('no valid CalcJob or WorkChain class defined for `_calculation_class` attribute')
 
         self._load_error_handlers()
 


### PR DESCRIPTION
BaseRestartWorkChain can also wrap another WorkChain due to similarities between CalcJob and WorkChain classes. There is no reason to restrict a user to wrap a CalcJob only, sometimes it might be helpful to automatically restart a WorkChain. Personally I found the same update for AiiDA-Fleur helpful.

PS. self.ctx.calculations and other variables could be renamed to self.ctx.processes or something like that. However, one needs to update error handlers then.