### PR TITLE
`PwParser`: add `smearing_type` and `smearing` from new XML output

### DIFF
--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -2,6 +2,8 @@
 """`Parser` implementation for the `PwCalculation` calculation job class."""
 from __future__ import absolute_import
 
+import traceback
+
 import numpy
 
 from aiida import orm
@@ -285,8 +287,7 @@ class PwParser(Parser):
         except XMLUnsupportedFormatError:
             self.exit_code_xml = self.exit_codes.ERROR_OUTPUT_XML_FORMAT
         except Exception:
-            import traceback
-            traceback.print_exc()
+            logs.critical.append(traceback.format_exc())
             self.exit_code_xml = self.exit_codes.ERROR_UNEXPECTED_PARSER_EXCEPTION
 
         return parsed_data, logs
@@ -319,8 +320,7 @@ class PwParser(Parser):
         try:
             parsed_data, logs = parse_stdout(stdout, parameters, parser_options, parsed_xml)
         except Exception:
-            import traceback
-            traceback.print_exc()
+            logs.critical.append(traceback.format_exc())
             self.exit_code_stdout = self.exit_codes.ERROR_UNEXPECTED_PARSER_EXCEPTION
 
         # If the stdout was incomplete, most likely the job was interrupted before it could cleanly finish, so the

--- a/tests/parsers/test_neb/test_neb_default.yml
+++ b/tests/parsers/test_neb/test_neb_default.yml
@@ -70,6 +70,7 @@ parameters:
         scf_error: 2.251833940343682e-10
     creator_name: pwscf
     creator_version: 6.4.1
+    degauss: 0.0408170751759
     dft_exchange_correlation: PBE
     do_magnetization: false
     do_not_use_time_reversal: false
@@ -137,6 +138,7 @@ parameters:
     q_real_space: false
     rho_cutoff: 1360.56917253
     rho_cutoff_units: eV
+    smearing_type: gaussian
     smooth_fft_grid:
     - 36
     - 15
@@ -183,6 +185,7 @@ parameters:
         scf_error: 2.987478357372217e-09
     creator_name: pwscf
     creator_version: 6.4.1
+    degauss: 0.0408170751759
     dft_exchange_correlation: PBE
     do_magnetization: false
     do_not_use_time_reversal: false
@@ -234,6 +237,7 @@ parameters:
     q_real_space: false
     rho_cutoff: 1360.56917253
     rho_cutoff_units: eV
+    smearing_type: gaussian
     smooth_fft_grid:
     - 36
     - 15
@@ -296,6 +300,7 @@ parameters:
         scf_error: 2.80245941733356e-10
     creator_name: pwscf
     creator_version: 6.4.1
+    degauss: 0.0408170751759
     dft_exchange_correlation: PBE
     do_magnetization: false
     do_not_use_time_reversal: false
@@ -363,6 +368,7 @@ parameters:
     q_real_space: false
     rho_cutoff: 1360.56917253
     rho_cutoff_units: eV
+    smearing_type: gaussian
     smooth_fft_grid:
     - 36
     - 15

--- a/tests/parsers/test_pw.py
+++ b/tests/parsers/test_pw.py
@@ -3,7 +3,6 @@
 """Tests for the `PwParser`."""
 from __future__ import absolute_import
 
-import functools
 import pytest
 
 from aiida import orm
@@ -11,52 +10,28 @@ from aiida.common import AttributeDict
 
 
 @pytest.fixture
-def generate_inputs_default(generate_structure):
+def generate_inputs(generate_structure):
     """Return only those inputs that the parser will expect to be there."""
-    structure = generate_structure()
-    parameters = {'CONTROL': {'calculation': 'scf'}}
-    kpoints = orm.KpointsData()
-    kpoints.set_cell_from_structure(structure)
-    kpoints.set_kpoints_mesh_from_density(0.15)
 
