### PR TITLE
Add support for `aiida-sssp`

### DIFF
--- a/aiida_quantumespresso/cli/calculations/dos.py
+++ b/aiida_quantumespresso/cli/calculations/dos.py
@@ -2,21 +2,22 @@
 """Command line scripts to launch a `DosCalculation` for testing and demonstration purposes."""
 import click
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
 
 from ..utils import launch
-from ..utils import options as options_qe
+from ..utils import options
 from . import cmd_launch
 
 
 @cmd_launch.command('dos')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.dos'))
-@options.CALCULATION(required=True)
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.dos'))
+@options_core.CALCULATION(required=True)
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_calculation(code, calculation, max_num_machines, max_wallclock_seconds, with_mpi, daemon):
     """Run a DosCalculation."""

--- a/aiida_quantumespresso/cli/calculations/epw.py
+++ b/aiida_quantumespresso/cli/calculations/epw.py
@@ -2,26 +2,27 @@
 """Command line scripts to launch a `EpwCalculation` for testing and demonstration purposes."""
 import click
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
 
 from ..utils import launch
-from ..utils import options as options_qe
+from ..utils import options
 from . import cmd_launch
 
 
 @cmd_launch.command('epw')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.epw'))
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.epw'))
 @click.option('--pw-nscf-parent', type=types.CalculationParamType(), help='The parent pw.x nscf calculation.')
 @click.option('--ph-parent', type=types.CalculationParamType(), help='The parent ph.x calculation.')
