### PR TITLE
Enable checking of log messages in parser unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,8 @@ def flatten_inputs(inputs, prefix=''):
 def fixture_environment():
     """Setup a complete AiiDA test environment, with configuration, profile, database and repository."""
     with fixture_manager() as manager:
+        from aiida.common.log import configure_logging
+        configure_logging(with_orm=True)
         yield manager
 
 

--- a/tests/parsers/test_cp.py
+++ b/tests/parsers/test_cp.py
@@ -67,6 +67,7 @@ def test_cp_default(fixture_database, fixture_computer_localhost, generate_calc_
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     assert 'output_trajectory' in results
     data_regression.check({

--- a/tests/parsers/test_dos.py
+++ b/tests/parsers/test_dos.py
@@ -3,7 +3,8 @@
 """Tests for the `DosParser`."""
 from __future__ import absolute_import
 import pytest
-from aiida.orm import FolderData
+
+from aiida import orm
 from aiida.common import AttributeDict
 
 
@@ -12,7 +13,7 @@ def dos_inputs():
     # The DosParser doesn't really need to access the parent folder, but we'd like to make the inputs as realistic
     # as possible, so we create an empty FolderData and attach it as an input to the current CalcJobNode.
     inputs = {
-        'parent_folder': FolderData().store(),
+        'parent_folder': orm.FolderData().store(),
     }
 
     return AttributeDict(inputs)
@@ -35,10 +36,11 @@ def test_dos_default(fixture_database, fixture_computer_localhost, generate_calc
     out_dos_y = results['output_dos'].get_y()
     dos_labels = [out_dos_x[0]] + [arr[0] for arr in out_dos_y]  # 4 strings
     dos_values = [out_dos_x[1]] + [arr[1] for arr in out_dos_y]  # 4 numpy arrays
-    dos_units  = [out_dos_x[2]] + [arr[2] for arr in out_dos_y]  # 4 strings
+    dos_units = [out_dos_x[2]] + [arr[2] for arr in out_dos_y]  # 4 strings
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     assert 'output_dos' in results
     data_regression.check({
@@ -49,5 +51,5 @@ def test_dos_default(fixture_database, fixture_computer_localhost, generate_calc
         }
     })
     num_regression.check({
-        'dos_val_{}'.format(i) : val for i,val in enumerate(dos_values)
+        'dos_val_{}'.format(i): val for i, val in enumerate(dos_values)
     }, default_tolerance=dict(atol=0, rtol=1e-18))

--- a/tests/parsers/test_matdyn.py
+++ b/tests/parsers/test_matdyn.py
@@ -32,6 +32,7 @@ def test_matdyn_default(fixture_database, fixture_computer_localhost, generate_c
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     assert 'output_phonon_bands' in results
     data_regression.check({

--- a/tests/parsers/test_neb.py
+++ b/tests/parsers/test_neb.py
@@ -66,6 +66,7 @@ def test_neb_default(fixture_database, fixture_computer_localhost, generate_calc
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     assert 'output_mep' in results
     assert 'output_trajectory' in results
@@ -96,6 +97,7 @@ def test_neb_all_iterations(fixture_database, fixture_computer_localhost, genera
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     assert 'output_mep' in results
     assert 'output_trajectory' in results
@@ -122,6 +124,7 @@ def test_neb_deprecated_keys(fixture_database, fixture_computer_localhost, gener
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     assert 'output_mep' in results
     assert 'output_trajectory' in results

--- a/tests/parsers/test_ph.py
+++ b/tests/parsers/test_ph.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 
 import pytest
 
+from aiida import orm
+
 
 @pytest.fixture
 def generate_inputs():
@@ -25,6 +27,7 @@ def test_ph_default(fixture_database, fixture_computer_localhost, generate_calc_
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     data_regression.check(results['output_parameters'].get_dict())
 

--- a/tests/parsers/test_pw.py
+++ b/tests/parsers/test_pw.py
@@ -91,9 +91,11 @@ def test_pw_default(fixture_database, fixture_computer_localhost, generate_calc_
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_trajectory' in results
+
     data_regression.check({
         'output_kpoints': results['output_kpoints'].attributes,
         'output_parameters': results['output_parameters'].get_dict(),
@@ -118,9 +120,11 @@ def test_pw_default_xml_new(fixture_database, fixture_computer_localhost, genera
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_band' in results
     assert 'output_parameters' in results
     assert 'output_trajectory' in results
+
     data_regression.check({
         'output_band': results['output_band'].attributes,
         'output_parameters': results['output_parameters'].get_dict(),
@@ -141,6 +145,7 @@ def test_pw_initialization_xml_new(fixture_database, fixture_computer_localhost,
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_band' not in results
     assert 'output_kpoints' not in results
     assert 'output_parameters' in results
@@ -171,6 +176,7 @@ def test_pw_failed_missing(fixture_database, fixture_computer_localhost, generat
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_failed, calcfunction.exit_status
     assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_OUTPUT_FILES.status
+    assert orm.Log.objects.get_logs_for(node)
 
 
 def test_pw_failed_interrupted(fixture_database, fixture_computer_localhost, generate_calc_job_node,
@@ -196,6 +202,7 @@ def test_pw_failed_interrupted(fixture_database, fixture_computer_localhost, gen
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_failed, calcfunction.exit_status
     assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_OUTPUT_FILES.status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     data_regression.check(results['output_parameters'].get_dict())
 
@@ -224,6 +231,7 @@ def test_pw_failed_interrupted_stdout(fixture_database, fixture_computer_localho
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_failed, calcfunction.exit_status
     assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE.status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_trajectory' in results
@@ -253,6 +261,7 @@ def test_pw_failed_interrupted_xml(fixture_database, fixture_computer_localhost,
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_failed, calcfunction.exit_status
     assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_OUTPUT_XML_PARSE.status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     assert 'output_trajectory' in results
     data_regression.check(results['output_parameters'].get_dict())
@@ -272,6 +281,7 @@ def test_pw_failed_out_of_walltime(fixture_database, fixture_computer_localhost,
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_failed, calcfunction.exit_status
     assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_OUT_OF_WALLTIME.status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     assert 'output_trajectory' in results
     data_regression.check({
@@ -294,6 +304,7 @@ def test_pw_failed_scf_not_converged(fixture_database, fixture_computer_localhos
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_failed, calcfunction.exit_status
     assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_ELECTRONIC_CONVERGENCE_NOT_REACHED.status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     assert 'output_trajectory' in results
     data_regression.check({
@@ -315,6 +326,7 @@ def test_pw_relax_success(fixture_database, fixture_computer_localhost, generate
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_structure' in results
@@ -341,6 +353,7 @@ def test_pw_relax_failed_electronic(fixture_database, fixture_computer_localhost
 
     assert calcfunction.is_failed
     assert calcfunction.exit_status == expected_exit_status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_structure' in results
@@ -361,6 +374,7 @@ def test_pw_relax_failed_not_converged_nstep(fixture_database, fixture_computer_
 
     assert calcfunction.is_failed
     assert calcfunction.exit_status == expected_exit_status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_structure' in results
@@ -380,6 +394,7 @@ def test_pw_vcrelax_success(fixture_database, fixture_computer_localhost, genera
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_structure' in results
@@ -407,6 +422,7 @@ def test_pw_vcrelax_fractional_success(fixture_database, fixture_computer_localh
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_structure' in results
@@ -434,6 +450,7 @@ def test_pw_vcrelax_failed_charge_wrong(fixture_database, fixture_computer_local
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_failed, calcfunction.exit_status
     assert calcfunction.exit_status == expected_exit_status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
 
 
@@ -452,6 +469,7 @@ def test_pw_vcrelax_failed_symmetry_not_orthogonal(fixture_database, fixture_com
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_failed, calcfunction.exit_status
     assert calcfunction.exit_status == expected_exit_status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
 
 
@@ -469,6 +487,7 @@ def test_pw_vcrelax_failed_bfgs_history(fixture_database, fixture_computer_local
 
     assert calcfunction.is_failed
     assert calcfunction.exit_status == expected_exit_status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_structure' in results
@@ -489,6 +508,7 @@ def test_pw_vcrelax_failed_bfgs_history_final_scf(fixture_database, fixture_comp
 
     assert calcfunction.is_failed
     assert calcfunction.exit_status == expected_exit_status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_structure' in results
@@ -509,6 +529,7 @@ def test_pw_vcrelax_failed_electronic(fixture_database, fixture_computer_localho
 
     assert calcfunction.is_failed
     assert calcfunction.exit_status == expected_exit_status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_structure' in results
@@ -529,6 +550,7 @@ def test_pw_vcrelax_failed_electronic_final_scf(fixture_database, fixture_comput
 
     assert calcfunction.is_failed
     assert calcfunction.exit_status == expected_exit_status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_structure' in results
@@ -549,6 +571,7 @@ def test_pw_vcrelax_failed_not_converged_final_scf(fixture_database, fixture_com
 
     assert calcfunction.is_failed
     assert calcfunction.exit_status == expected_exit_status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_structure' in results
@@ -569,6 +592,7 @@ def test_pw_vcrelax_failed_not_converged_nstep(fixture_database, fixture_compute
 
     assert calcfunction.is_failed
     assert calcfunction.exit_status == expected_exit_status
+    assert orm.Log.objects.get_logs_for(node)
     assert 'output_kpoints' in results
     assert 'output_parameters' in results
     assert 'output_structure' in results

--- a/tests/parsers/test_pw2wannier90.py
+++ b/tests/parsers/test_pw2wannier90.py
@@ -2,9 +2,11 @@
 # pylint: disable=unused-argument
 """Tests for the `Pw2wannier90Parser`."""
 from __future__ import absolute_import
+
 import pytest
 import os
-from aiida.orm import Dict, FolderData, SinglefileData
+
+from aiida import orm
 from aiida.common import AttributeDict
 
 
@@ -31,10 +33,10 @@ def pw2wannier90_inputs():
     # Since we don't actually run pw2wannier.x, we only pretend to have the output folder
     # of a parent pw.x calculation. The nnkp file, instead, is real.
     inputs = {
-        'parent_folder': FolderData().store(),
-        'nnkp_file': SinglefileData(file=nnkp_filepath).store(),
-        'parameters': Dict(dict=parameters),
-        'settings': Dict(dict=settings),
+        'parent_folder': orm.FolderData().store(),
+        'nnkp_file': orm.SinglefileData(file=nnkp_filepath).store(),
+        'parameters': orm.Dict(dict=parameters),
+        'settings': orm.Dict(dict=settings),
     }
 
     return AttributeDict(inputs)
@@ -56,6 +58,7 @@ def test_pw2wannier90_default(fixture_database, fixture_computer_localhost, gene
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'output_parameters' in results
     data_regression.check({
         'parameters': results['output_parameters'].get_dict()

--- a/tests/parsers/test_q2r.py
+++ b/tests/parsers/test_q2r.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 
 import pytest
 
+from aiida import orm
+
 
 @pytest.fixture
 def generate_inputs():
@@ -24,5 +26,6 @@ def test_q2r_default(fixture_database, fixture_computer_localhost, generate_calc
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
     assert 'force_constants' in results
     data_regression.check(results['force_constants'].get_content())


### PR DESCRIPTION
Fixes #419 

The parsers configure a logger on the calculation node, which will
automatically insert `Log` entries in the database when a message is
emitted through that logger. Tests for successful calculations now check
that there are no log messages, whereas tests for failed calculations
verify the opposite, that there are in fact logs attached to the node.

Note that currently the `Log.objects.get_logs_for` method does not
provide a way to filter for log levels. Once this is implemented in
`aiida-core` the tests should be updated to only check for `warning` and
or `error` messages.