### PR TITLE
Small change to test_pw.py.

### DIFF
--- a/tests/parsers/test_pw.py
+++ b/tests/parsers/test_pw.py
@@ -22,7 +22,7 @@ def generate_inputs(generate_structure):
             'structure': generate_structure(),
             'kpoints': kpoints,
             'parameters': orm.Dict(dict=parameters),
-            'settings': orm.Dict(dict=settings) or orm.Dict(),
+            'settings': orm.Dict(dict=settings),
             'metadata': metadata or {}
         })
 


### PR DESCRIPTION
The second part of the statement `orm.Dict(dict=settings) or orm.Dict()`
is never executed since `orm.Dict(dict=settings)` can't be a falsy
object. Moreover, if `settings` is equal to `None` or `{}`, the
`orm.Dict(dict=settings)` is exactly the same as `orm.Dict()`. Hence
`or orm.Dict()` can be safely removed.