-@options_qe.KPOINTS_MESH(default=[6, 6, 6])
-@options_qe.QPOINTS_MESH(default=[2, 2, 2])
-@options_qe.KFPOINTS_MESH(default=[6, 6, 6])
-@options_qe.QFPOINTS_MESH(default=[2, 2, 2])
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
+@options.KPOINTS_MESH(default=[6, 6, 6])
+@options.QPOINTS_MESH(default=[2, 2, 2])
+@options.KFPOINTS_MESH(default=[6, 6, 6])
+@options.QFPOINTS_MESH(default=[2, 2, 2])
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_calculation(
     code, kpoints_mesh, qpoints_mesh, kfpoints_mesh, qfpoints_mesh, pw_nscf_parent, ph_parent, max_num_machines,
@@ -56,38 +57,30 @@ def launch_calculation(
 
     ph_parent_folder = ph_parent.get_outgoing(node_class=orm.RemoteData, link_label_filter='remote_folder').one().node
 
+    parameters = {
+        'INPUTEPW': {
+            'nbndsub': 8,
+            'elph': True,  # default is false
+            'epbwrite': True,  # default is false
+            'epwwrite': True,  # default is false
+            'proj(1)': 'Si : sp3',
+            'elecselfen': True,
+            'wannierize': True,
+            'dvscf_dir': './save/',
+            'dis_win_max': 18,
+            'dis_froz_max': 8.5
+        }
+    }
+
     inputs = {
-        'code':
-        code,
-        'qpoints':
-        qpoints_mesh,
-        'kpoints':
-        kpoints_mesh,
-        'qfpoints':
-        qfpoints_mesh,
-        'kfpoints':
-        kfpoints_mesh,
-        'parameters':
-        orm.Dict(
-            dict={
-                'INPUTEPW': {
-                    'nbndsub': 8,
-                    'elph': True,  # default is false
-                    'epbwrite': True,  # default is false
-                    'epwwrite': True,  # default is false
-                    'proj(1)': 'Si : sp3',
-                    'elecselfen': True,
-                    'wannierize': True,
-                    'dvscf_dir': './save/',
-                    'dis_win_max': 18,
-                    'dis_froz_max': 8.5
-                }
-            }
-        ),
-        'parent_folder_nscf':
-        pw_nscf_parent_folder,
-        'parent_folder_ph':
-        ph_parent_folder,
+        'code': code,
+        'qpoints': qpoints_mesh,
+        'kpoints': kpoints_mesh,
+        'qfpoints': qfpoints_mesh,
+        'kfpoints': kfpoints_mesh,
+        'parameters': orm.Dict(dict=parameters),
+        'parent_folder_nscf': pw_nscf_parent_folder,
+        'parent_folder_ph': ph_parent_folder,
         'metadata': {
             'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi),
         }

--- a/aiida_quantumespresso/cli/calculations/matdyn.py
+++ b/aiida_quantumespresso/cli/calculations/matdyn.py
@@ -1,25 +1,26 @@
 # -*- coding: utf-8 -*-
 """Command line scripts to launch a `MatdynCalculation` for testing and demonstration purposes."""
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
 
 from ..utils import launch
-from ..utils import options as options_qe
+from ..utils import options
 from . import cmd_launch
 
 
 @cmd_launch.command('matdyn')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.matdyn'))
-@options.DATUM(
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.matdyn'))
+@options_core.DATUM(
     required=True,
     type=types.DataParamType(sub_classes=('aiida.data:quantumespresso.force_constants',)),
     help='A ForceConstantsData node produced by a `Q2rCalculation`'
 )
-@options_qe.KPOINTS_MESH(default=[1, 1, 1])
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
+@options.KPOINTS_MESH(default=[1, 1, 1])
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_calculation(code, datum, kpoints_mesh, max_num_machines, max_wallclock_seconds, with_mpi, daemon):
     """Run a MatdynCalculation."""

--- a/aiida_quantumespresso/cli/calculations/ph.py
+++ b/aiida_quantumespresso/cli/calculations/ph.py
@@ -2,22 +2,23 @@
 """Command line scripts to launch a `PhCalculation` for testing and demonstration purposes."""
 import click
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
 
 from ..utils import launch
-from ..utils import options as options_qe
+from ..utils import options
 from . import cmd_launch
 
 
 @cmd_launch.command('ph')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.ph'))
-@options.CALCULATION(required=True)
-@options_qe.KPOINTS_MESH(default=[1, 1, 1])
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.ph'))
+@options_core.CALCULATION(required=True)
+@options.KPOINTS_MESH(default=[1, 1, 1])
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_calculation(code, kpoints_mesh, calculation, max_num_machines, max_wallclock_seconds, with_mpi, daemon):
     """Run a PhCalculation."""

--- a/aiida_quantumespresso/cli/calculations/pp.py
+++ b/aiida_quantumespresso/cli/calculations/pp.py
@@ -2,21 +2,22 @@
 """Command line scripts to launch a `PpCalculation` for testing and demonstration purposes."""
 import click
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
 
 from ..utils import launch
-from ..utils import options as options_qe
+from ..utils import options
 from . import cmd_launch
 
 
 @cmd_launch.command('pp')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pp'))
-@options.CALCULATION(required=True)
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pp'))
+@options_core.CALCULATION(required=True)
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_calculation(code, calculation, max_num_machines, max_wallclock_seconds, with_mpi, daemon):
     """Run a PpCalculation."""

--- a/aiida_quantumespresso/cli/calculations/projwfc.py
+++ b/aiida_quantumespresso/cli/calculations/projwfc.py
@@ -2,21 +2,22 @@
 """Command line scripts to launch a `ProjwfcCalculation` for testing and demonstration purposes."""
 import click
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
 
 from ..utils import launch
-from ..utils import options as options_qe
+from ..utils import options
 from . import cmd_launch
 
 
 @cmd_launch.command('projwfc')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.projwfc'))
-@options.CALCULATION(required=True)
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.projwfc'))
+@options_core.CALCULATION(required=True)
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_calculation(code, calculation, max_num_machines, max_wallclock_seconds, with_mpi, daemon):
     """Run a ProjwfcCalculation."""

--- a/aiida_quantumespresso/cli/calculations/pw.py
+++ b/aiida_quantumespresso/cli/calculations/pw.py
@@ -2,12 +2,14 @@
 """Command line scripts to launch a `PwCalculation` for testing and demonstration purposes."""
 import click
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
+from aiida_sssp.cli import options as options_sssp
 
 from ..utils import defaults
 from ..utils import launch
-from ..utils import options as options_qe
+from ..utils import options
 from ..utils import validate
 from . import cmd_launch
 
@@ -15,23 +17,23 @@ CALCS_REQUIRING_PARENT = set(['nscf'])
 
 
 @cmd_launch.command('pw')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pw'))
-@options_qe.STRUCTURE(default=defaults.get_structure)
-@options_qe.PSEUDO_FAMILY(required=True)
-@options_qe.KPOINTS_MESH(default=[2, 2, 2])
-@options_qe.ECUTWFC()
-@options_qe.ECUTRHO()
-@options_qe.HUBBARD_U()
-@options_qe.HUBBARD_V()
-@options_qe.HUBBARD_FILE()
-@options_qe.STARTING_MAGNETIZATION()
-@options_qe.SMEARING()
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
-@options_qe.PARENT_FOLDER()
-@options.DRY_RUN()
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pw'))
+@options.STRUCTURE(default=defaults.get_structure)
+@options_sssp.SSSP_FAMILY()
+@options.KPOINTS_MESH(default=[2, 2, 2])
+@options.ECUTWFC()
+@options.ECUTRHO()
+@options.HUBBARD_U()
+@options.HUBBARD_V()
+@options.HUBBARD_FILE()
+@options.STARTING_MAGNETIZATION()
+@options.SMEARING()
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
+@options.PARENT_FOLDER()
+@options_core.DRY_RUN()
 @click.option(
     '-z',
     '--calculation-mode',
@@ -50,23 +52,24 @@ CALCS_REQUIRING_PARENT = set(['nscf'])
 )
 @decorators.with_dbenv()
 def launch_calculation(
-    code, structure, pseudo_family, kpoints_mesh, ecutwfc, ecutrho, hubbard_u, hubbard_v, hubbard_file_pk,
+    code, structure, sssp_family, kpoints_mesh, ecutwfc, ecutrho, hubbard_u, hubbard_v, hubbard_file_pk,
     starting_magnetization, smearing, max_num_machines, max_wallclock_seconds, with_mpi, daemon, parent_folder, dry_run,
     mode, unfolded_kpoints
 ):
     """Run a PwCalculation."""
-    from aiida.orm import Dict
-    from aiida.orm.nodes.data.upf import get_pseudos_from_structure
+    from aiida.orm import Dict, KpointsData
     from aiida.plugins import CalculationFactory
     from aiida_quantumespresso.utils.resources import get_default_options
+
+    cutoff_wfc, cutoff_rho = sssp_family.get_cutoffs(structure=structure)
 
     parameters = {
         'CONTROL': {
             'calculation': mode,
         },
         'SYSTEM': {
-            'ecutwfc': ecutwfc,
-            'ecutrho': ecutrho,
+            'ecutwfc': ecutwfc or cutoff_wfc,
+            'ecutrho': ecutrho or cutoff_rho,
         }
     }
 
@@ -91,7 +94,6 @@ def launch_calculation(
         raise click.BadParameter(str(exception))
 
     if unfolded_kpoints:
-        from aiida.orm import KpointsData
         unfolded_list = kpoints_mesh.get_kpoints_mesh(print_list=True)
         kpoints_mesh = KpointsData()
         kpoints_mesh.set_kpoints(unfolded_list)
@@ -99,7 +101,7 @@ def launch_calculation(
     inputs = {
         'code': code,
         'structure': structure,
-        'pseudos': get_pseudos_from_structure(structure, pseudo_family),
+        'pseudos': sssp_family.get_pseudos(structure),
         'kpoints': kpoints_mesh,
         'parameters': Dict(dict=parameters),
         'metadata': {

--- a/aiida_quantumespresso/cli/calculations/pw2wannier90.py
+++ b/aiida_quantumespresso/cli/calculations/pw2wannier90.py
@@ -6,12 +6,13 @@ those hardcoded in the Pw2wannier90Calculation class. We also hardcode some para
 """
 import click
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.params.options import OverridableOption
 from aiida.cmdline.utils import decorators
 
 from ..utils import launch
-from ..utils import options as options_qe
+from ..utils import options
 from . import cmd_launch
 
 NNKP_FILE = OverridableOption(
@@ -41,15 +42,15 @@ WRITE_UNK = OverridableOption(
 
 
 @cmd_launch.command('pw2wannier90')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pw2wannier90'))
-@options_qe.PARENT_FOLDER(required=True, help='RemoteData node containing the output of a PW NSCF calculation.')
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pw2wannier90'))
+@options.PARENT_FOLDER(required=True, help='RemoteData node containing the output of a PW NSCF calculation.')
 @NNKP_FILE()
 @SCDM_MODE()
 @WRITE_UNK()
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_calculation(
     code, parent_folder, nnkp_file, scdm_mode, write_unk, max_num_machines, max_wallclock_seconds, with_mpi, daemon

--- a/aiida_quantumespresso/cli/calculations/q2r.py
+++ b/aiida_quantumespresso/cli/calculations/q2r.py
@@ -2,21 +2,22 @@
 """Command line scripts to launch a `Q2rCalculation` for testing and demonstration purposes."""
 import click
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
 
 from ..utils import launch
-from ..utils import options as options_qe
+from ..utils import options
 from . import cmd_launch
 
 
 @cmd_launch.command('q2r')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.q2r'))
-@options.CALCULATION(required=True)
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.q2r'))
+@options_core.CALCULATION(required=True)
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_calculation(code, calculation, max_num_machines, max_wallclock_seconds, with_mpi, daemon):
     """Run a Q2rCalculation."""

--- a/aiida_quantumespresso/cli/utils/options.py
+++ b/aiida_quantumespresso/cli/utils/options.py
@@ -8,11 +8,7 @@ from aiida.cmdline.params.options import OverridableOption
 from . import validate
 
 STRUCTURE = OverridableOption(
-    '-s', '--structure', type=types.DataParamType(sub_classes=('aiida.data:structure',)), help='StructureData node.'
-)
-
-PSEUDO_FAMILY = OverridableOption(
-    '-p', '--pseudo-family', 'pseudo_family', type=click.STRING, help='Pseudo potential family name.'
+    '-S', '--structure', type=types.DataParamType(sub_classes=('aiida.data:structure',)), help='StructureData node.'
 )
 
 KPOINTS_DISTANCE = OverridableOption(
@@ -138,16 +134,11 @@ CLEAN_WORKDIR = OverridableOption(
 )
 
 ECUTWFC = OverridableOption(
-    '-W', '--ecutwfc', type=click.FLOAT, default=30., show_default=True, help='The plane wave cutoff energy in Ry.'
+    '-W', '--ecutwfc', type=click.FLOAT, show_default=True, help='The plane wave cutoff energy in Ry.'
 )
 
 ECUTRHO = OverridableOption(
-    '-R',
-    '--ecutrho',
-    type=click.FLOAT,
-    default=240.,
-    show_default=True,
-    help='The charge density cutoff energy in Ry.'
+    '-R', '--ecutrho', type=click.FLOAT, show_default=True, help='The charge density cutoff energy in Ry.'
 )
 
 HUBBARD_U = OverridableOption(
@@ -179,7 +170,6 @@ HUBBARD_FILE = OverridableOption(
 )
 
 STARTING_MAGNETIZATION = OverridableOption(
-    '-M',
     '--starting-magnetization',
     nargs=2,
     multiple=True,
@@ -189,7 +179,6 @@ STARTING_MAGNETIZATION = OverridableOption(
 )
 
 SMEARING = OverridableOption(
-    '-S',
     '--smearing',
     nargs=2,
     default=(None, None),

--- a/aiida_quantumespresso/cli/workflows/pw/bands.py
+++ b/aiida_quantumespresso/cli/workflows/pw/bands.py
@@ -2,52 +2,55 @@
 """Command line scripts to launch a `PwBandsWorkChain` for testing and demonstration purposes."""
 import click
 
-from aiida.cmdline.params import options as options_cli
+from aiida.cmdline.params import options as options_core
 from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
+from aiida_sssp.cli import options as options_sssp
 
 from ...utils import launch
-from ...utils import options as options_qe
+from ...utils import options
 from ...utils import validate
 from .. import cmd_launch
 
 
 @cmd_launch.command('pw-bands')
-@options_cli.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pw'))
-@options_qe.STRUCTURE(required=True)
-@options_qe.PSEUDO_FAMILY(required=True)
-@options_qe.KPOINTS_DISTANCE()
-@options_qe.ECUTWFC()
-@options_qe.ECUTRHO()
-@options_qe.HUBBARD_U()
-@options_qe.HUBBARD_V()
-@options_qe.HUBBARD_FILE()
-@options_qe.STARTING_MAGNETIZATION()
-@options_qe.SMEARING()
-@options_qe.AUTOMATIC_PARALLELIZATION()
-@options_qe.CLEAN_WORKDIR()
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pw'))
+@options.STRUCTURE(required=True)
+@options_sssp.SSSP_FAMILY()
+@options.KPOINTS_DISTANCE()
+@options.ECUTWFC()
+@options.ECUTRHO()
+@options.HUBBARD_U()
+@options.HUBBARD_V()
+@options.HUBBARD_FILE()
+@options.STARTING_MAGNETIZATION()
+@options.SMEARING()
+@options.AUTOMATIC_PARALLELIZATION()
+@options.CLEAN_WORKDIR()
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_workflow(
-    code, structure, pseudo_family, kpoints_distance, ecutwfc, ecutrho, hubbard_u, hubbard_v, hubbard_file_pk,
+    code, structure, sssp_family, kpoints_distance, ecutwfc, ecutrho, hubbard_u, hubbard_v, hubbard_file_pk,
     starting_magnetization, smearing, automatic_parallelization, clean_workdir, max_num_machines, max_wallclock_seconds,
     with_mpi, daemon
 ):
     """Run a `PwBandsWorkChain`."""
     # pylint: disable=too-many-statements
-    from aiida.orm import Bool, Float, Str, Dict
+    from aiida.orm import Bool, Float, Dict
     from aiida.plugins import WorkflowFactory
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     builder = WorkflowFactory('quantumespresso.pw.bands').get_builder()
 
+    cutoff_wfc, cutoff_rho = sssp_family.get_cutoffs(structure=structure)
+
     parameters = {
         'SYSTEM': {
-            'ecutwfc': ecutwfc,
-            'ecutrho': ecutrho,
+            'ecutwfc': ecutwfc or cutoff_wfc,
+            'ecutrho': ecutrho or cutoff_rho,
         },
     }
 
@@ -68,22 +71,22 @@ def launch_workflow(
     except ValueError as exception:
         raise click.BadParameter(str(exception))
 
-    pseudo_family = Str(pseudo_family)
+    pseudos = sssp_family.get_pseudos(structure)
     parameters = Dict(dict=parameters)
 
     builder.structure = structure
     builder.relax.base.pw.code = code
     builder.relax.base.pw.parameters = parameters
-    builder.relax.base.pseudo_family = pseudo_family
+    builder.relax.base.pw.pseudos = pseudos
     builder.relax.base.kpoints_distance = Float(kpoints_distance)
     builder.relax.meta_convergence = Bool(False)
     builder.scf.pw.code = code
     builder.scf.pw.parameters = parameters
-    builder.scf.pseudo_family = pseudo_family
+    builder.scf.pw.pseudos = pseudos
     builder.scf.kpoints_distance = Float(kpoints_distance)
     builder.bands.pw.code = code
     builder.bands.pw.parameters = parameters
-    builder.bands.pseudo_family = pseudo_family
+    builder.bands.pw.pseudos = pseudos
 
     if hubbard_file:
         builder.relax.base.pw.hubbard_file = hubbard_file
@@ -96,10 +99,10 @@ def launch_workflow(
         builder.scf.automatic_parallelization = auto_para
         builder.bands.automatic_parallelization = auto_para
     else:
-        options = get_default_options(max_num_machines, max_wallclock_seconds, with_mpi)
-        builder.relax.base.pw.metadata.options = options
-        builder.scf.pw.metadata.options = options
-        builder.bands.pw.metadata.options = options
+        metadata_options = get_default_options(max_num_machines, max_wallclock_seconds, with_mpi)
+        builder.relax.base.pw.metadata.options = metadata_options
+        builder.scf.pw.metadata.options = metadata_options
+        builder.bands.pw.metadata.options = metadata_options
 
     if clean_workdir:
         builder.clean_workdir = Bool(True)

--- a/aiida_quantumespresso/cli/workflows/pw/base.py
+++ b/aiida_quantumespresso/cli/workflows/pw/base.py
@@ -2,51 +2,55 @@
 """Command line scripts to launch a `PwBaseWorkChain` for testing and demonstration purposes."""
 import click
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
+from aiida_sssp.cli import options as options_sssp
 
 from ...utils import defaults
 from ...utils import launch
-from ...utils import options as options_qe
+from ...utils import options
 from ...utils import validate
 from .. import cmd_launch
 
 
 @cmd_launch.command('pw-base')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pw'))
-@options_qe.STRUCTURE(default=defaults.get_structure)
-@options_qe.PSEUDO_FAMILY(required=True)
-@options_qe.KPOINTS_DISTANCE()
-@options_qe.ECUTWFC()
-@options_qe.ECUTRHO()
-@options_qe.HUBBARD_U()
-@options_qe.HUBBARD_V()
-@options_qe.HUBBARD_FILE()
-@options_qe.STARTING_MAGNETIZATION()
-@options_qe.SMEARING()
-@options_qe.AUTOMATIC_PARALLELIZATION()
-@options_qe.CLEAN_WORKDIR()
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pw'))
+@options.STRUCTURE(default=defaults.get_structure)
+@options_sssp.SSSP_FAMILY()
+@options.KPOINTS_DISTANCE()
+@options.ECUTWFC()
+@options.ECUTRHO()
+@options.HUBBARD_U()
+@options.HUBBARD_V()
+@options.HUBBARD_FILE()
+@options.STARTING_MAGNETIZATION()
+@options.SMEARING()
+@options.AUTOMATIC_PARALLELIZATION()
+@options.CLEAN_WORKDIR()
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_workflow(
-    code, structure, pseudo_family, kpoints_distance, ecutwfc, ecutrho, hubbard_u, hubbard_v, hubbard_file_pk,
+    code, structure, sssp_family, kpoints_distance, ecutwfc, ecutrho, hubbard_u, hubbard_v, hubbard_file_pk,
     starting_magnetization, smearing, automatic_parallelization, clean_workdir, max_num_machines, max_wallclock_seconds,
     with_mpi, daemon
 ):
     """Run a `PwBaseWorkChain`."""
-    from aiida.orm import Bool, Float, Str, Dict
+    from aiida.orm import Bool, Float, Dict
     from aiida.plugins import WorkflowFactory
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     builder = WorkflowFactory('quantumespresso.pw.base').get_builder()
 
+    cutoff_wfc, cutoff_rho = sssp_family.get_cutoffs(structure=structure)
+
     parameters = {
         'SYSTEM': {
-            'ecutwfc': ecutwfc,
-            'ecutrho': ecutrho,
+            'ecutwfc': ecutwfc or cutoff_wfc,
+            'ecutrho': ecutrho or cutoff_rho,
         },
     }
 
@@ -70,7 +74,7 @@ def launch_workflow(
     builder.pw.code = code
     builder.pw.structure = structure
     builder.pw.parameters = Dict(dict=parameters)
-    builder.pseudo_family = Str(pseudo_family)
+    builder.pw.pseudos = sssp_family.get_pseudos(structure)
     builder.kpoints_distance = Float(kpoints_distance)
 
     if hubbard_file:

--- a/aiida_quantumespresso/cli/workflows/pw/relax.py
+++ b/aiida_quantumespresso/cli/workflows/pw/relax.py
@@ -2,33 +2,35 @@
 """Command line scripts to launch a `PwRelaxWorkChain` for testing and demonstration purposes."""
 import click
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
+from aiida_sssp.cli import options as options_sssp
 
 from ...utils import launch
-from ...utils import options as options_qe
+from ...utils import options
 from ...utils import validate
 from .. import cmd_launch
 
 
 @cmd_launch.command('pw-relax')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pw'))
-@options_qe.STRUCTURE(required=True)
-@options_qe.PSEUDO_FAMILY(required=True)
-@options_qe.KPOINTS_DISTANCE()
-@options_qe.ECUTWFC()
-@options_qe.ECUTRHO()
-@options_qe.HUBBARD_U()
-@options_qe.HUBBARD_V()
-@options_qe.HUBBARD_FILE()
-@options_qe.STARTING_MAGNETIZATION()
-@options_qe.SMEARING()
-@options_qe.AUTOMATIC_PARALLELIZATION()
-@options_qe.CLEAN_WORKDIR()
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.pw'))
+@options.STRUCTURE(required=True)
+@options_sssp.SSSP_FAMILY()
+@options.KPOINTS_DISTANCE()
+@options.ECUTWFC()
+@options.ECUTRHO()
+@options.HUBBARD_U()
+@options.HUBBARD_V()
+@options.HUBBARD_FILE()
+@options.STARTING_MAGNETIZATION()
+@options.SMEARING()
+@options.AUTOMATIC_PARALLELIZATION()
+@options.CLEAN_WORKDIR()
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.DAEMON()
 @click.option(
     '-f',
     '--final-scf',
@@ -39,21 +41,23 @@ from .. import cmd_launch
 )
 @decorators.with_dbenv()
 def launch_workflow(
-    code, structure, pseudo_family, kpoints_distance, ecutwfc, ecutrho, hubbard_u, hubbard_v, hubbard_file_pk,
+    code, structure, sssp_family, kpoints_distance, ecutwfc, ecutrho, hubbard_u, hubbard_v, hubbard_file_pk,
     starting_magnetization, smearing, automatic_parallelization, clean_workdir, max_num_machines, max_wallclock_seconds,
     with_mpi, daemon, final_scf
 ):
     """Run a `PwRelaxWorkChain`."""
-    from aiida.orm import Bool, Float, Str, Dict
+    from aiida.orm import Bool, Float, Dict
     from aiida.plugins import WorkflowFactory
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     builder = WorkflowFactory('quantumespresso.pw.relax').get_builder()
 
+    cutoff_wfc, cutoff_rho = sssp_family.get_cutoffs(structure=structure)
+
     parameters = {
         'SYSTEM': {
-            'ecutwfc': ecutwfc,
-            'ecutrho': ecutrho,
+            'ecutwfc': ecutwfc or cutoff_wfc,
+            'ecutrho': ecutrho or cutoff_rho,
         },
     }
 
@@ -75,9 +79,9 @@ def launch_workflow(
         raise click.BadParameter(str(exception))
 
     builder.structure = structure
-    builder.base.pseudo_family = Str(pseudo_family)
     builder.base.kpoints_distance = Float(kpoints_distance)
     builder.base.pw.code = code
+    builder.base.pw.pseudos = sssp_family.get_pseudos(structure)
     builder.base.pw.parameters = Dict(dict=parameters)
 
     if hubbard_file:

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -341,7 +341,6 @@ class PwBaseWorkChain(BaseRestartWorkChain):
             args = [self._process_class.__name__, calculation.pk]
             self.report('{}<{}> run with smearing and highest band is occupied'.format(*args))
             self.report('BandsData<{}> has invalid occupations: {}'.format(bands.pk, exception))
-            self.report('{}<{}> had insufficient bands'.format(calculation.process_label, calculation.pk))
 
             nbnd_cur = calculation.outputs.output_parameters.get_dict()['number_of_bands']
             nbnd_new = nbnd_cur + max(int(nbnd_cur * self.defaults.delta_factor_nbnd), self.defaults.delta_minimum_nbnd)

--- a/setup.json
+++ b/setup.json
@@ -87,6 +87,7 @@
     },
     "install_requires": [
         "aiida_core[atomic_tools]~=1.2",
+        "aiida-sssp~=0.1",
         "packaging",
         "qe-tools~=1.1",
         "xmlschema~=1.0"


### PR DESCRIPTION
Fixes #512 

This new library provides functionality to automatically install any
configuration of the SSSP and simplifies working with the pseudo
potentials that ship with it, as well as the recommended cutoffs for
wave functions and charge densities.