### PR TITLE
Homogenize the exit codes for all `CalcJob` implementations

### DIFF
--- a/aiida_quantumespresso/calculations/cp.py
+++ b/aiida_quantumespresso/calculations/cp.py
@@ -129,26 +129,30 @@ class CpCalculation(BasePwCpInputGenerator, CalcJob):
 
     @classmethod
     def define(cls, spec):
-        super(CpCalculation, cls).define(spec)  # noqa: D102 # yapf: disable
+        # yapf: disable
+        super(CpCalculation, cls).define(spec)
         spec.input('metadata.options.parser_name', valid_type=six.string_types, default='quantumespresso.cp')
         spec.output('output_trajectory', valid_type=orm.TrajectoryData)
         spec.output('output_parameters', valid_type=orm.Dict)
         spec.default_output_node = 'output_parameters'
 
-        spec.exit_code(
-            100, 'ERROR_NO_RETRIEVED_FOLDER', message='The retrieved folder data node could not be accessed.'
-        )
-        spec.exit_code(
-            101, 'ERROR_NO_RETRIEVED_TEMPORARY_FOLDER', message='The retrieved temporary folder could not be accessed.'
-        )
-        spec.exit_code(
-            110, 'ERROR_READING_OUTPUT_FILE', message='The output file could not be read from the retrieved folder.'
-        )
-        spec.exit_code(
-            115, 'ERROR_MISSING_XML_FILE', message='The required XML file is not present in the retrieved folder.'
-        )
-        spec.exit_code(116, 'ERROR_MULTIPLE_XML_FILES', message='The retrieved folder contains multiple XML files.')
-        spec.exit_code(117, 'ERROR_READING_XML_FILE', message='The required XML file could not be read.')
-        spec.exit_code(118, 'ERROR_READING_POS_FILE', message='The required POS file could not be read.')
-        spec.exit_code(119, 'ERROR_READING_TRAJECTORY_DATA', message='The required trajectory data could not be read.')
-        spec.exit_code(120, 'ERROR_INVALID_OUTPUT', message='The output file contains invalid output.')
+        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
+            message='The retrieved folder data node could not be accessed.')
+        spec.exit_code(301, 'ERROR_NO_RETRIEVED_TEMPORARY_FOLDER',
+            message='The retrieved temporary folder could not be accessed.')
+        spec.exit_code(303, 'ERROR_MISSING_XML_FILE',
+            message='The required XML file is not present in the retrieved folder.')
+        spec.exit_code(304, 'ERROR_OUTPUT_XML_MULTIPLE',
+            message='The retrieved folder contains multiple XML files.')
+        spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
+            message='The stdout output file could not be read.')
+        spec.exit_code(311, 'ERROR_OUTPUT_STDOUT_PARSE',
+            message='The output file contains invalid output.')
+        spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',
+            message='The stdout output file was incomplete probably because the calculation got interrupted.')
+        spec.exit_code(320, 'ERROR_OUTPUT_XML_READ',
+            message='The required XML file could not be read.')
+        spec.exit_code(330, 'ERROR_READING_POS_FILE',
+            message='The required POS file could not be read.')
+        spec.exit_code(340, 'ERROR_READING_TRAJECTORY_DATA',
+            message='The required trajectory data could not be read.')

--- a/aiida_quantumespresso/calculations/dos.py
+++ b/aiida_quantumespresso/calculations/dos.py
@@ -27,11 +27,11 @@ class DosCalculation(NamelistsCalculation):
         spec.output('output_parameters', valid_type=orm.Dict)
         spec.output('output_dos', valid_type=orm.XyData)
         spec.default_output_node = 'output_parameters'
-        spec.exit_code(
-            100, 'ERROR_NO_RETRIEVED_FOLDER', message='The retrieved folder data node could not be accessed.')
-        spec.exit_code(
-            110, 'ERROR_READING_OUTPUT_FILE', message='The output file could not be read from the retrieved folder.')
-        spec.exit_code(
-            111, 'ERROR_READING_DOS_FILE', message='The dos file could not be read from the retrieved folder.')
-        spec.exit_code(
-            130, 'ERROR_JOB_NOT_DONE', message='The computation did not finish properly ("JOB DONE" not found).')
+        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
+            message='The retrieved folder data node could not be accessed.')
+        spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
+            message='The stdout output file could not be read.')
+        spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',
+            message='The stdout output file was incomplete probably because the calculation got interrupted.')
+        spec.exit_code(330, 'ERROR_READING_DOS_FILE',
+            message='The dos file could not be read from the retrieved folder.')

