### PR TITLE
Add custom base `Parser` class that all parsers should use

### DIFF
--- a/aiida_quantumespresso/calculations/pw2gw.py
+++ b/aiida_quantumespresso/calculations/pw2gw.py
@@ -36,8 +36,7 @@ class Pw2gwCalculation(NamelistsCalculation):
         spec.output('output_parameters', valid_type=orm.Dict,
             help='The `output_parameters` output node of the successful calculation.`')
         spec.output('eps', valid_type=orm.ArrayData,
-            help='The `eps` output node containing 5 arrays `energy`, `epsX`, `epsY`, `epsZ`, `epsTOT`'
-            )
+            help='The `eps` output node containing 5 arrays `energy`, `epsX`, `epsY`, `epsZ`, `epsTOT`')
 
         spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
             message='The retrieved folder data node could not be accessed.')
@@ -59,7 +58,6 @@ class Pw2gwCalculation(NamelistsCalculation):
             message='The parser raised an unexpected exception.')
 
     def prepare_for_submission(self, folder):
-        # yapf: disable
         calcinfo = super(Pw2gwCalculation, self).prepare_for_submission(folder)
 
         calcinfo.codes_run_mode = datastructures.CodeRunMode.SERIAL

--- a/aiida_quantumespresso/parsers/base.py
+++ b/aiida_quantumespresso/parsers/base.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""Defines a `Parser` base class for `aiida-quantumespresso`.
+
+All `Parser` implementations in `aiida-quantumespresso` must use this base class, not `aiida.parsers.Parser`.
+"""
+from __future__ import absolute_import
+
+from aiida.parsers import Parser as _BaseParser
+
+__all__ = ('Parser',)
+
+
+class Parser(_BaseParser):  # pylint: disable=abstract-method
+    """Custom `Parser` class for `aiida-quantumespresso` parser implementations."""
+
+    def emit_logs(self, logging_dictionaries, ignore=None):
+        """Emit the messages in one or multiple "log dictionaries" through the logger of the parser.
+
+        A log dictionary is expected to have the following structure: each key must correspond to a log level of the
+        python logging module, e.g. `error` or `warning` and its values must be a list of string messages. The method
+        will loop over all log dictionaries and emit the messages it contains with the log level indicated by the key.
+
+        Example log dictionary structure::
+
+            logs = {
+                'warning': ['Could not parse the `etot_threshold` variable from the stdout.'],
+                'error': ['Self-consistency was not achieved']
+            }
+
+        :param logging_dictionaries: log dictionaries
+        :param ignore: list of log messages to ignore
+        """
+        ignore = ignore or []
+
+        if not isinstance(logging_dictionaries, (list, tuple)):
+            logging_dictionaries = [logging_dictionaries]
+
+        for logs in logging_dictionaries:
+            for level, messages in logs.items():
+                for message in messages:
+
+                    if message is None:
+                        continue
+
+                    stripped = message.strip()
+
+                    if not stripped or stripped in ignore:
+                        continue
+
+                    try:
+                        getattr(self.logger, level)(stripped)
+                    except AttributeError:
+                        pass
+
+    def exit(self, exit_code):
+        """Log the exit message of the give exit code with level `ERROR` and return the exit code.
+
+        This is a utility function if one wants to return from the parse method and automically add the exit message
+        associated to the exit code as a log message to the node: e.g. `return self.exit(self.exit_codes.LABEL))`
+
+        :param exit_code: an `ExitCode`
+        :return: the exit code
+        """
+        self.logger.error(exit_code.message)
+        return exit_code

--- a/aiida_quantumespresso/parsers/cp.py
+++ b/aiida_quantumespresso/parsers/cp.py
@@ -6,11 +6,11 @@ from distutils.version import LooseVersion
 import numpy
 from aiida.common import NotExistent
 from aiida.orm import Dict, TrajectoryData
-from aiida.parsers import Parser
 from six.moves import zip
 
 from qe_tools.constants import bohr_to_ang, hartree_to_ev, timeau_to_sec
 from aiida_quantumespresso.parsers.parse_raw.cp import parse_cp_raw_output, parse_cp_traj_stanzas
+from .base import Parser
 
 
 class CpParser(Parser):
@@ -24,8 +24,7 @@ class CpParser(Parser):
         try:
             out_folder = self.retrieved
         except NotExistent:
-            self.logger.error('No retrieved folder found')
-            return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
+            return self.exit(self.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
 
         # check what is inside the folder
         list_of_files = out_folder._repository.list_object_names()
@@ -34,8 +33,7 @@ class CpParser(Parser):
         stdout_filename = self.node.get_attribute('output_filename')
         # at least the stdout should exist
         if stdout_filename not in list_of_files:
-            self.logger.error('Standard output not found')
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
+            return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
 
         # This should match 1 file
         xml_files = [
@@ -43,16 +41,14 @@ class CpParser(Parser):
             if xml_file in list_of_files
         ]
         if not xml_files:
-            self.logger.error('no XML output files found, which is required for parsing')
-            return self.exit_codes.ERROR_MISSING_XML_FILE
+            return self.exit(self.exit_codes.ERROR_MISSING_XML_FILE)
         elif len(xml_files) > 1:
-            self.logger.error('more than one XML file retrieved, which should never happen')
-            return self.exit_codes.ERROR_OUTPUT_XML_MULTIPLE
+            return self.exit(self.exit_codes.ERROR_OUTPUT_XML_MULTIPLE)
 
         if self.node.process_class._FILE_XML_PRINT_COUNTER_BASENAME not in list_of_files:
             self.logger.error('We could not find the print counter file in the output')
             # TODO: Add an error for this counter
-            return self.exit_codes.ERROR_MISSING_XML_FILE
+            return self.exit(self.exit_codes.ERROR_MISSING_XML_FILE)
 
         # Let's pass file handlers to this function
         out_dict, _raw_successful = parse_cp_raw_output(
@@ -71,13 +67,11 @@ class CpParser(Parser):
         ]
 
         # Now prepare the reordering, as filex in the xml are  ordered
-        reordering = self._generate_sites_ordering(out_dict['species'],
-                                                   out_dict['atoms'])
+        reordering = self._generate_sites_ordering(out_dict['species'], out_dict['atoms'])
 
         pos_filename = '{}.{}'.format(self.node.process_class._PREFIX, 'pos')
         if pos_filename not in list_of_files:
-            out_dict['warnings'].append('Unable to open the POS file... skipping.')
-            return self.exit_codes.ERROR_READING_POS_FILE
+            return self.exit(self.exit_codes.ERROR_READING_POS_FILE)
 
         trajectories = [
             ('positions', 'pos', bohr_to_ang, out_dict['number_of_atoms']),
@@ -163,7 +157,7 @@ class CpParser(Parser):
             if max_time_difference > 1.e-4: # It is typically ~1.e-7 due to roundoff errors
                 # If there is a large discrepancy
                 # it means there is something very weird going on...
-                return self.exit_codes.ERROR_READING_TRAJECTORY_DATA
+                return self.exit(self.exit_codes.ERROR_READING_TRAJECTORY_DATA)
 
             # Delete evp_times in any case, it's a duplicate of 'times'
             del raw_trajectory['evp_times']

--- a/aiida_quantumespresso/parsers/matdyn.py
+++ b/aiida_quantumespresso/parsers/matdyn.py
@@ -5,9 +5,10 @@ from six.moves import range
 
 from aiida import orm
 from aiida.common import exceptions
-from aiida.parsers.parser import Parser
 from qe_tools.constants import invcm_to_THz
+
 from aiida_quantumespresso.calculations.matdyn import MatdynCalculation
+from .base import Parser
 
 
 class MatdynParser(Parser):
@@ -18,22 +19,19 @@ class MatdynParser(Parser):
         try:
             output_folder = self.retrieved
         except exceptions.NotExistent:
-            return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
+            return self.exit(self.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
 
         filename_stdout = self.node.get_option('output_filename')
         filename_frequencies = MatdynCalculation._PHONON_FREQUENCIES_NAME
 
         if filename_stdout not in output_folder.list_object_names():
-            self.logger.error("The standard output file '{}' was not found but is required".format(filename_stdout))
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
+            return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
 
         if 'JOB DONE' not in output_folder.get_object_content(filename_stdout):
-            self.logger.error('Computation did not finish properly')
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE
+            return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE)
 
         if filename_frequencies not in output_folder.list_object_names():
-            self.logger.error("The frequencies output file '{}' was not found but is required".format(filename_stdout))
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
+            return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
 
         # Extract the kpoints from the input data and create the `KpointsData` for the `BandsData`
         try:
@@ -49,14 +47,10 @@ class MatdynParser(Parser):
         try:
             num_kpoints = parsed_data.pop('num_kpoints')
         except KeyError:
-            exit_code = self.exit_codes.ERROR_OUTPUT_KPOINTS_MISSING
-            self.logger.error(exit_code.message)
-            return exit_code
+            return self.exit(self.exit_codes.ERROR_OUTPUT_KPOINTS_MISSING)
 
         if num_kpoints != kpoints.shape[0]:
-            exit_code = self.exit_codes.ERROR_OUTPUT_KPOINTS_INCOMMENSURATE
-            self.logger.error(exit_code.message)
-            return exit_code
+            return self.exit(self.exit_codes.ERROR_OUTPUT_KPOINTS_INCOMMENSURATE)
 
         output_bands = orm.BandsData()
         output_bands.set_kpointsdata(kpoints_for_bands)

--- a/aiida_quantumespresso/parsers/parse_raw/base.py
+++ b/aiida_quantumespresso/parsers/parse_raw/base.py
@@ -3,9 +3,7 @@
 from __future__ import absolute_import
 from aiida_quantumespresso.parsers import get_parser_info
 
-__all__ = (
-    'parse_output_base', 'parse_output_error', 'convert_qe_time_to_sec', 'convert_qe2aiida_structure'
-)
+__all__ = ('parse_output_base', 'parse_output_error', 'convert_qe_time_to_sec', 'convert_qe2aiida_structure')
 
 
 def parse_output_base(filecontent, codename=None, message_map=None):
@@ -61,46 +59,6 @@ def parse_output_base(filecontent, codename=None, message_map=None):
                 parse_output_error(lines, line_number, logs, message_map)
 
     return parsed_data, logs
-
-
-def emit_logs(logger, logging_containers, ignore=None):
-    """Emit the messages in one or multiple "log dictionaries" through the logger of the parser.
-
-    A log dictionary is expected to have the following structure: each key must correspond to a log level of the
-    python logging module, e.g. `error` or `warning` and its values must be a list of string messages. The method
-    will loop over all log dictionaries and emit the messages it contains with the log level indicated by the key.
-
-    Example log dictionary structure::
-
-        logs = {
-            'warning': ['Could not parse the `etot_threshold` variable from the stdout.'],
-            'error': ['Self-consistency was not achieved']
-        }
-
-    :param logging_containers: list of log dictionaries
-    """
-    if ignore is None:
-        ignore = []
-
-    if not isinstance(logging_containers, list):
-        logging_containers = [logging_containers]
-
-    for logging_container in logging_containers:
-        for level, messages in logging_container.items():
-            for message in messages:
-
-                if message is None:
-                    continue
-
-                stripped = message.strip()
-
-                if not stripped or stripped in ignore:
-                    continue
-
-                try:
-                    getattr(logger, level)(stripped)
-                except AttributeError:
-                    pass
 
 
 def parse_output_error(lines, line_number_start, logs, message_map=None):

--- a/aiida_quantumespresso/parsers/ph.py
+++ b/aiida_quantumespresso/parsers/ph.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""`Parser` implementation for the `PhCalculation` calculation job class."""
 from __future__ import absolute_import
 
 import os
