### PR TITLE
`PwBandsWorkChain`: make kpoints for bands configurable

### DIFF
--- a/aiida_quantumespresso/cli/workflows/pw/bands.py
+++ b/aiida_quantumespresso/cli/workflows/pw/bands.py
@@ -85,7 +85,6 @@ def launch_workflow(
     builder.bands.pw.code = code
     builder.bands.pw.parameters = parameters
     builder.bands.pseudo_family = pseudo_family
-    builder.bands.kpoints_distance = Float(kpoints_distance)
 
     if hubbard_file:
         builder.relax.base.pw.hubbard_file = hubbard_file

--- a/aiida_quantumespresso/workflows/functions/seekpath_structure_analysis.py
+++ b/aiida_quantumespresso/workflows/functions/seekpath_structure_analysis.py
@@ -2,15 +2,31 @@
 """Calcfunction to primitivize a structure and return high symmetry k-point path through its Brillouin zone."""
 from __future__ import absolute_import
 from aiida.engine import calcfunction
+from aiida.orm import Data
 
 
 @calcfunction
-def seekpath_structure_analysis(structure, parameters):
-    """Primitivize the structure with SeeKpath and return high symmetry k-point path through its Brillouin zone.
+def seekpath_structure_analysis(structure, **kwargs):
+    """Primitivize the structure with SeeKpath and generate the high symmetry k-point path through its Brillouin zone.
 
     This calcfunction will take a structure and pass it through SeeKpath to get the normalized primitive cell and the
     path of high symmetry k-points through its Brillouin zone. Note that the returned primitive cell may differ from the
     original structure in which case the k-points are only congruent with the primitive cell.
+
+    The keyword arguments can be used to specify various Seekpath parameters, such as:
+
+        with_time_reversal: True
+        reference_distance: 0.025
+        recipe: 'hpkot'
+        threshold: 1e-07
+        symprec: 1e-05
+        angle_tolerance: -1.0
+
+    Note that exact parameters that are available and their defaults will depend on your Seekpath version.
     """
     from aiida.tools import get_explicit_kpoints_path
-    return get_explicit_kpoints_path(structure, **parameters.get_dict())
+
+    # All keyword arugments should be `Data` node instances of base type and so should have the `.value` attribute
+    unwrapped_kwargs = {key: node.value for key, node in kwargs.items() if isinstance(node, Data)}
+
+    return get_explicit_kpoints_path(structure, **unwrapped_kwargs)


### PR DESCRIPTION
Fixes #471 

The caller may want to define an explicit kpoint data node to use for
the bands calculation. This can now be passed as `bands_kpoints` in
which case the Seekpath part is completely skipped because if the
structure is changed in that operation the input kpoints may no longer
be congruent. Instead, if `bands_kpoints` is not defined, Seekpath is
called and the returned explicit kpoint path will be used. The input
`bands_kpoint_distance` can be used to change the default reference
distance defined by Seekpath to control the minium distance between
k-points in reciprocal space.