### PR TITLE
Add default for `resources.num_machines` option to `CalcJob` base class

### DIFF
--- a/aiida_quantumespresso/calculations/base.py
+++ b/aiida_quantumespresso/calculations/base.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Defines a CalcJob base class for aiida-quantumespresso.
+"""Defines a `CalcJob` base class for `aiida-quantumespresso`.
 
-The custom CalcJob base class automatically sets the `invalidates_cache`
-attribute of exit codes based on the status integer. All `CalcJob`
-implementations in `aiida-quantumespresso` must use this base class,
-not `aiida.engine.CalcJob`.
+The custom `CalcJob` base class automatically sets the `invalidates_cache` attribute of exit codes based on the status
+integer. All `CalcJob` implementations in `aiida-quantumespresso` must use this base class, not `aiida.engine.CalcJob`.
 """
-
 from __future__ import absolute_import
 
 from aiida.engine import CalcJob as _BaseCalcJob
@@ -16,23 +13,22 @@ __all__ = ('CalcJob',)
 
 
 class CalcJobProcessSpec(_BaseCalcJobProcessSpec):
-    """Process spec for aiida-quantumespresso CalcJob classes.
+    """Process spec for `aiida-quantumespresso` `CalcJob` classes.
 
-    Automatically sets the `invalidates_cache` flag to `True` for an
-    exit status smaller than 400, unless explicitly overriden.
+    Automatically sets the `invalidates_cache` flag to `True` if `exit_status < 400`, unless explicitly overridden.
     """
 
     def exit_code(self, status, label, message, invalidates_cache=None):
         """Add an exit code to the ProcessSpec.
 
-        .. note: for any status smaller than `400` the `invalidates_cache` is
-            automatically set to `True`, unless explicitly overridden.
+        .. note: for any status smaller than `400` the `invalidates_cache` is automatically set to `True`, unless
+            explicitly overridden.
 
         :param status: the exit status integer
         :param label: a label by which the exit code can be addressed
         :param message: a more detailed description of the exit code
-        :param invalidates_cache: when set to `True`, a process exiting
-            with this exit code will not be considered for caching
+        :param invalidates_cache: when set to `True`, a process exiting with this exit code will not be considered for
+            caching
         """
         if invalidates_cache is None:
             invalidates_cache = (isinstance(status, int) and status < 400)
@@ -45,6 +41,12 @@ class CalcJobProcessSpec(_BaseCalcJobProcessSpec):
 
 
 class CalcJob(_BaseCalcJob):  # pylint: disable=abstract-method
-    """Custom CalcJob class for aiida-quantumespresso calculations."""
+    """Custom `CalcJob` class for `aiida-quantumespresso` calculations."""
 
     _spec_class = CalcJobProcessSpec
+
+    @classmethod
+    def define(cls, spec):
+        # yapf: disable
+        super(CalcJob, cls).define(spec)
+        spec.inputs['metadata']['options']['resources'].default = lambda: {'num_machines': 1}


### PR DESCRIPTION
Fixes #389 

Any `CalcJob` requires at least the `resources.num_machines` option to
be set. This is often forgotten by beginning users and will result in a
failed calculation. In almost all cases, unless the user really knows
they want to use more, one wants to use a single machine. By setting
this on the `CalcJob` base class, all implementations will automatically
inherit this default.