@@ -7,9 +8,10 @@ import traceback
 
 from aiida import orm
 from aiida.common import exceptions
-from aiida.parsers.parser import Parser
+
 from aiida_quantumespresso.calculations.ph import PhCalculation
 from aiida_quantumespresso.parsers.parse_raw.ph import parse_raw_ph_output as parse_stdout
+from .base import Parser
 
 
 class PhParser(Parser):
@@ -27,12 +29,12 @@ class PhParser(Parser):
         filename_tensor = PhCalculation._OUTPUT_XML_TENSOR_FILE_NAME
 
         if filename_stdout not in self.retrieved.list_object_names():
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_MISSING
+            return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_MISSING)
 
         try:
             stdout = self.retrieved.get_object_content(filename_stdout)
         except (IOError, OSError):
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
+            return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
 
         try:
             tensor_file = self.retrieved.get_object_content(filename_tensor)
@@ -55,7 +57,7 @@ class PhParser(Parser):
             parsed_data, logs = parse_stdout(stdout, tensor_file, dynmat_files)
         except Exception:
             self.logger.error(traceback.format_exc())
-            return self.exit_codes.ERROR_UNEXPECTED_PARSER_EXCEPTION
+            return self.exit(self.exit_codes.ERROR_UNEXPECTED_PARSER_EXCEPTION)
 
         self.emit_logs(logs)
         self.out('output_parameters', orm.Dict(dict=parsed_data))
