### PR TITLE
`PwParser`: parser estimated dynamical RAM total and per process

### DIFF
--- a/tests/parsers/fixtures/pw/default/aiida.out
+++ b/tests/parsers/fixtures/pw/default/aiida.out
@@ -635,6 +635,9 @@
 
      Estimated max dynamical RAM per process >      10.86MB
 
+     # Note following line is pasted manually for testing purposes
+     Estimated total dynamical RAM >      11.35 GB
+
      Initial potential from superposition of free atoms
 
      starting charge    7.99888, renormalised to    8.00000

--- a/tests/parsers/test_pw/test_pw_default.yml
+++ b/tests/parsers/test_pw/test_pw_default.yml
@@ -38,6 +38,10 @@ output_parameters:
   energy_units: eV
   energy_xc: -168.63179023436172
   energy_xc_units: eV
+  estimated_ram_per_process: 10.86
+  estimated_ram_per_process_units: MB
+  estimated_ram_total: 11.35
+  estimated_ram_total_units: GB
   fermi_energy: 6.5091589497144975
   fermi_energy_units: eV
   fft_grid:

--- a/tests/parsers/test_pw/test_pw_default_xml_new.yml
+++ b/tests/parsers/test_pw/test_pw_default_xml_new.yml
@@ -51,6 +51,8 @@ output_parameters:
   energy_units: eV
   energy_xc: -168.63202466043015
   energy_xc_units: eV
+  estimated_ram_per_process: 60.62
+  estimated_ram_per_process_units: MB
   exit_status: 0
   fermi_energy_units: eV
   fft_grid:

--- a/tests/parsers/test_pw/test_pw_failed_interrupted.yml
+++ b/tests/parsers/test_pw/test_pw_failed_interrupted.yml
@@ -11,6 +11,8 @@ energy_threshold: 3.84e-06
 energy_units: eV
 energy_xc: -168.63179023436172
 energy_xc_units: eV
+estimated_ram_per_process: 10.86
+estimated_ram_per_process_units: MB
 fft_grid:
 - 36
 - 36

--- a/tests/parsers/test_pw/test_pw_failed_interrupted_stdout.yml
+++ b/tests/parsers/test_pw/test_pw_failed_interrupted_stdout.yml
@@ -18,6 +18,8 @@ energy_threshold: 3.84e-06
 energy_units: eV
 energy_xc: -168.63179023436172
 energy_xc_units: eV
+estimated_ram_per_process: 10.86
+estimated_ram_per_process_units: MB
 fermi_energy: 6.5091589497144975
 fermi_energy_units: eV
 fft_grid:

--- a/tests/parsers/test_pw/test_pw_failed_interrupted_xml.yml
+++ b/tests/parsers/test_pw/test_pw_failed_interrupted_xml.yml
@@ -11,6 +11,8 @@ energy_threshold: 3.84e-06
 energy_units: eV
 energy_xc: -168.63179023436172
 energy_xc_units: eV
+estimated_ram_per_process: 10.86
+estimated_ram_per_process_units: MB
 fft_grid:
 - 36
 - 36

--- a/tests/parsers/test_pw/test_pw_failed_out_of_walltime.yml
+++ b/tests/parsers/test_pw/test_pw_failed_out_of_walltime.yml
@@ -6,6 +6,8 @@ output_parameters:
   creator_version: '6.1'
   dft_exchange_correlation: PBE
   do_not_use_time_reversal: false
+  estimated_ram_per_process: 10.86
+  estimated_ram_per_process_units: MB
   fermi_energy: 6.506310350624009
   fermi_energy_units: eV
   fft_grid:

--- a/tests/parsers/test_pw/test_pw_failed_scf_not_converged.yml
+++ b/tests/parsers/test_pw/test_pw_failed_scf_not_converged.yml
@@ -7,6 +7,8 @@ output_parameters:
   dft_exchange_correlation: PBE
   do_not_use_time_reversal: false
   energy_threshold: 6.69e-05
+  estimated_ram_per_process: 10.86
+  estimated_ram_per_process_units: MB
   fermi_energy: 6.551119364541959
   fermi_energy_units: eV
   fft_grid:

--- a/tests/parsers/test_pw/test_pw_initialization_xml_new.yml
+++ b/tests/parsers/test_pw/test_pw_initialization_xml_new.yml
@@ -12,6 +12,8 @@ output_parameters:
   dft_exchange_correlation: PBE
   do_magnetization: false
   do_not_use_time_reversal: false
+  estimated_ram_per_process: 60.62
+  estimated_ram_per_process_units: MB
   exit_status: 0
   fermi_energy_units: eV
   fft_grid:

--- a/tests/parsers/test_pw/test_pw_relax_success.yml
+++ b/tests/parsers/test_pw/test_pw_relax_success.yml
@@ -38,6 +38,8 @@ output_parameters:
   energy_units: eV
   energy_xc: -168.63179023436172
   energy_xc_units: eV
+  estimated_ram_per_process: 10.86
+  estimated_ram_per_process_units: MB
   fermi_energy: 6.5091589497144975
   fermi_energy_units: eV
   fft_grid:

--- a/tests/parsers/test_pw/test_pw_vcrelax_fractional_success.yml
+++ b/tests/parsers/test_pw/test_pw_vcrelax_fractional_success.yml
@@ -38,6 +38,8 @@ output_parameters:
   energy_units: eV
   energy_xc: -65.18946056869883
   energy_xc_units: eV
+  estimated_ram_per_process: 12.05
+  estimated_ram_per_process_units: MB
   fermi_energy: 5.955412275759516
   fermi_energy_units: eV
   fft_grid:

--- a/tests/parsers/test_pw/test_pw_vcrelax_success.yml
+++ b/tests/parsers/test_pw/test_pw_vcrelax_success.yml
@@ -38,6 +38,8 @@ output_parameters:
   energy_units: eV
   energy_xc: -166.99420223940183
   energy_xc_units: eV
+  estimated_ram_per_process: 12.89
+  estimated_ram_per_process_units: MB
   fermi_energy: 5.502885817503379
   fermi_energy_units: eV
   fft_grid:


### PR DESCRIPTION
Fixes #431 

This is especially useful for the automatic parallelization
functionality which can use this information to estimate how many
machines will be needed to not exceed the memory limit per machine.
The parsing regex format should work for versions from 5.2 up to
6.4 included.