--- a/aiida_quantumespresso/calculations/matdyn.py
+++ b/aiida_quantumespresso/calculations/matdyn.py
@@ -35,15 +35,17 @@ class MatdynCalculation(NamelistsCalculation):
         spec.output('output_parameters', valid_type=orm.Dict)
         spec.output('output_phonon_bands', valid_type=orm.BandsData)
         spec.default_output_node = 'output_parameters'
-        spec.exit_code(100, 'ERROR_NO_RETRIEVED_FOLDER',
+        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
             message='The retrieved folder data node could not be accessed.')
-        spec.exit_code(110, 'ERROR_READING_OUTPUT_FILE',
-            message='The output file could not be read from the retrieved folder.')
-        spec.exit_code(130, 'ERROR_JOB_NOT_DONE',
-            message='The computation did not finish properly ("JOB DONE" not found).')
-        spec.exit_code(131, 'ERROR_OUTPUT_KPOINTS_MISSING',
+        spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
+            message='The stdout output file could not be read.')
+        spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',
+            message='The stdout output file was incomplete probably because the calculation got interrupted.')
+        spec.exit_code(330, 'ERROR_OUTPUT_FREQUENCIES',
+            message='The output frequencies file could not be read from the retrieved folder.')
+        spec.exit_code(410, 'ERROR_OUTPUT_KPOINTS_MISSING',
             message='Number of kpoints not found in the output data')
-        spec.exit_code(132, 'ERROR_OUTPUT_KPOINTS_INCOMMENSURATE',
+        spec.exit_code(411, 'ERROR_OUTPUT_KPOINTS_INCOMMENSURATE',
             message='Number of kpoints in the inputs is not commensurate with those in the output')
 
     def _get_following_text(self):

--- a/aiida_quantumespresso/calculations/neb.py
+++ b/aiida_quantumespresso/calculations/neb.py
@@ -78,16 +78,16 @@ class NebCalculation(CalcJob):
         spec.output('output_mep', valid_type=orm.ArrayData,
             help='The original and interpolated energy profiles along the minimum-energy path (mep)')
         spec.default_output_node = 'output_parameters'
-        spec.exit_code(
-            100, 'ERROR_NO_RETRIEVED_FOLDER', message='The retrieved folder data node could not be accessed.')
-        spec.exit_code(
-            110, 'ERROR_READING_OUTPUT_FILE', message='The output file could not be read from the retrieved folder.')
-        spec.exit_code(
-            115, 'ERROR_MISSING_XML_FILE', message='The required XML file is not present in the retrieved folder.')
-        spec.exit_code(
-            120, 'ERROR_INVALID_OUTPUT', message='The output file contains invalid output.')
+        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
+            message='The retrieved folder data node could not be accessed.')
+        spec.exit_code(303, 'ERROR_MISSING_XML_FILE',
+            message='The required XML file is not present in the retrieved folder.')
+        spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
+            message='The stdout output file could not be read.')
+        spec.exit_code(311, 'ERROR_OUTPUT_STDOUT_PARSE',
+            message='The output file contains invalid output.')
         spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',