@@ -65,38 +67,3 @@ class PhParser(Parser):
 
         if 'ERROR_CONVERGENCE_NOT_REACHED' in logs['error']:
             return self.exit_codes.ERROR_CONVERGENCE_NOT_REACHED
-
-    def emit_logs(self, *args):
-        """Emit the messages in one or multiple "log dictionaries" through the logger of the parser.
-
-        A log dictionary is expected to have the following structure: each key must correspond to a log level of the
-        python logging module, e.g. `error` or `warning` and its values must be a list of string messages. The method
-        will loop over all log dictionaries and emit the messages it contains with the log level indicated by the key.
-
-        Example log dictionary structure::
-
-            logs = {
-                'warning': ['Could not parse the `etot_threshold` variable from the stdout.'],
-                'error': ['Self-consistency was not achieved']
-            }
-
-        :param args: log dictionaries
-        """
-        ignore = []
-
-        for logs in args:
-            for level, messages in logs.items():
-                for message in messages:
-
-                    if message is None:
-                        continue
-
-                    stripped = message.strip()
-
-                    if not stripped or stripped in ignore:
-                        continue
-
-                    try:
-                        getattr(self.logger, level)(stripped)
-                    except AttributeError:
-                        pass

--- a/aiida_quantumespresso/parsers/q2r.py
+++ b/aiida_quantumespresso/parsers/q2r.py
@@ -2,9 +2,10 @@
 from __future__ import absolute_import
 
 from aiida.common import exceptions
