### PR TITLE
`PwParser`: add new exit code `ERROR_OUT_OF_WALLTIME_INTERRUPTED`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -61,7 +61,8 @@ disable=bad-continuation,
         logging-format-interpolation,
         no-else-raise,
         useless-object-inheritance,
-        inconsistent-return-statements
+        inconsistent-return-statements,
+        import-outside-toplevel
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -105,6 +105,9 @@ class PwCalculation(BasePwCpInputGenerator):
             message='The XML output file could not be parsed.')
         spec.exit_code(322, 'ERROR_OUTPUT_XML_FORMAT',
             message='The XML output file has an unsupported format.')
+        spec.exit_code(340, 'ERROR_OUT_OF_WALLTIME_INTERRUPTED',
+            message='The calculation stopped prematurely because it ran out of walltime but the job was killed by the '
+            'scheduler before the files were safely written to disk for a potential restart.')
         spec.exit_code(350, 'ERROR_UNEXPECTED_PARSER_EXCEPTION',
             message='The parser raised an unexpected exception.')
 

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -132,6 +132,9 @@ class PwParser(Parser):
 
     def validate_premature_exit(self, logs):
         """Analyze problems that will cause a pre-mature termination of the calculation, controlled or not."""
+        if 'ERROR_OUT_OF_WALLTIME' in logs['error'] and 'ERROR_OUTPUT_STDOUT_INCOMPLETE' in logs['error']:
+            return self.exit_codes.ERROR_OUT_OF_WALLTIME_INTERRUPTED
+
         if 'ERROR_OUT_OF_WALLTIME' in logs['error']:
             return self.exit_codes.ERROR_OUT_OF_WALLTIME
 

--- a/tests/parsers/fixtures/pw/failed_out_of_walltime_interrupted/aiida.out
+++ b/tests/parsers/fixtures/pw/failed_out_of_walltime_interrupted/aiida.out
@@ -1,0 +1,15 @@
+     Program PWSCF v.6.1 (svn rev. 13369) starts on 12Jun2019 at 12:30:36
+
+     [CONTENT REMOVED]
+
+     total energy              =     -22.65168903 Ry
+     Harris-Foulkes estimate   =     -22.65168903 Ry
+     estimated scf accuracy    <          2.9E-15 Ry
+
+     Maximum CPU time exceeded
+
+     max_seconds     =       3.00
+     elapsed seconds =       3.16
+     Calculation stopped in scf loop at iteration #    12
+
+     Writing output data file aiida.save

--- a/tests/parsers/test_pw/test_pw_failed_out_of_walltime_interrupted.yml
+++ b/tests/parsers/test_pw/test_pw_failed_out_of_walltime_interrupted.yml
@@ -1,0 +1,18 @@
+output_parameters:
+  parser_info: aiida-quantumespresso parser pw.x v3.0.0a5
+  parser_version: 3.0.0a5
+  parser_warnings: []
+output_trajectory:
+  array|cells:
+  - 1
+  - 3
+  - 3
+  array|positions:
+  - 1
+  - 2
+  - 3
+  array|steps:
+  - 1
+  symbols:
+  - Si
+  - Si


### PR DESCRIPTION
Fixes #450 

If the `max_seconds` parameter is set in the input and this number is
exceeded, Quantum ESPRESSO will attempt to terminate the calculation
cleanly by writing all files to disk that are necessary for a restart.
However, during this phase the scheduler can still kill the job if the
total requested walltime has been exceeded. This will result in the
restart files being corrupt and not suitable for a restart. Therefore
this case needs a different exit code than the currently existing one
`ERROR_OUT_OF_WALLTIME` which should only be used for calculation that
shutdown cleanly.