### PR TITLE
CI: update `actions/setup-python` to `@v2` and pin Python 3.7.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
                     pip-docs-
 
         -   name: Set up Python
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: 3.8
 
@@ -52,7 +52,7 @@ jobs:
                     pip-pre-commit-
 
         -   name: Set up Python
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: 3.8
 
@@ -70,7 +70,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7, 3.8]
+                python-version: [3.5, 3.6, 3.7.7, 3.8]
 
         services:
             postgres:
@@ -99,7 +99,7 @@ jobs:
                     pip-${{ matrix.python-version }}-tests
 
         -   name: Set up Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
The `actions/setup-python` action starting installing Python `3.7.8` as
of recently, which was crashing at the `pip` install step. Pinning the
Python version to `3.7.7` does not seem to suffer from the same problem.
Note that for version pinning an upgrade to `actions/setup-python@v2`
was necessary.