### PR TITLE
`PwBandsWorkChain`: do not define `restart_mode` in bands step

### DIFF
--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -157,7 +157,6 @@ class PwBandsWorkChain(WorkChain):
         inputs.pw.parameters.setdefault('SYSTEM', {})
         inputs.pw.parameters.setdefault('ELECTRONS', {})
 
-        inputs.pw.parameters['CONTROL']['restart_mode'] = 'restart'
         inputs.pw.parameters['CONTROL']['calculation'] = 'bands'
         inputs.pw.parameters['SYSTEM']['nbnd'] = nbands
 


### PR DESCRIPTION
Fixes #404 

The correct value for the `restart_mode` of a first run of a `bands`
calculation following an `scf` one is `from_scratch`. This is also the
default so we don't set it in the `PwBandsWorkChain.run_bands` step.
Note that a `restart` can be used for a `bands` calculation but this is
intended for a restart of an interrupted bands calculation, for example
if it ran out of wall time. If the calculation shut down cleanly, the
calculation will continue from the last k-point where it left off.

We choose not to explicitly set `from_scratch` in the work chain because
in this way an expert user can override it should they chose to even
though the use-case is now not immediately obvious.