### PR TITLE
Make unit test independent of the current working directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,17 @@ import six
 pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
 
 
+@pytest.fixture(scope='session')
+def filepath_tests():
+    """Return the absolute filepath of the `tests` folder.
+
+    .. warning:: if this file moves with respect to the `tests` folder, the implementation should change.
+
+    :return: absolute filepath of `tests` folder which is the basepath for all test resources.
+    """
+    return os.path.dirname(os.path.abspath(__file__))
+
+
 @pytest.fixture(scope='function')
 def fixture_sandbox():
     """Return a `SandboxFolder`."""
@@ -154,15 +165,14 @@ def generate_calc_job_node():
 
 
 @pytest.fixture(scope='session')
-def generate_upf_data():
+def generate_upf_data(filepath_tests):
     """Return a `UpfData` instance for the given element a file for which should exist in `tests/fixtures/pseudos`."""
 
     def _generate_upf_data(element):
         """Return `UpfData` node."""
         from aiida.orm import UpfData
 
-        filename = os.path.join('tests', 'fixtures', 'pseudos', '{}.upf'.format(element))
-        filepath = os.path.abspath(filename)
+        filepath = os.path.join(filepath_tests, 'fixtures', 'pseudos', '{}.upf'.format(element))
 
         with io.open(filepath, 'r') as handle:
             upf = UpfData(file=handle.name)

--- a/tests/tools/test_immigrate.py
+++ b/tests/tools/test_immigrate.py
@@ -6,7 +6,9 @@ import os
 from aiida_quantumespresso.tools.pwinputparser import create_builder_from_file
 
 
-def test_create_builder(aiida_profile, fixture_sandbox, fixture_code, generate_upf_data, generate_calc_job):
+def test_create_builder(
+    aiida_profile, fixture_sandbox, fixture_code, generate_upf_data, generate_calc_job, filepath_tests
+):
     """Test the `create_builder_from_file` method that parses an existing `pw.x` folder into a process builder.
 
     The input file used is the one generated for `tests.calculations.test_pw.test_pw_default`.
@@ -26,11 +28,9 @@ def test_create_builder(aiida_profile, fixture_sandbox, fixture_code, generate_u
         }
     }
 
-    in_foldername = os.path.join('tests', 'calculations', 'test_pw')
-    in_folderpath = os.path.abspath(in_foldername)
+    in_folderpath = os.path.join(filepath_tests, 'calculations', 'test_pw')
+    upf_folderpath = os.path.join(filepath_tests, 'fixtures', 'pseudos')
 
-    upf_foldername = os.path.join('tests', 'fixtures', 'pseudos')
-    upf_folderpath = os.path.abspath(upf_foldername)
     si_upf = generate_upf_data('Si')
     si_upf.store()
 


### PR DESCRIPTION
Fixes #505 

For convenience, the `filepath_tests` fixture is provided which gives
the absolute path to the `tests` folder. Note that this is now dependent
on the `conftest.py` file being directly in the `tests` folder but that
is unlikely to change. If it does, the implementation should be updated.