### PR TITLE
Use 'get_hash' instead of 'id' when comparing UpfData in test.

### DIFF
--- a/tests/tools/test_immigrate.py
+++ b/tests/tools/test_immigrate.py
@@ -39,7 +39,9 @@ def test_create_builder(
 
     assert builder['code'] == code
     assert builder['metadata'] == metadata
-    assert builder['pseudos']['Si'].id == si_upf.id
+    pseudo_hash = si_upf.get_hash()
+    assert pseudo_hash is not None
+    assert builder['pseudos']['Si'].get_hash() == pseudo_hash
     assert builder['parameters'].get_dict() == {
         'CONTROL': {
             'calculation': 'scf',


### PR DESCRIPTION
In the 'immigrate' tests, the ``UpfData`` for Si was compared by id. When using an AIIDA_TEST_PROFILE, this led to errors because a different `UpfData` of the same kind could already be present, and the immigration did not necessarily pick the one created for the test.
To make the test independent of the exact PK, they are now compared by hash.