-from aiida.parsers import Parser
+
 from aiida_quantumespresso.calculations.q2r import Q2rCalculation
 from aiida_quantumespresso.data.force_constants import ForceConstantsData
+from .base import Parser
 
 
 class Q2rParser(Parser):
@@ -15,22 +16,19 @@ class Q2rParser(Parser):
         try:
             output_folder = self.retrieved
         except exceptions.NotExistent:
-            return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
+            return self.exit(self.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
 
         filename_stdout = self.node.get_option('output_filename')
         filename_force_constants = Q2rCalculation._FORCE_CONSTANTS_NAME
 
         if filename_stdout not in output_folder.list_object_names():
-            self.logger.error("The standard output file '{}' was not found but is required".format(filename_stdout))
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
+            return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
 
         if filename_force_constants not in output_folder.list_object_names():
-            self.logger.error("The force constants file '{}' was not found but is required".format(filename_force_constants))
-            return self.exit_codes.ERROR_READING_FORCE_CONSTANTS_FILE
+            return self.exit(self.exit_codes.ERROR_READING_FORCE_CONSTANTS_FILE)
 
         if 'JOB DONE' not in output_folder.get_object_content(filename_stdout):
-            self.logger.error('Computation did not finish properly')
-            return self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE
+            return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE)
 
         with output_folder.open(filename_force_constants, 'rb') as handle:
             self.out('force_constants', ForceConstantsData(file=handle))


### PR DESCRIPTION
The base class serves as a central point for useful functionality for
all parsers to be implemented. Currently it provides:

 * `emit_logs`: function to emit parsed messages to node logger
 * `exit`: exit with an exit code with the exit message automatically
   being emitted through the node's logger