### PR TITLE
add a protocol for testing

### DIFF
--- a/aiida_quantumespresso/utils/protocols/pw.py
+++ b/aiida_quantumespresso/utils/protocols/pw.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 import json
 import os
-import six
 from copy import deepcopy
+import six
 
 
 def _load_pseudo_metadata(filename):
@@ -74,8 +74,8 @@ def _get_all_protocol_modifiers():
     testing['parameters']['fast']['kpoints_mesh_density'] = 0.3
     testing['parameters_default'] = 'fast'
     ps_data = testing['pseudo']['SSSP-efficiency-1.1']
-    for ps in ps_data:
-        ps_data[ps]['cutoff'] = ps_data[ps]['cutoff']/2
+    for pseudo in ps_data:
+        ps_data[pseudo]['cutoff'] = ps_data[pseudo]['cutoff'] / 2
     testing['pseudo']['SSSP-efficiency-1.1'] = ps_data
     protocols['testing'] = testing
 

--- a/aiida_quantumespresso/utils/protocols/pw.py
+++ b/aiida_quantumespresso/utils/protocols/pw.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import json
 import os
 import six
+from copy import deepcopy
 
 
 def _load_pseudo_metadata(filename):
@@ -67,6 +68,17 @@ def _get_all_protocol_modifiers():
     }
     protocols['theos-ht-1.0']['parameters']['scdm'] = protocols['theos-ht-1.0']['parameters']['default']
     protocols['theos-ht-1.0']['parameters']['scdm']['num_bands_factor'] = 3.0
+
+    # a protocol for testing purpose, decrease kmesh density & ecutoff
+    testing = deepcopy(protocols['theos-ht-1.0'])
+    testing['parameters']['fast']['kpoints_mesh_density'] = 0.3
+    testing['parameters_default'] = 'fast'
+    ps_data = testing['pseudo']['SSSP-efficiency-1.1']
+    for ps in ps_data:
+        ps_data[ps]['cutoff'] = ps_data[ps]['cutoff']/2
+    testing['pseudo']['SSSP-efficiency-1.1'] = ps_data
+    protocols['testing'] = testing
+
     return protocols
 
 


### PR DESCRIPTION
Based on `theos-ht-1.0`, this `testing` protocol 
1. increase `kpoints_mesh_density` to `0.3`
2. divide `cutoff` by 2

So for debug/tutorial, the whole calculation can be quicker.