-            message='The stdout output file was incomplete.')
+            message='The stdout output file was incomplete probably because the calculation got interrupted.')
         spec.exit_code(320, 'ERROR_OUTPUT_XML_READ',
             message='The XML output file could not be read.')
         spec.exit_code(321, 'ERROR_OUTPUT_XML_PARSE',

--- a/aiida_quantumespresso/calculations/ph.py
+++ b/aiida_quantumespresso/calculations/ph.py
@@ -58,21 +58,19 @@ class PhCalculation(CalcJob):
         spec.output('output_parameters', valid_type=orm.Dict)
         spec.default_output_node = 'output_parameters'
 
-        # Unrecoverable errors: resources like the retrieved folder or its expected contents are missing
-        spec.exit_code(200, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
-        spec.exit_code(210, 'ERROR_OUTPUT_STDOUT_MISSING',
-            message='The retrieved folder did not contain the required stdout output file.')
-
         # Unrecoverable errors: required retrieved files could not be read, parsed or are otherwise incomplete
-        spec.exit_code(300, 'ERROR_OUTPUT_FILES',
+        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
+            message='The retrieved folder data node could not be accessed.')
+        spec.exit_code(302, 'ERROR_OUTPUT_STDOUT_MISSING',
+            message='The retrieved folder did not contain the required stdout output file.')
+        spec.exit_code(305, 'ERROR_OUTPUT_FILES',
             message='Both the stdout and XML output files could not be read or parsed.')
         spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
             message='The stdout output file could not be read.')
         spec.exit_code(311, 'ERROR_OUTPUT_STDOUT_PARSE',
             message='The stdout output file could not be parsed.')
         spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',
-            message='The stdout output file was incomplete.')
+            message='The stdout output file was incomplete probably because the calculation got interrupted.')
         spec.exit_code(350, 'ERROR_UNEXPECTED_PARSER_EXCEPTION',
             message='The parser raised an unexpected exception.')
 

--- a/aiida_quantumespresso/calculations/projwfc.py
+++ b/aiida_quantumespresso/calculations/projwfc.py
@@ -45,13 +45,13 @@ class ProjwfcCalculation(NamelistsCalculation):
         spec.output('projections', valid_type=ProjectionData, required=False)
         spec.output('bands', valid_type=BandsData, required=False)
         spec.default_output_node = 'output_parameters'
-        spec.exit_code(
-            100, 'ERROR_NO_RETRIEVED_FOLDER', message='The retrieved folder data node could not be accessed.')
-        spec.exit_code(
-            110, 'ERROR_READING_OUTPUT_FILE', message='The output file could not be read from the retrieved folder.')
-        spec.exit_code(
-            111, 'ERROR_READING_PDOSTOT_FILE', message='The pdos_tot file could not be read from the retrieved folder.')
-        spec.exit_code(
-            112, 'ERROR_PARSING_PROJECTIONS', message='An exception was raised parsing bands and projections.')
-        spec.exit_code(
-            130, 'ERROR_JOB_NOT_DONE', message='The computation did not finish properly (\'JOB DONE\' not found).')
+        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
+            message='The retrieved folder data node could not be accessed.')
+        spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
+            message='The stdout output file could not be read.')
+        spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',
+            message='The stdout output file was incomplete probably because the calculation got interrupted.')
+        spec.exit_code(330, 'ERROR_READING_PDOSTOT_FILE',
+            message='The pdos_tot file could not be read from the retrieved folder.')
+        spec.exit_code(340, 'ERROR_PARSING_PROJECTIONS',
+            message='An exception was raised parsing bands and projections.')

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -78,27 +78,25 @@ class PwCalculation(BasePwCpInputGenerator):
         spec.output('output_atomic_occupations', valid_type=orm.Dict, required=False)
         spec.default_output_node = 'output_parameters'
 
-        # Unrecoverable errors: resources like the retrieved folder or its expected contents are missing
-        spec.exit_code(200, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
-        spec.exit_code(201, 'ERROR_NO_RETRIEVED_TEMPORARY_FOLDER',
-            message='The retrieved temporary folder could not be accessed.')
-        spec.exit_code(210, 'ERROR_OUTPUT_STDOUT_MISSING',
-            message='The retrieved folder did not contain the required stdout output file.')
-        spec.exit_code(220, 'ERROR_OUTPUT_XML_MISSING',
-            message='The retrieved folder did not contain the required required XML file.')
-        spec.exit_code(221, 'ERROR_OUTPUT_XML_MULTIPLE',
-            message='The retrieved folder contained multiple XML files.')
-
         # Unrecoverable errors: required retrieved files could not be read, parsed or are otherwise incomplete
-        spec.exit_code(300, 'ERROR_OUTPUT_FILES',
+        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
+            message='The retrieved folder data node could not be accessed.')
+        spec.exit_code(301, 'ERROR_NO_RETRIEVED_TEMPORARY_FOLDER',
+            message='The retrieved temporary folder could not be accessed.')
+        spec.exit_code(302, 'ERROR_OUTPUT_STDOUT_MISSING',
+            message='The retrieved folder did not contain the required stdout output file.')
+        spec.exit_code(303, 'ERROR_OUTPUT_XML_MISSING',
+            message='The retrieved folder did not contain the required required XML file.')
+        spec.exit_code(304, 'ERROR_OUTPUT_XML_MULTIPLE',
+            message='The retrieved folder contained multiple XML files.')
+        spec.exit_code(305, 'ERROR_OUTPUT_FILES',
             message='Both the stdout and XML output files could not be read or parsed.')
         spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
             message='The stdout output file could not be read.')
         spec.exit_code(311, 'ERROR_OUTPUT_STDOUT_PARSE',
             message='The stdout output file could not be parsed.')
         spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',
