### PR TITLE
`PwParser`: include external pressure in ionic convergence threshold

### DIFF
--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -232,13 +232,15 @@ class PwParser(Parser):
         parameters = self.node.inputs.parameters.get_dict()
         threshold_forces = parameters.get('CONTROL', {}).get('forc_conv_thr', pw.forc_conv_thr)
         threshold_stress = parameters.get('CELL', {}).get('press_conv_thr', pw.press_conv_thr)
+        external_pressure = parameters.get('CELL', {}).get('press', 0)
 
         if relax_type == 'relax':
             return verify_convergence_trajectory(trajectory, -1, *[threshold_forces, None])
 
         if relax_type == 'vc-relax':
-            converged_relax = verify_convergence_trajectory(trajectory, -2, *[threshold_forces, threshold_stress])
-            converged_final = verify_convergence_trajectory(trajectory, -1, *[threshold_forces, threshold_stress])
+            values = [threshold_forces, threshold_stress, external_pressure]
+            converged_relax = verify_convergence_trajectory(trajectory, -2, *values)
+            converged_final = verify_convergence_trajectory(trajectory, -1, *values)
             return converged_relax and (converged_final or except_final_scf)
 
         raise RuntimeError('unknown relax_type: {}'.format(relax_type))

--- a/aiida_quantumespresso/utils/validation/trajectory.py
+++ b/aiida_quantumespresso/utils/validation/trajectory.py
@@ -6,7 +6,9 @@ from __future__ import division
 import numpy
 
 
-def verify_convergence_trajectory(trajectory, index=-1, threshold_forces=None, threshold_stress=None):
+def verify_convergence_trajectory(
+    trajectory, index=-1, threshold_forces=None, threshold_stress=None, reference_pressure=0.
+):
     """Verify that the data of the given `TrajectoryData` is converged with respect to the given thresholds.
 
     There are up to three properties controlled for convergence: total energy, forces and stress.
@@ -14,10 +16,14 @@ def verify_convergence_trajectory(trajectory, index=-1, threshold_forces=None, t
     array, or index within that array, does not exist in the `TrajectoryData`, None is returned. If all thresholds are
     successfully met, `True` is returned, if at least one of them fails, `False` is returned.
 
+    The stress is converged if the absolute difference of its corresponding pressure and the reference pressure is
+    within the given threshold.
+
     :param trajectory: the `TrajectoryData`
     :param index: the frame index of the trajectory data to check, default is `-1` meaning the last frame
     :param threshold_forces: the force threshold in Ry / bohr
     :param threshold_stress: the stress threshold in kbar
+    :param reference_pressure: reference pressure in kbar
     :return: `True` if all thresholds are valid, `False` otherwise
     :raises ValueError: if any of the arrays or indices don't exist
     """
