### PR TITLE
Add an exit code for the case where some nodes have no k-points.

### DIFF
--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -117,6 +117,9 @@ class PwCalculation(BasePwCpInputGenerator):
         spec.exit_code(461, 'ERROR_DEXX_IS_NEGATIVE',
             message='The code failed with negative dexx in the exchange calculation.')
 
+        spec.exit_code(481, 'ERROR_NPOOLS_TOO_HIGH',
+            message='The k-point parallelization "npools" is too high, some nodes have no k-points.')
+
         spec.exit_code(500, 'ERROR_IONIC_CONVERGENCE_NOT_REACHED',
             message='The ionic minimization cycle did not converge for the given thresholds.')
         spec.exit_code(501, 'ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF',

--- a/aiida_quantumespresso/parsers/parse_raw/pw.py
+++ b/aiida_quantumespresso/parsers/parse_raw/pw.py
@@ -275,7 +275,8 @@ def detect_important_message(logs, line):
             'problems computing cholesky': 'ERROR_DIAGONALIZATION_CHOLESKY_DECOMPOSITION',
             'charge is wrong': 'ERROR_CHARGE_IS_WRONG',
             'not orthogonal operation': 'ERROR_SYMMETRY_NON_ORTHOGONAL_OPERATION',
-            'dexx is negative': 'ERROR_DEXX_IS_NEGATIVE'
+            'dexx is negative': 'ERROR_DEXX_IS_NEGATIVE',
+            'some nodes have no k-points': 'ERROR_NPOOLS_TOO_HIGH',
         },
         'warning': {
             'Warning:': None,

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -144,6 +144,9 @@ class PwParser(Parser):
         if 'ERROR_DEXX_IS_NEGATIVE' in logs['error']:
             return self.exit_codes.ERROR_DEXX_IS_NEGATIVE
 
+        if 'ERROR_NPOOLS_TOO_HIGH' in logs['error']:
+            return self.exit_codes.ERROR_NPOOLS_TOO_HIGH
+
     def validate_electronic(self, trajectory, parameters, logs):
         """Analyze problems that are specific to `electronic` type calculations: i.e. `scf`, `nscf` and `bands`."""
         if self.get_calculation_type() not in ['scf', 'nscf', 'bands']:

--- a/tests/parsers/fixtures/pw/failed_npools_too_high/aiida.out
+++ b/tests/parsers/fixtures/pw/failed_npools_too_high/aiida.out
@@ -1,0 +1,21 @@
+
+     Program PWSCF v.6.4.1 starts on 15Oct2019 at 14:12: 0
+
+     This program is part of the open-source Quantum ESPRESSO suite
+     for quantum simulation of materials; please cite
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 21 395502 (2009);
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 29 465901 (2017);
+          URL http://www.quantum-espresso.org",
+     in publications or presentations arising from this work. More details at
+     http://www.quantum-espresso.org/quote
+
+# NOTE: 25 lines of output removed
+
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     Error in routine divide_et_impera (1):
+     some nodes have no k-points
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+     stopping ...
+
+# NOTE: duplicate error messages removed

--- a/tests/parsers/test_pw.py
+++ b/tests/parsers/test_pw.py
@@ -617,3 +617,24 @@ def test_pw_hybrid_failed_dexx_negative(
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_failed, calcfunction.exit_status
     assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_DEXX_IS_NEGATIVE.status
+
+
+def test_pw_npools_too_high(
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default
+):
+    """Test the parsing of a calculation that failed because some nodes have no k-points.
+
+    In this test the stdout is incomplete, and the XML is missing completely. The stdout contains
+    the relevant error message.
+    """
+    name = 'failed_npools_too_high'
+    entry_point_calc_job = 'quantumespresso.pw'
+    entry_point_parser = 'quantumespresso.pw'
+
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    parser = generate_parser(entry_point_parser)
+    _, calcfunction = parser.parse_from_node(node, store_provenance=False)
+
+    assert calcfunction.is_finished, calcfunction.exception
+    assert calcfunction.is_failed, calcfunction.exit_status
+    assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_NPOOLS_TOO_HIGH.status


### PR DESCRIPTION
Fixes #437.

The reason for this error is that the number of k-points is lower than the given 'npools'.