### PR TITLE
Fix import or `URLError` which has been removed in `xmlschema`

### DIFF
--- a/aiida_quantumespresso/parsers/parse_xml/pw/parse.py
+++ b/aiida_quantumespresso/parsers/parse_xml/pw/parse.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from distutils.version import StrictVersion
 import numpy as np
+from urllib.error import URLError
+
 from xmlschema import XMLSchema
 from xmlschema.etree import ElementTree
-from xmlschema.exceptions import URLError
+from qe_tools.constants import hartree_to_ev, bohr_to_ang, ry_to_ev
 
 from aiida_quantumespresso.utils.mapping import get_logging_container
-from qe_tools.constants import hartree_to_ev, bohr_to_ang, ry_to_ev
 
 from .exceptions import XMLParseError
 from .legacy import parse_pw_xml_pre_6_2

--- a/setup.json
+++ b/setup.json
@@ -89,7 +89,7 @@
         "aiida_core[atomic_tools]~=1.2",
         "packaging",
         "qe-tools~=1.1",
-        "xmlschema~=1.0"
+        "xmlschema~=1.2"
     ],
     "license": "MIT License",
     "name": "aiida_quantumespresso",


### PR DESCRIPTION
Fixes #523 

As of `xmlschema==1.2.0` the `xmlschema.exceptions.URLError` exception
has been removed. This was just an alias for Python 2 and 3 compatibility
reasons, which now that Python 2 support is dropped can be removed.
Simply using `from urllib.error import URLError` addressed the problem.