-            message='The stdout output file was incomplete.')
+            message='The stdout output file was incomplete probably because the calculation got interrupted.')
         spec.exit_code(320, 'ERROR_OUTPUT_XML_READ',
             message='The XML output file could not be read.')
         spec.exit_code(321, 'ERROR_OUTPUT_XML_PARSE',
@@ -107,7 +105,7 @@ class PwCalculation(BasePwCpInputGenerator):
             message='The XML output file has an unsupported format.')
         spec.exit_code(340, 'ERROR_OUT_OF_WALLTIME_INTERRUPTED',
             message='The calculation stopped prematurely because it ran out of walltime but the job was killed by the '
-            'scheduler before the files were safely written to disk for a potential restart.')
+                    'scheduler before the files were safely written to disk for a potential restart.')
         spec.exit_code(350, 'ERROR_UNEXPECTED_PARSER_EXCEPTION',
             message='The parser raised an unexpected exception.')
 

--- a/aiida_quantumespresso/calculations/pw2wannier90.py
+++ b/aiida_quantumespresso/calculations/pw2wannier90.py
@@ -29,16 +29,16 @@ class Pw2wannier90Calculation(NamelistsCalculation):
                    help='The output folder of a pw.x calculation')
         spec.output('output_parameters', valid_type=Dict)
         spec.default_output_node = 'output_parameters'
