### PR TITLE
Remove `prospector` and run `yapf` and `pylint` from repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,10 @@ repos:
                 tests/.*.in$
             )$
 
--   repo: https://github.com/PyCQA/prospector
-    rev: 1.2.0
+-   repo: https://github.com/PyCQA/pylint
+    rev: pylint-2.5.2
     hooks:
-    -   id: prospector
+    -   id: pylint
         language: system
         exclude: &exclude_files >
             (?x)^(
@@ -32,15 +32,16 @@ repos:
         exclude: *exclude_files
         args: ['--ignore=D104,D202,D203,D213']
 
--   repo: local
+-   repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.30.0
     hooks:
     -   id: yapf
         name: yapf
-        entry: yapf
-        language: system
         types: [python]
         args: ['-i']
 
+-   repo: local
+    hooks:
     -   id: version-number
         name: Check consistency in version number
         entry: python ./utils/validate_version_number.py

--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,8 @@ disable=bad-continuation,
         no-else-raise,
         useless-object-inheritance,
         inconsistent-return-statements,
-        import-outside-toplevel
+        import-outside-toplevel,
+        duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/setup.json
+++ b/setup.json
@@ -68,8 +68,7 @@
     "extras_require": {
         "pre-commit": [
             "pre-commit~=2.2",
-            "prospector~=1.2",
-            "yapf~=0.29"
+            "pylint~=2.5.0"
         ],
         "tests": [
             "pgtest~=1.3",


### PR DESCRIPTION
Fixes #525 

The `prospector` tools has been giving a lot of problems with dependency
incompatibilities since we have been using it and we really only use it
to run `pylint`. However, this is easy to run directly as well from a
remote, specifying the desired revision.

We do the same for `yapf` and remove the explicit dependency from the
`pre-commit` extra since the latter was not pinning a particular version
which could cause arbitrary style changes in different environments that
just happen to have a slightly different version.