### PR TITLE
`PwBandsWorkChain`: only set nscf diag algorithm if not defined

### DIFF
--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -159,9 +159,11 @@ class PwBandsWorkChain(WorkChain):
 
         inputs.pw.parameters['CONTROL']['restart_mode'] = 'restart'
         inputs.pw.parameters['CONTROL']['calculation'] = 'bands'
-        inputs.pw.parameters['ELECTRONS']['diagonalization'] = 'cg'
-        inputs.pw.parameters['ELECTRONS']['diago_full_acc'] = True
         inputs.pw.parameters['SYSTEM']['nbnd'] = nbands
+
+        # Only set the following parameters if not directly explicitly defined in the inputs
+        inputs.pw.parameters['ELECTRONS'].setdefault('diagonalization', 'cg')
+        inputs.pw.parameters['ELECTRONS'].setdefault('diago_full_acc', True)
 
         if 'kpoints' not in self.inputs.bands:
             inputs.kpoints = self.ctx.kpoints_path


### PR DESCRIPTION
Fixes #50 

The goal of the `PwBandsWorkChain` is to provide a general purpose
workchain to compute the electronic bands of a given structure. As such
it should try to override as little parameters for the downstream
calculations as possible and certainly not override anything that the
caller explicitly provided in the inputs.

With this approach, an expert user can profit from the high level logic
without having certain parameters they want override, while the
workchain still provides sensible defaults if no specific values for
certain parameters are defined in the inputs.

In this case, we set the diagonalization algorithm in the bands
calculation to `cg` if it is not explicitly defined. This algorithm is
more robust but typically also more costly. Likewise, the
diagonalization is performed with full accuracy unless specified
otherwise.