@@ -27,7 +33,7 @@ def verify_convergence_trajectory(trajectory, index=-1, threshold_forces=None, t
         converged_forces = True
 
     if threshold_stress is not None:
-        converged_stress = verify_convergence_stress(trajectory, index, threshold_stress)
+        converged_stress = verify_convergence_stress(trajectory, index, threshold_stress, reference_pressure)
     else:
         converged_stress = True
 
@@ -58,12 +64,16 @@ def verify_convergence_forces(trajectory, index=-1, threshold=None):
     return numpy.max(abs(forces)) < threshold
 
 
-def verify_convergence_stress(trajectory, index=-1, threshold=None):
+def verify_convergence_stress(trajectory, index=-1, threshold=None, reference_pressure=0.):
     """Verify that the `stress` of the given `TrajectoryData` are converged with respect to given threshold.
+
+    The stress is converged if the absolute difference of its corresponding pressure and the reference pressure is
+    within the given threshold.
 
     :param trajectory: the `TrajectoryData`
     :param index: the frame index of the trajectory data to check, default is `-1` meaning the last frame
     :param threshold: the stress threshold in kbar
+    :param reference_pressure: reference pressure in kbar
     :return: `True` if threshold is valid, `False` otherwise
     :raises ValueError: if the `stress` array or given index does not exist
     """
@@ -71,10 +81,13 @@ def verify_convergence_stress(trajectory, index=-1, threshold=None):
         return None
 
     threshold /= 10.  # Convert to GPa
+    reference_pressure /= 10.  # Convert to GPa
 
     try:
         stress = trajectory.get_array('stress')[index]
     except (KeyError, IndexError):
         raise ValueError('the `stress` array does not exist or the given index exceeds the length.')
 
-    return (numpy.trace(stress) / 3.) < threshold
+    pressure = (numpy.trace(stress) / 3.)
+
+    return abs(pressure - reference_pressure) < threshold

--- a/tests/parsers/fixtures/pw/vcrelax_success_external_pressure/aiida.in
+++ b/tests/parsers/fixtures/pw/vcrelax_success_external_pressure/aiida.in
@@ -1,0 +1,33 @@
+&CONTROL
+  calculation = 'vc-relax'
+  outdir = './out/'
+  prefix = 'aiida'
+  pseudo_dir = './pseudo/'
+  verbosity = 'high'
+/
+&SYSTEM
+  ecutrho =   2.4000000000d+02
+  ecutwfc =   3.0000000000d+01
+  ibrav = 0
+  nat = 2
+  ntyp = 1
+/
+&ELECTRONS
+/
+&IONS
+/
+&CELL
+  press = 10
+/
+ATOMIC_SPECIES
+Si     28.0855 Si.pbe-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS angstrom
+Si           0.0000000000       0.0000000000       0.0000000000 
+Si           1.3575000000       1.3575000000       1.3575000000 
+K_POINTS automatic
+2 2 2 0 0 0
+CELL_PARAMETERS angstrom
+      2.7150000000       2.7150000000       0.0000000000
+      2.7150000000       0.0000000000       2.7150000000
+      0.0000000000       2.7150000000       2.7150000000
+

--- a/tests/parsers/fixtures/pw/vcrelax_success_external_pressure/aiida.out
+++ b/tests/parsers/fixtures/pw/vcrelax_success_external_pressure/aiida.out
@@ -1,0 +1,286 @@
+
+     Program PWSCF v.6.3MaX starts on  4Mar2020 at 14:38:24 
+
+     This program is part of the open-source Quantum ESPRESSO suite
+     for quantum simulation of materials; please cite
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 21 395502 (2009);
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 29 465901 (2017);
+          URL http://www.quantum-espresso.org", 
+     in publications or presentations arising from this work. More details at
+     http://www.quantum-espresso.org/quote
+
+--- OUTPUT REMOVED ---
+
+     Writing output data file aiida.save/
+     NEW-OLD atomic charge density approx. for the potential
+     extrapolated charge    8.03700, renormalised to    8.00000
+
+     total cpu time spent up to now is       13.3 secs
+
+     Self-consistent Calculation
+
+     iteration #  1     ecut=    30.00 Ry     beta= 0.70
+     Davidson diagonalization with overlap
+     ethr =  1.00E-06,  avg # of iterations =  2.0
+
+     Threshold (ethr) on eigenvalues was too large:
+     Diagonalizing with lowered threshold
+
+     Davidson diagonalization with overlap
+     ethr =  8.77E-08,  avg # of iterations =  1.0
+
+     total cpu time spent up to now is       13.5 secs
+
+     total energy              =     -22.66027943 Ry
+     Harris-Foulkes estimate   =     -22.67871680 Ry
+     estimated scf accuracy    <       0.00000700 Ry
+
+     iteration #  2     ecut=    30.00 Ry     beta= 0.70
+     Davidson diagonalization with overlap
+     ethr =  8.75E-08,  avg # of iterations =  3.3
+
+     total cpu time spent up to now is       13.7 secs
+
+     total energy              =     -22.66029591 Ry
+     Harris-Foulkes estimate   =     -22.66029757 Ry
+     estimated scf accuracy    <       0.00000624 Ry
+
+     iteration #  3     ecut=    30.00 Ry     beta= 0.70
+     Davidson diagonalization with overlap
+     ethr =  7.80E-08,  avg # of iterations =  1.0
+
+     total cpu time spent up to now is       13.8 secs
+
+     total energy              =     -22.66029518 Ry
+     Harris-Foulkes estimate   =     -22.66029603 Ry
+     estimated scf accuracy    <       0.00000196 Ry
+
+     iteration #  4     ecut=    30.00 Ry     beta= 0.70
+     Davidson diagonalization with overlap
+     ethr =  2.45E-08,  avg # of iterations =  2.0
+
+     total cpu time spent up to now is       14.0 secs
+
+     total energy              =     -22.66029539 Ry
+     Harris-Foulkes estimate   =     -22.66029542 Ry
+     estimated scf accuracy    <       0.00000006 Ry
+
+     iteration #  5     ecut=    30.00 Ry     beta= 0.70
+     Davidson diagonalization with overlap
+     ethr =  7.34E-10,  avg # of iterations =  2.3
+
+     total cpu time spent up to now is       14.2 secs
+
+     End of self-consistent calculation
+
+          k = 0.0000 0.0000 0.0000 (   749 PWs)   bands (ev):
+
+    -5.8148   5.6191   5.6191   5.6191
+
+     occupation numbers 
+     1.0000   1.0000   1.0000   1.0000
+
+          k = 0.3435-0.3435-0.3435 (   754 PWs)   bands (ev):
+
+    -3.6789  -1.0226   4.4685   4.4685
+
+     occupation numbers 
+     1.0000   1.0000   1.0000   1.0000
+
+          k = 0.0000 0.0000-0.6869 (   740 PWs)   bands (ev):
+
+    -1.9601  -1.9601   2.9304   2.9304
+
+     occupation numbers 
+     1.0000   1.0000   1.0000   1.0000
+
+     highest occupied level (ev):     5.6191
+
+!    total energy              =     -22.66029541 Ry
+     Harris-Foulkes estimate   =     -22.66029541 Ry
+     estimated scf accuracy    <          3.1E-10 Ry
+
+     The total energy is the sum of the following terms:
+
+     one-electron contribution =       4.60300797 Ry
+     hartree contribution      =       1.34362169 Ry
+     xc contribution           =     -12.28784551 Ry
+     ewald contribution        =     -16.31907956 Ry
+
+     convergence has been achieved in   5 iterations
+
+     Forces acting on atoms (cartesian axes, Ry/au):
+
+     atom    1 type  1   force =    -0.00000000   -0.00000000    0.00000000
+     atom    2 type  1   force =     0.00000000    0.00000000   -0.00000000
+     The non-local contrib.  to forces
+     atom    1 type  1   force =     0.00000000    0.00000000    0.00000000
+     atom    2 type  1   force =     0.00000000    0.00000000    0.00000000
+     The ionic contribution  to forces
+     atom    1 type  1   force =     0.00000000    0.00000000    0.00000000
+     atom    2 type  1   force =    -0.00000000   -0.00000000   -0.00000000
+     The local contribution  to forces
+     atom    1 type  1   force =     0.00000000    0.00000000    0.00000000
+     atom    2 type  1   force =    -0.00000000   -0.00000000   -0.00000000
+     The core correction contribution to forces
+     atom    1 type  1   force =    -0.00000000   -0.00000000   -0.00000000
+     atom    2 type  1   force =     0.00000000    0.00000000    0.00000000
+     The Hubbard contrib.    to forces
+     atom    1 type  1   force =     0.00000000    0.00000000    0.00000000
+     atom    2 type  1   force =     0.00000000    0.00000000    0.00000000
+     The SCF correction term to forces
+     atom    1 type  1   force =     0.00000000    0.00000000   -0.00000000
+     atom    2 type  1   force =    -0.00000000   -0.00000000    0.00000000
+
+     Total force =     0.000000     Total SCF correction =     0.000000
+
+
+     Computing stress (Cartesian axis) and pressure
+
+          total   stress  (Ry/bohr**3)                   (kbar)     P=   10.31
+   0.00007012   0.00000000   0.00000000         10.31      0.00      0.00
+   0.00000000   0.00007012   0.00000000          0.00     10.31      0.00
+   0.00000000   0.00000000   0.00007012          0.00      0.00     10.31
+
+--- OUTPUT REMOVED ---
+
+     Initial potential from superposition of free atoms
+
+     starting charge    7.99888, renormalised to    8.00000
+     Starting wfcs are    8 randomized atomic wfcs
+
+     total cpu time spent up to now is       17.7 secs
+
+     Self-consistent Calculation
+
+     iteration #  1     ecut=    30.00 Ry     beta= 0.70
+     Davidson diagonalization with overlap
+     ethr =  1.00E-06,  avg # of iterations =  6.7
+
+     total cpu time spent up to now is       17.9 secs
+
+     total energy              =     -22.65637530 Ry
+     Harris-Foulkes estimate   =     -22.67970821 Ry
+     estimated scf accuracy    <       0.09700014 Ry
+
+     iteration #  2     ecut=    30.00 Ry     beta= 0.70
+     Davidson diagonalization with overlap
+     ethr =  1.21E-03,  avg # of iterations =  1.0
+
+     total cpu time spent up to now is       18.1 secs
+
+     total energy              =     -22.65992387 Ry
+     Harris-Foulkes estimate   =     -22.65983894 Ry
+     estimated scf accuracy    <       0.00432327 Ry
+
+     iteration #  3     ecut=    30.00 Ry     beta= 0.70
+     Davidson diagonalization with overlap
+     ethr =  5.40E-05,  avg # of iterations =  1.0
+
+     total cpu time spent up to now is       18.2 secs
+
+     total energy              =     -22.66027125 Ry
+     Harris-Foulkes estimate   =     -22.66024059 Ry
+     estimated scf accuracy    <       0.00004701 Ry
+
+     iteration #  4     ecut=    30.00 Ry     beta= 0.70
+     Davidson diagonalization with overlap
+     ethr =  5.88E-07,  avg # of iterations =  3.7
+
+     total cpu time spent up to now is       18.4 secs
+
+     total energy              =     -22.66039403 Ry
+     Harris-Foulkes estimate   =     -22.66040028 Ry
+     estimated scf accuracy    <       0.00001484 Ry
+
+     iteration #  5     ecut=    30.00 Ry     beta= 0.70
+     Davidson diagonalization with overlap
+     ethr =  1.86E-07,  avg # of iterations =  2.0
+
+     total cpu time spent up to now is       18.6 secs
+
+     total energy              =     -22.66039556 Ry
+     Harris-Foulkes estimate   =     -22.66039603 Ry
+     estimated scf accuracy    <       0.00000115 Ry
+
+     iteration #  6     ecut=    30.00 Ry     beta= 0.70
+     Davidson diagonalization with overlap
+     ethr =  1.44E-08,  avg # of iterations =  2.7
+
+     total cpu time spent up to now is       18.8 secs
+
+     End of self-consistent calculation
+
+          k = 0.0000 0.0000 0.0000 (   869 PWs)   bands (ev):
+
+    -5.8148   5.6186   5.6186   5.6186
+
+     occupation numbers 
+     1.0000   1.0000   1.0000   1.0000
+
+          k = 0.3435-0.3435-0.3435 (   832 PWs)   bands (ev):
+
+    -3.6788  -1.0227   4.4684   4.4684
+
+     occupation numbers 
+     1.0000   1.0000   1.0000   1.0000
+
+          k = 0.0000 0.0000-0.6869 (   790 PWs)   bands (ev):
+
+    -1.9600  -1.9600   2.9304   2.9304
+
+     occupation numbers 
+     1.0000   1.0000   1.0000   1.0000
+
+     highest occupied level (ev):     5.6186
+
+!    total energy              =     -22.66039571 Ry
+     Harris-Foulkes estimate   =     -22.66039571 Ry
+     estimated scf accuracy    <          5.5E-09 Ry
+
+     The total energy is the sum of the following terms:
+
+     one-electron contribution =       4.60293329 Ry
+     hartree contribution      =       1.34359456 Ry
+     xc contribution           =     -12.28784400 Ry
+     ewald contribution        =     -16.31907955 Ry
+
+     convergence has been achieved in   6 iterations
+
+     Forces acting on atoms (cartesian axes, Ry/au):
+
+     atom    1 type  1   force =    -0.00000000    0.00000000    0.00000000
+     atom    2 type  1   force =    -0.00000000   -0.00000000   -0.00000000
+     The non-local contrib.  to forces
+     atom    1 type  1   force =     0.00000000    0.00000000   -0.00000000
+     atom    2 type  1   force =     0.00000000    0.00000000   -0.00000000
+     The ionic contribution  to forces
+     atom    1 type  1   force =     0.00000000    0.00000000    0.00000000
+     atom    2 type  1   force =     0.00000000    0.00000000    0.00000000
+     The local contribution  to forces
+     atom    1 type  1   force =    -0.00000000   -0.00000000   -0.00000000
+     atom    2 type  1   force =     0.00000000    0.00000000    0.00000000
+     The core correction contribution to forces
+     atom    1 type  1   force =     0.00000000    0.00000000    0.00000000
+     atom    2 type  1   force =     0.00000000    0.00000000    0.00000000
+     The Hubbard contrib.    to forces
+     atom    1 type  1   force =     0.00000000    0.00000000    0.00000000
+     atom    2 type  1   force =     0.00000000    0.00000000    0.00000000
+     The SCF correction term to forces
+     atom    1 type  1   force =    -0.00000000   -0.00000000    0.00000000
+     atom    2 type  1   force =     0.00000000    0.00000000   -0.00000000
+
+     Total force =     0.000000     Total SCF correction =     0.000000
+
+
+     Computing stress (Cartesian axis) and pressure
+
+          total   stress  (Ry/bohr**3)                   (kbar)     P=   10.31
+   0.00007012  -0.00000000  -0.00000000         10.31     -0.00     -0.00
+  -0.00000000   0.00007012  -0.00000000         -0.00     10.31     -0.00
+  -0.00000000  -0.00000000   0.00007012         -0.00     -0.00     10.31
+
+=------------------------------------------------------------------------------=
+   JOB DONE.
+=------------------------------------------------------------------------------=
+

--- a/tests/parsers/fixtures/pw/vcrelax_success_external_pressure/data-file.xml
+++ b/tests/parsers/fixtures/pw/vcrelax_success_external_pressure/data-file.xml
@@ -1,0 +1,338 @@
+<?xml version="1.0"?>
+<?iotk version="1.2.0"?>
+<?iotk file_version="1.0"?>
+<?iotk binary="F"?>
+<?iotk qe_syntax="F"?>
+<Root>
+  <HEADER>
+    <FORMAT NAME="QEXML" VERSION="1.4.0"/>
+    <CREATOR NAME="PWSCF" VERSION="6.3MaX"/>
+  </HEADER>
+  <CONTROL>
+    <PP_CHECK_FLAG type="logical" size="1">
+T
+    </PP_CHECK_FLAG>
+    <LKPOINT_DIR type="logical" size="1">
+T
+    </LKPOINT_DIR>
+    <Q_REAL_SPACE type="logical" size="1">
+F
+    </Q_REAL_SPACE>
+    <BETA_REAL_SPACE type="logical" size="1">
+F
+    </BETA_REAL_SPACE>
+    <TQ_SMOOTHING type="logical" size="1">
+F
+    </TQ_SMOOTHING>
+    <TBETA_SMOOTHING type="logical" size="1">
+F
+    </TBETA_SMOOTHING>
+  </CONTROL>
+  <CELL>
+    <NON-PERIODIC_CELL_CORRECTION type="character" size="1" len="4">
+None
+    </NON-PERIODIC_CELL_CORRECTION>
+    <BRAVAIS_LATTICE type="character" size="1" len="4">
+free
+    </BRAVAIS_LATTICE>
+    <LATTICE_PARAMETER type="real" size="1" UNITS="Bohr">
+ 7.255773225898359E+000
+    </LATTICE_PARAMETER>
+    <CELL_DIMENSIONS type="real" size="6">
+ 7.255773225898359E+000
+ 0.000000000000000E+000
+ 0.000000000000000E+000
+ 0.000000000000000E+000
+ 0.000000000000000E+000
+ 0.000000000000000E+000
+    </CELL_DIMENSIONS>
+    <DIRECT_LATTICE_VECTORS>
+      <UNITS_FOR_DIRECT_LATTICE_VECTORS UNITS="Bohr"/>
+      <a1 type="real" size="3" columns="3">
+ 5.281472429758501E+000  5.281472429758501E+000  3.512815038853034E-017
+      </a1>
+      <a2 type="real" size="3" columns="3">
+ 5.281472429758501E+000 -2.101933954533961E-017  5.281472429758501E+000
+      </a2>
+      <a3 type="real" size="3" columns="3">
+-3.877374393062036E-017  5.281472429758501E+000  5.281472429758501E+000
+      </a3>
+    </DIRECT_LATTICE_VECTORS>
+    <RECIPROCAL_LATTICE_VECTORS>
+      <UNITS_FOR_RECIPROCAL_LATTICE_VECTORS UNITS="2 pi / a"/>
+      <b1 type="real" size="3" columns="3">
+ 6.869081797166681E-001  6.869081797166681E-001 -6.869081797166681E-001
+      </b1>
+      <b2 type="real" size="3" columns="3">
+ 6.869081797166681E-001 -6.869081797166681E-001  6.869081797166681E-001
+      </b2>
+      <b3 type="real" size="3" columns="3">
+-6.869081797166681E-001  6.869081797166681E-001  6.869081797166681E-001
+      </b3>
+    </RECIPROCAL_LATTICE_VECTORS>
+  </CELL>
+  <IONS>
+    <NUMBER_OF_ATOMS type="integer" size="1">
+         2
+    </NUMBER_OF_ATOMS>
+    <NUMBER_OF_SPECIES type="integer" size="1">
+         1
+    </NUMBER_OF_SPECIES>
+    <UNITS_FOR_ATOMIC_MASSES UNITS="a.m.u."/>
+    <SPECIE.1>
+      <ATOM_TYPE type="character" size="1" len="3">
+Si 
+      </ATOM_TYPE>
+      <MASS type="real" size="1">
+ 2.808550000000000E+001
+      </MASS>
+      <PSEUDO type="character" size="1" len="29">
+Si.pbe-n-rrkjus_psl.1.0.0.UPF
+      </PSEUDO>
+    </SPECIE.1>
+    <PSEUDO_DIR type="character" size="1" len="9">
+./pseudo/
+    </PSEUDO_DIR>
+    <UNITS_FOR_ATOMIC_POSITIONS UNITS="Bohr"/>
+    <ATOM.1 SPECIES="Si " INDEX="1" tau="-5.924368428807824E-049 -6.205751879236142E-049 -7.665594213892055E-033" if_pos="1 1 1"/>
+    <ATOM.2 SPECIES="Si " INDEX="1" tau="2.640736214879250E+000 2.640736214879250E+000 2.640736214879250E+000" if_pos="1 1 1"/>
+  </IONS>
+  <SYMMETRIES>
+    <NUMBER_OF_SYMMETRIES type="integer" size="1">
+        0
+    </NUMBER_OF_SYMMETRIES>
+    <NUMBER_OF_BRAVAIS_SYMMETRIES type="integer" size="1">
+        0
+    </NUMBER_OF_BRAVAIS_SYMMETRIES>
+    <INVERSION_SYMMETRY type="logical" size="1">
+T
+    </INVERSION_SYMMETRY>
+    <DO_NOT_USE_TIME_REVERSAL type="logical" size="1">
+F
+    </DO_NOT_USE_TIME_REVERSAL>
+    <TIME_REVERSAL_FLAG type="logical" size="1">
+T
+    </TIME_REVERSAL_FLAG>
+    <NO_TIME_REV_OPERATIONS type="logical" size="1">
+F
+    </NO_TIME_REV_OPERATIONS>
+    <NUMBER_OF_ATOMS type="integer" size="1">
+         2
+    </NUMBER_OF_ATOMS>
+    <UNITS_FOR_SYMMETRIES UNITS="Crystal"/>
+  </SYMMETRIES>
+  <ELECTRIC_FIELD>
+    <HAS_ELECTRIC_FIELD type="logical" size="1">
+F
+    </HAS_ELECTRIC_FIELD>
+    <HAS_DIPOLE_CORRECTION type="logical" size="1">
+F
+    </HAS_DIPOLE_CORRECTION>
+    <FIELD_DIRECTION type="integer" size="1">
+         1
+    </FIELD_DIRECTION>
+    <MAXIMUM_POSITION type="real" size="1">
+ 5.000000000000000E-001
+    </MAXIMUM_POSITION>
+    <INVERSE_REGION type="real" size="1">
+ 1.000000000000000E-001
+    </INVERSE_REGION>
+    <FIELD_AMPLITUDE type="real" size="1">
+ 0.000000000000000E+000
+    </FIELD_AMPLITUDE>
+    <CHARGED_PLATE type="logical" size="1">
+F
+    </CHARGED_PLATE>
+    <GATE_POS type="real" size="1">
+ 5.000000000000000E-001
+    </GATE_POS>
+    <RELAX_Z type="logical" size="1">
+F
+    </RELAX_Z>
+    <BLOCK type="logical" size="1">
+F
+    </BLOCK>
+    <BLOCK_1 type="real" size="1">
+ 4.499999880790710E-001
+    </BLOCK_1>
+    <BLOCK_2 type="real" size="1">
+ 5.500000119209290E-001
+    </BLOCK_2>
+    <BLOCK_HEIGHT type="real" size="1">
+ 0.000000000000000E+000
+    </BLOCK_HEIGHT>
+  </ELECTRIC_FIELD>
+  <PLANE_WAVES>
+    <UNITS_FOR_CUTOFF UNITS="Hartree"/>
+    <WFC_CUTOFF type="real" size="1">
+ 1.500000000000000E+001
+    </WFC_CUTOFF>
+    <RHO_CUTOFF type="real" size="1">
+ 1.200000000000000E+002
+    </RHO_CUTOFF>
+    <MAX_NUMBER_OF_GK-VECTORS type="integer" size="1">
+       869
+    </MAX_NUMBER_OF_GK-VECTORS>
+    <GAMMA_ONLY type="logical" size="1">
+F
+    </GAMMA_ONLY>
+    <FFT_GRID nr1="40" nr2="40" nr3="40"/>
+    <GVECT_NUMBER type="integer" size="1">
+     18499
+    </GVECT_NUMBER>
+    <SMOOTH_FFT_GRID nr1s="27" nr2s="27" nr3s="27"/>
+    <SMOOTH_GVECT_NUMBER type="integer" size="1">
+      6567
+    </SMOOTH_GVECT_NUMBER>
+    <G-VECTORS iotk_link="./gvectors.dat">
+      <!--This is a link to the file indicated in the iotk_link attribute-->
+    </G-VECTORS>
+    <SMALLBOX_FFT_GRID nr1b="40" nr2b="40" nr3b="40"/>
+  </PLANE_WAVES>
+  <SPIN>
+    <LSDA type="logical" size="1">
+F
+    </LSDA>
+    <NON-COLINEAR_CALCULATION type="logical" size="1">
+F
+    </NON-COLINEAR_CALCULATION>
+    <SPIN-ORBIT_CALCULATION type="logical" size="1">
+F
+    </SPIN-ORBIT_CALCULATION>
+    <SPIN-ORBIT_DOMAG type="logical" size="1">
+F
+    </SPIN-ORBIT_DOMAG>
+  </SPIN>
+  <MAGNETIZATION_INIT>
+    <CONSTRAINT_MAG type="integer" size="1">
+         0
+    </CONSTRAINT_MAG>
+    <NUMBER_OF_SPECIES type="integer" size="1">
+         1
+    </NUMBER_OF_SPECIES>
+    <SPECIE.1>
+      <STARTING_MAGNETIZATION type="real" size="1">
+ 0.000000000000000E+000
+      </STARTING_MAGNETIZATION>
+      <ANGLE1 type="real" size="1">
+ 0.000000000000000E+000
+      </ANGLE1>
+      <ANGLE2 type="real" size="1">
+ 0.000000000000000E+000
+      </ANGLE2>
+    </SPECIE.1>
+    <TWO_FERMI_ENERGIES type="logical" size="1">
+F
+    </TWO_FERMI_ENERGIES>
+  </MAGNETIZATION_INIT>
+  <EXCHANGE_CORRELATION>
+    <DFT type="character" size="1" len="20">
+PBE                 
+    </DFT>
+    <ACFDT_IN_PW type="logical" size="1">
+F
+    </ACFDT_IN_PW>
+    <ACFDT_IN_PW type="logical" size="1">
+F
+    </ACFDT_IN_PW>
+  </EXCHANGE_CORRELATION>
+  <ESM>
+    <esm_nfit type="integer" size="1">
+         4
+    </esm_nfit>
+    <esm_efield type="real" size="1">
+ 0.000000000000000E+000
+    </esm_efield>
+    <esm_w type="real" size="1">
+ 0.000000000000000E+000
+    </esm_w>
+    <esm_a type="real" size="1">
+ 0.000000000000000E+000
+    </esm_a>
+    <esm_bc type="character" size="1" len="3">
+pbc
+    </esm_bc>
+  </ESM>
+  <OCCUPATIONS>
+    <SMEARING_METHOD type="logical" size="1">
+F
+    </SMEARING_METHOD>
+    <TETRAHEDRON_METHOD type="logical" size="1">
+F
+    </TETRAHEDRON_METHOD>
+    <FIXED_OCCUPATIONS type="logical" size="1">
+F
+    </FIXED_OCCUPATIONS>
+  </OCCUPATIONS>
+  <BRILLOUIN_ZONE>
+    <NUMBER_OF_K-POINTS type="integer" size="1">
+         3
+    </NUMBER_OF_K-POINTS>
+    <UNITS_FOR_K-POINTS UNITS="2 pi / a"/>
+    <MONKHORST_PACK_GRID nk1="2" nk2="2" nk3="2"/>
+    <MONKHORST_PACK_OFFSET k1="0" k2="0" k3="0"/>
+    <K-POINT.1 XYZ="0.000000000000000E+000 0.000000000000000E+000 0.000000000000000E+000" WEIGHT="2.500000000000000E-001"/>
+    <K-POINT.2 XYZ="3.434540898583340E-001 -3.434540898583340E-001 -3.434540898583340E-001" WEIGHT="1.000000000000000E+000"/>
+    <K-POINT.3 XYZ="0.000000000000000E+000 0.000000000000000E+000 -6.869081797166681E-001" WEIGHT="7.500000000000000E-001"/>
+    <NORM-OF-Q type="real" size="1">
+ 0.000000000000000E+000
+    </NORM-OF-Q>
+  </BRILLOUIN_ZONE>
+  <PARALLELISM>
+    <GRANULARITY_OF_K-POINTS_DISTRIBUTION type="integer" size="1">
+         1
+    </GRANULARITY_OF_K-POINTS_DISTRIBUTION>
+    <NUMBER_OF_PROCESSORS type="integer" size="1">
+         1
+    </NUMBER_OF_PROCESSORS>
+    <NUMBER_OF_PROCESSORS_PER_POOL type="integer" size="1">
+         1
+    </NUMBER_OF_PROCESSORS_PER_POOL>
+    <NUMBER_OF_PROCESSORS_PER_IMAGE type="integer" size="1">
+         1
+    </NUMBER_OF_PROCESSORS_PER_IMAGE>
+    <NUMBER_OF_PROCESSORS_PER_TASKGROUP type="integer" size="1">
+         1
+    </NUMBER_OF_PROCESSORS_PER_TASKGROUP>
+    <NUMBER_OF_PROCESSORS_PER_BAND_GROUP type="integer" size="1">
+         1
+    </NUMBER_OF_PROCESSORS_PER_BAND_GROUP>
+    <NUMBER_OF_PROCESSORS_PER_DIAGONALIZATION type="integer" size="1">
+         1
+    </NUMBER_OF_PROCESSORS_PER_DIAGONALIZATION>
+  </PARALLELISM>
+  <CHARGE-DENSITY iotk_link="./charge-density.dat">
+    <!--This is a link to the file indicated in the iotk_link attribute-->
+  </CHARGE-DENSITY>
+  <BAND_STRUCTURE_INFO>
+    <NUMBER_OF_K-POINTS type="integer" size="1">
+         3
+    </NUMBER_OF_K-POINTS>
+    <NUMBER_OF_SPIN_COMPONENTS type="integer" size="1">
+         1
+    </NUMBER_OF_SPIN_COMPONENTS>
+    <NON-COLINEAR_CALCULATION type="logical" size="1">
+F
+    </NON-COLINEAR_CALCULATION>
+    <NUMBER_OF_ATOMIC_WFC type="integer" size="1">
+         8
+    </NUMBER_OF_ATOMIC_WFC>
+    <NUMBER_OF_BANDS type="integer" size="1">
+         4
+    </NUMBER_OF_BANDS>
+    <NUMBER_OF_ELECTRONS type="real" size="1">
+ 8.000000000000000E+000
+    </NUMBER_OF_ELECTRONS>
+    <UNITS_FOR_K-POINTS UNITS="2 pi / a"/>
+    <UNITS_FOR_ENERGIES UNITS="Hartree"/>
+    <FERMI_ENERGY type="real" size="1">
+ 2.064814165084842E-001
+    </FERMI_ENERGY>
+  </BAND_STRUCTURE_INFO>
+  <EIGENVALUES>
+  </EIGENVALUES>
+  <EIGENVECTORS>
+  </EIGENVECTORS>
+</Root>
+
+

--- a/tests/parsers/test_pw.py
+++ b/tests/parsers/test_pw.py
@@ -493,6 +493,27 @@ def test_pw_vcrelax_success_fractional(
     })
 
 
+def test_pw_vcrelax_success_external_pressure(
+    aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
+):
+    """Test a `vc-relax` with external pressure that successfully converges and the final scf also converges."""
+    name = 'vcrelax_success_external_pressure'
+    entry_point_calc_job = 'quantumespresso.pw'
+    entry_point_parser = 'quantumespresso.pw'
+
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs_relax())
+    parser = generate_parser(entry_point_parser)
+    results, calcfunction = parser.parse_from_node(node, store_provenance=False)
+
+    assert calcfunction.is_finished, calcfunction.exception
+    assert calcfunction.is_finished_ok, calcfunction.exit_message
+    assert not orm.Log.objects.get_logs_for(node)
+    assert 'output_kpoints' in results
+    assert 'output_parameters' in results
+    assert 'output_structure' in results
+    assert 'output_trajectory' in results
+
+
 def test_pw_vcrelax_failed_charge_wrong(
     aiida_profile, fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_relax
 ):


### PR DESCRIPTION
Fixes #449 

The parser was not properly including an external pressure when checking
the stress for convergence, leading the calculation to be unjustly as
not converged. By simply adding the external pressure from the input
parameters to the pressure convergence threshold this is solved.