-    return AttributeDict({
-        'structure': generate_structure(),
-        'kpoints': kpoints,
-        'parameters': orm.Dict(dict=parameters),
-        'settings': orm.Dict()
-    })
-
-
-@pytest.fixture
-def generate_inputs_relax(generate_structure):
-    """Return only those inputs that the parser will expect to be there.
-
-    This needs a separate input generation function from the default one, because the parser depends on certain values
-    in the input parameters to determine what kind of calculation it was. For example, it will check the card
-    `CONTROL.calculation` to determine whether the `TrajectoryData` should be attached. If we would not set it to
-    `relax`, the parser would not parse that output node and the test would fail. Until we can make the raw output
-    parser independent of the input parameters, this will have to remain a separate test inputs generator.
-    """
-
-    def _generate_inputs(relax_type='vc-relax'):
+    def _generate_inputs(calculation_type='scf', settings=None):
         structure = generate_structure()
-        parameters = {'CONTROL': {'calculation': relax_type}}
+        parameters = {'CONTROL': {'calculation': calculation_type}}
         kpoints = orm.KpointsData()
         kpoints.set_cell_from_structure(structure)
         kpoints.set_kpoints_mesh_from_density(0.15)
 
         return AttributeDict({
-            'structure': structure,
+            'structure': generate_structure(),
             'kpoints': kpoints,
             'parameters': orm.Dict(dict=parameters),
-            'settings': orm.Dict()
+            'settings': orm.Dict(dict=settings) or orm.Dict()
         })
 
     return _generate_inputs
 
 
 def test_pw_default(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test a `pw.x` calculation in `scf` mode.
 
@@ -67,7 +42,7 @@ def test_pw_default(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -86,7 +61,7 @@ def test_pw_default(
 
 
 def test_pw_default_xml_190304(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test a `pw.x` calculation in `scf` mode that produced the XML output with schema of 190304.
 
@@ -97,7 +72,7 @@ def test_pw_default_xml_190304(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -116,7 +91,7 @@ def test_pw_default_xml_190304(
 
 
 def test_pw_default_xml_191206(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test a `pw.x` calculation in `scf` mode that produced the XML output with schema of 191206.
 
@@ -127,7 +102,7 @@ def test_pw_default_xml_191206(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -146,20 +121,21 @@ def test_pw_default_xml_191206(
 
 
 def test_pw_initialization_xml_new(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test a `pw.x` calculation with new XML that only runs the preamble, i.e. an initialization-only calculation."""
     name = 'initialization_xml_new'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    inputs = generate_inputs(settings={'ONLY_INITIALIZATION': True})
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
-    assert orm.Log.objects.get_logs_for(node)
+    assert not orm.Log.objects.get_logs_for(node), [log.message for log in orm.Log.objects.get_logs_for(node)]
     assert 'output_band' not in results
     assert 'output_kpoints' not in results
     assert 'output_parameters' in results
@@ -171,7 +147,7 @@ def test_pw_initialization_xml_new(
 
 
 def test_pw_failed_computing_cholesky(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test the parsing of a calculation that failed during cholesky factorization.
 
@@ -182,7 +158,7 @@ def test_pw_failed_computing_cholesky(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     _, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -192,7 +168,7 @@ def test_pw_failed_computing_cholesky(
 
 
 def test_pw_failed_dexx_negative(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test the parsing of a calculation that failed due to negative dexx.
 
@@ -203,7 +179,7 @@ def test_pw_failed_dexx_negative(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     _, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -212,9 +188,7 @@ def test_pw_failed_dexx_negative(
     assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_DEXX_IS_NEGATIVE.status
 
 
-def test_pw_failed_missing(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default
-):
+def test_pw_failed_missing(aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs):
     """Test the parsing of a calculation that was interrupted before output files could even be written.
 
     In this particular interrupted test both the XML and the stdout are completely missing.
@@ -226,7 +200,7 @@ def test_pw_failed_missing(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     _, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -237,7 +211,7 @@ def test_pw_failed_missing(
 
 
 def test_pw_failed_interrupted(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test the parsing of a calculation that was interrupted *after* convergence was achieved.
 
@@ -253,7 +227,7 @@ def test_pw_failed_interrupted(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -266,7 +240,7 @@ def test_pw_failed_interrupted(
 
 
 def test_pw_failed_interrupted_stdout(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test the parsing of a calculation that was interrupted *after* convergence was achieved.
 
@@ -283,7 +257,7 @@ def test_pw_failed_interrupted_stdout(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -298,7 +272,7 @@ def test_pw_failed_interrupted_stdout(
 
 
 def test_pw_failed_interrupted_xml(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test the parsing of a calculation that was interrupted *after* convergence was achieved.
 
@@ -314,7 +288,7 @@ def test_pw_failed_interrupted_xml(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -327,9 +301,7 @@ def test_pw_failed_interrupted_xml(
     data_regression.check(results['output_parameters'].get_dict())
 
 
-def test_pw_npools_too_high(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default
-):
+def test_pw_npools_too_high(aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs):
     """Test the parsing of a calculation that failed because some nodes have no k-points.
 
     In this test the stdout is incomplete, and the XML is missing completely. The stdout contains
@@ -339,7 +311,7 @@ def test_pw_npools_too_high(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     _, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -349,14 +321,14 @@ def test_pw_npools_too_high(
 
 
 def test_pw_failed_out_of_walltime(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test the parsing of an scf calculation that ran nominally but was cut short because it ran out of walltime."""
     name = 'failed_out_of_walltime'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -373,7 +345,7 @@ def test_pw_failed_out_of_walltime(
 
 
 def test_pw_failed_out_of_walltime_interrupted(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test the parsing of an scf calculation that ran nominally but was cut short because it ran out of walltime.
 
@@ -385,7 +357,7 @@ def test_pw_failed_out_of_walltime_interrupted(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -402,14 +374,14 @@ def test_pw_failed_out_of_walltime_interrupted(
 
 
 def test_pw_failed_scf_not_converged(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_default, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test the parsing of an scf calculation that ran nominally but did not reach convergence."""
     name = 'failed_scf_not_converged'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_default)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -426,15 +398,15 @@ def test_pw_failed_scf_not_converged(
 
 
 def test_pw_relax_success(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test a `relax` that successfully converges."""
     name = 'relax_success'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    generate_inputs = functools.partial(generate_inputs_relax, relax_type='relax')()
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs)
+    inputs = generate_inputs(calculation_type='relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -454,15 +426,15 @@ def test_pw_relax_success(
 
 
 def test_pw_relax_failed_electronic(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `relax` that failed to converge during electronic cycle before ionic convergence is reached."""
     name = 'relax_failed_electronic'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    generate_inputs = functools.partial(generate_inputs_relax, relax_type='relax')()
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs)
+    inputs = generate_inputs(calculation_type='relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
     expected_exit_status = node.process_class.exit_codes.ERROR_IONIC_CYCLE_ELECTRONIC_CONVERGENCE_NOT_REACHED.status
@@ -477,15 +449,15 @@ def test_pw_relax_failed_electronic(
 
 
 def test_pw_relax_failed_not_converged_nstep(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `relax` that failed to converge within the maximum number of steps."""
     name = 'relax_failed_not_converged_nstep'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    generate_inputs = functools.partial(generate_inputs_relax, relax_type='relax')()
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs)
+    inputs = generate_inputs(calculation_type='relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
     expected_exit_status = node.process_class.exit_codes.ERROR_IONIC_CYCLE_EXCEEDED_NSTEP.status
@@ -500,14 +472,15 @@ def test_pw_relax_failed_not_converged_nstep(
 
 
 def test_pw_vcrelax_success(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test a `vc-relax` that successfully converges and the final scf also converges."""
     name = 'vcrelax_success'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -527,7 +500,7 @@ def test_pw_vcrelax_success(
 
 
 def test_pw_vcrelax_success_fractional(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax, data_regression
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test a `vc-relax`, that successfully converges and the final scf also converges.
 
@@ -537,7 +510,8 @@ def test_pw_vcrelax_success_fractional(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -557,14 +531,15 @@ def test_pw_vcrelax_success_fractional(
 
 
 def test_pw_vcrelax_success_external_pressure(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `vc-relax` with external pressure that successfully converges and the final scf also converges."""
     name = 'vcrelax_success_external_pressure'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -578,14 +553,15 @@ def test_pw_vcrelax_success_external_pressure(
 
 
 def test_pw_vcrelax_failed_charge_wrong(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `vc-relax` that failed because the integrated charge is different from the expected one."""
     name = 'vcrelax_failed_charge_wrong'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
     expected_exit_status = node.process_class.exit_codes.ERROR_CHARGE_IS_WRONG.status
@@ -598,14 +574,15 @@ def test_pw_vcrelax_failed_charge_wrong(
 
 
 def test_pw_vcrelax_failed_symmetry_not_orthogonal(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `vc-relax` that failed because original symmetries no longer map onto new structure."""
     name = 'vcrelax_failed_symmetry_not_orthogonal'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
     expected_exit_status = node.process_class.exit_codes.ERROR_SYMMETRY_NON_ORTHOGONAL_OPERATION.status
@@ -618,14 +595,15 @@ def test_pw_vcrelax_failed_symmetry_not_orthogonal(
 
 
 def test_pw_vcrelax_failed_bfgs_history(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `vc-relax` that failed to converge due to two consecutive failures of BFGS."""
     name = 'vcrelax_failed_bfgs_history'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
     expected_exit_status = node.process_class.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_FAILURE.status
@@ -640,7 +618,7 @@ def test_pw_vcrelax_failed_bfgs_history(
 
 
 def test_pw_vcrelax_failed_bfgs_history_already_converged(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `vc-relax` that stops due to two consecutive failures of BFGS but is actually converged.
 
@@ -653,7 +631,8 @@ def test_pw_vcrelax_failed_bfgs_history_already_converged(
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -666,14 +645,15 @@ def test_pw_vcrelax_failed_bfgs_history_already_converged(
 
 
 def test_pw_vcrelax_failed_bfgs_history_final_scf(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `vc-relax` that failed to converge due to two consecutive failures of BFGS and final SCF fails."""
     name = 'vcrelax_failed_bfgs_history_final_scf'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
     expected_exit_status = node.process_class.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_AND_FINAL_SCF_FAILURE.status
@@ -688,14 +668,15 @@ def test_pw_vcrelax_failed_bfgs_history_final_scf(
 
 
 def test_pw_vcrelax_failed_electronic(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `vc-relax` that failed to converge during electronic cycle before ionic convergence is reached."""
     name = 'vcrelax_failed_electronic'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
     expected_exit_status = node.process_class.exit_codes.ERROR_IONIC_CYCLE_ELECTRONIC_CONVERGENCE_NOT_REACHED.status
@@ -710,14 +691,15 @@ def test_pw_vcrelax_failed_electronic(
 
 
 def test_pw_vcrelax_failed_electronic_final_scf(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `vc-relax` that failed to converge in electronic cycle in the final SCF after ionic convergence."""
     name = 'vcrelax_failed_electronic_final_scf'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
     expected_exit_status = node.process_class.exit_codes.ERROR_IONIC_CONVERGENCE_REACHED_FINAL_SCF_FAILED.status
@@ -732,14 +714,15 @@ def test_pw_vcrelax_failed_electronic_final_scf(
 
 
 def test_pw_vcrelax_failed_not_converged_final_scf(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `vc-relax` that successfully converges in ionic cycle, but thresholds are exceeded in the SCF."""
     name = 'vcrelax_failed_not_converged_final_scf'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
     expected_exit_status = node.process_class.exit_codes.ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF.status
@@ -754,14 +737,15 @@ def test_pw_vcrelax_failed_not_converged_final_scf(
 
 
 def test_pw_vcrelax_failed_not_converged_nstep(
-    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
 ):
     """Test a `vc-relax` that failed to converge within the maximum number of steps."""
     name = 'vcrelax_failed_not_converged_nstep'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    inputs = generate_inputs(calculation_type='vc-relax')
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs)
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
     expected_exit_status = node.process_class.exit_codes.ERROR_IONIC_CYCLE_EXCEEDED_NSTEP.status


### PR DESCRIPTION
Fixes #415 

These keys were not yet being parsed from the output file with the new
XML schema. In addition, if an exception is thrown by the raw XML or
stdout parser, it is now caught and added as a critical warning. Finally
the test input generator for `PwParser` is simplified and only a single
generator is used for both scf and relax tests.