-        spec.exit_code(
-            100, 'ERROR_NO_RETRIEVED_FOLDER', message='The retrieved folder data node could not be accessed.')
-        spec.exit_code(
-            110, 'ERROR_READING_OUTPUT_FILE', message='The output file could not be read from the retrieved folder.')
-        spec.exit_code(
-            130, 'ERROR_JOB_NOT_DONE', message='The computation did not finish properly (\'JOB DONE\' not found).')
-        spec.exit_code(
-            140, 'ERROR_GENERIC_QE_ERROR', message='QE printed an error message')
-        spec.exit_code(
-            150, 'ERROR_GENERIC_PARSING_FAILURE', message='An error happened while parsing the output file')
+        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
+            message='The retrieved folder data node could not be accessed.')
+        spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
+            message='The stdout output file could not be read.')
+        spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',
+            message='The stdout output file was incomplete probably because the calculation got interrupted.')
+        spec.exit_code(340, 'ERROR_GENERIC_QE_ERROR',
+            message='Encountered a generic error message')
+        spec.exit_code(350, 'ERROR_UNEXPECTED_PARSER_EXCEPTION',
+            message='An error happened while parsing the output file')
 
     def prepare_for_submission(self, folder):
         """Prepare the inputs of the calculation and the calcinfo data.

--- a/aiida_quantumespresso/calculations/q2r.py
+++ b/aiida_quantumespresso/calculations/q2r.py
@@ -32,11 +32,11 @@ class Q2rCalculation(NamelistsCalculation):
         super(Q2rCalculation, cls).define(spec)
         spec.input('parent_folder', valid_type=(orm.RemoteData, orm.FolderData), required=True)
         spec.output('force_constants', valid_type=ForceConstantsData)
-        spec.exit_code(100, 'ERROR_NO_RETRIEVED_FOLDER',
+        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
             message='The retrieved folder data node could not be accessed.')
-        spec.exit_code(110, 'ERROR_READING_OUTPUT_FILE',
-            message='The output file could not be read from the retrieved folder.')
-        spec.exit_code(120, 'ERROR_READING_FORCE_CONSTANTS_FILE',
+        spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
+            message='The stdout output file could not be read.')
+        spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',
+            message='The stdout output file was incomplete probably because the calculation got interrupted.')
+        spec.exit_code(330, 'ERROR_READING_FORCE_CONSTANTS_FILE',
             message='The force constants file could not be read.')
-        spec.exit_code(130, 'ERROR_JOB_NOT_DONE',
-            message='The computation did not finish properly ("JOB DONE" not found).')

--- a/aiida_quantumespresso/parsers/cp.py
+++ b/aiida_quantumespresso/parsers/cp.py
@@ -35,7 +35,7 @@ class CpParser(Parser):
         # at least the stdout should exist
         if stdout_filename not in list_of_files:
             self.logger.error('Standard output not found')
-            return self.exit_codes.ERROR_READING_OUTPUT_FILE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
         # This should match 1 file
         xml_files = [
@@ -47,7 +47,7 @@ class CpParser(Parser):
             return self.exit_codes.ERROR_MISSING_XML_FILE
         elif len(xml_files) > 1:
             self.logger.error('more than one XML file retrieved, which should never happen')
-            return self.exit_codes.ERROR_MULTIPLE_XML_FILES
+            return self.exit_codes.ERROR_OUTPUT_XML_MULTIPLE
 
         if self.node.process_class._FILE_XML_PRINT_COUNTER_BASENAME not in list_of_files:
             self.logger.error('We could not find the print counter file in the output')

--- a/aiida_quantumespresso/parsers/dos.py
+++ b/aiida_quantumespresso/parsers/dos.py
@@ -32,7 +32,7 @@ class DosParser(Parser):
             with out_folder.open(filename_stdout, 'r') as fil:
                     out_file = fil.readlines()
         except OSError:
-            return self.exit_codes.ERROR_READING_OUTPUT_FILE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
         job_done = False
         for i in range(len(out_file)):
@@ -41,7 +41,7 @@ class DosParser(Parser):
                 job_done = True
                 break
         if not job_done:
-            return self.exit_codes.ERROR_JOB_NOT_DONE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE
 
         # check that the dos file is present, if it is, read it
         try:

--- a/aiida_quantumespresso/parsers/matdyn.py
+++ b/aiida_quantumespresso/parsers/matdyn.py
@@ -25,15 +25,15 @@ class MatdynParser(Parser):
 
         if filename_stdout not in output_folder.list_object_names():
             self.logger.error("The standard output file '{}' was not found but is required".format(filename_stdout))
-            return self.exit_codes.ERROR_READING_OUTPUT_FILE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
         if 'JOB DONE' not in output_folder.get_object_content(filename_stdout):
             self.logger.error('Computation did not finish properly')
-            return self.exit_codes.ERROR_JOB_NOT_DONE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE
 
         if filename_frequencies not in output_folder.list_object_names():
             self.logger.error("The frequencies output file '{}' was not found but is required".format(filename_stdout))
-            return self.exit_codes.ERROR_READING_OUTPUT_FILE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
         # Extract the kpoints from the input data and create the `KpointsData` for the `BandsData`
         try:

--- a/aiida_quantumespresso/parsers/neb.py
+++ b/aiida_quantumespresso/parsers/neb.py
@@ -46,7 +46,7 @@ class NebParser(Parser):
 
         if filename_stdout not in list_of_files:
             self.logger.error("The standard output file '{}' was not found but is required".format(filename_stdout))
-            return self.exit_codes.ERROR_READING_OUTPUT_FILE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
         # Look for optional settings input node and potential 'parser_options' dictionary within it
         # Note that we look for both NEB and PW parser options under "inputs.settings.parser_options";
@@ -77,7 +77,7 @@ class NebParser(Parser):
             # TODO: why do we ignore raw_successful ?
         except QEOutputParsingError as exc:
             self.logger.error('QEOutputParsingError in parse_raw_output_neb: {}'.format(exc))
-            return self.exit_codes.ERROR_READING_OUTPUT_FILE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
         for warn_type in ['warnings', 'parser_warnings']:
             for message in neb_out_dict[warn_type]:
@@ -94,10 +94,10 @@ class NebParser(Parser):
                 num_images = neb_out_dict['num_of_images']
             except KeyError:
                 self.logger.error('Impossible to understand the number of images')
-                return self.exit_codes.ERROR_INVALID_OUTPUT
+                return self.exit_codes.ERROR_OUTPUT_STDOUT_PARSE
         if num_images < 2:
             self.logger.error('Too few images: {}'.format(num_images))
-            return self.exit_codes.ERROR_INVALID_OUTPUT
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_PARSE
 
         # Now parse the information from the individual pw calculations for the different images
         image_data = {}
@@ -138,7 +138,7 @@ class NebParser(Parser):
                     pw_out_text = f.read()  # Note: read() and not readlines()
             except IOError:
                 self.logger.error('No pw output file found for image {}'.format(i + 1))
-                return self.exit_codes.ERROR_READING_OUTPUT_FILE
+                return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
             try:
                 parsed_data_stdout, logs_stdout = parse_pw_stdout(pw_out_text, pw_input_dict, parser_options, parsed_data_xml)

--- a/aiida_quantumespresso/parsers/projwfc.py
+++ b/aiida_quantumespresso/parsers/projwfc.py
@@ -243,7 +243,7 @@ class ProjwfcParser(Parser):
             with out_folder.open(filename_stdout, 'r') as fil:
                 out_file = fil.readlines()
         except OSError:
-            return self.exit_codes.ERROR_READING_OUTPUT_FILE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
         job_done = False
         for i in range(len(out_file)):
@@ -253,7 +253,7 @@ class ProjwfcParser(Parser):
                 break
         if not job_done:
             self.logger.error('Computation did not finish properly')
-            return self.exit_codes.ERROR_JOB_NOT_DONE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE
 
         # Parse basic info and warnings, and output them as output_parmeters
         parsed_data = parse_raw_out_basic(out_file, 'PROJWFC')

--- a/aiida_quantumespresso/parsers/pw2wannier90.py
+++ b/aiida_quantumespresso/parsers/pw2wannier90.py
@@ -28,7 +28,7 @@ class Pw2wannier90Parser(Parser):
             with out_folder.open(filename_stdout, 'r') as fil:
                 out_file = fil.read()
         except OSError:
-            return self.exit_codes.ERROR_READING_OUTPUT_FILE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
         # check that the file has finished (i.e. JOB DONE is inside the file)
         successful_raw, out_dict = parse_qe_simple(out_file, codename='PW2WANNIER')
@@ -39,8 +39,8 @@ class Pw2wannier90Parser(Parser):
         # In case of parsing error or calculation error, return an exit code
         if not successful_raw:
             if 'Computation did not finish properly' in out_dict['warnings']:
-                return self.exit_codes.ERROR_JOB_NOT_DONE
+                return self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE
             elif 'error_message' in list(out_dict.keys()):
                 return self.exit_codes.ERROR_GENERIC_QE_ERROR
             else:
-                return self.exit_codes.ERROR_GENERIC_PARSING_FAILURE
+                return self.exit_codes.ERROR_UNEXPECTED_PARSER_EXCEPTION

--- a/aiida_quantumespresso/parsers/q2r.py
+++ b/aiida_quantumespresso/parsers/q2r.py
@@ -22,7 +22,7 @@ class Q2rParser(Parser):
 
         if filename_stdout not in output_folder.list_object_names():
             self.logger.error("The standard output file '{}' was not found but is required".format(filename_stdout))
-            return self.exit_codes.ERROR_READING_OUTPUT_FILE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
         if filename_force_constants not in output_folder.list_object_names():
             self.logger.error("The force constants file '{}' was not found but is required".format(filename_force_constants))
@@ -30,7 +30,7 @@ class Q2rParser(Parser):
 
         if 'JOB DONE' not in output_folder.get_object_content(filename_stdout):
             self.logger.error('Computation did not finish properly')
-            return self.exit_codes.ERROR_JOB_NOT_DONE
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE
 
         with output_folder.open(filename_force_constants, 'rb') as handle:
             self.out('force_constants', ForceConstantsData(file=handle))


### PR DESCRIPTION
Fixes #296 

Making sure that all calculation jobs use the same exit codes for the
same problem does not only make things easier for the user but it can
then also be used in code to make certain assertions based on the exit
code of a failed calculations. An example is the automatically
invalidating of caching for exit codes smaller than 400, which will be
implemented soon. This is only possible if all calculations respect the
convention that codes below 400 are irrecoverable errors and so those
should also not be used for caching.