### PR TITLE
Fix the incorrect usage of repository interface of `aiida-core`

### DIFF
--- a/aiida_quantumespresso/parsers/cp.py
+++ b/aiida_quantumespresso/parsers/cp.py
@@ -44,11 +44,10 @@ class CpParser(Parser):
             # TODO: Add an error for this counter
             return self.exit(self.exit_codes.ERROR_MISSING_XML_FILE)
 
-        # Let's pass file handlers to this function
-        out_dict, _raw_successful = parse_cp_raw_output(
-            out_folder.open(stdout_filename), out_folder.open(xml_files[0]),
-            out_folder.open(self.node.process_class._FILE_XML_PRINT_COUNTER_BASENAME)
-        )
+        output_stdout = out_folder.get_object_content(stdout_filename)
+        output_xml = out_folder.get_object_content(xml_files[0])
+        output_xml_counter = out_folder.get_object_content(self.node.process_class._FILE_XML_PRINT_COUNTER_BASENAME)
+        out_dict, _raw_successful = parse_cp_raw_output(output_stdout, output_xml, output_xml_counter)
 
         # parse the trajectory. Units in Angstrom, picoseconds and eV.
         # append everthing in the temporary dictionary raw_trajectory
@@ -96,7 +95,8 @@ class CpParser(Parser):
 
         # =============== EVP trajectory ============================
         try:
-            matrix = numpy.genfromtxt(out_folder.open('{}.evp'.format(self._node.process_class._PREFIX)))
+            with out_folder.open('{}.evp'.format(self._node.process_class._PREFIX)) as handle:
+                matrix = numpy.genfromtxt(handle)
             # there might be a different format if the matrix has one row only
             try:
                 matrix.shape[1]

--- a/aiida_quantumespresso/parsers/neb.py
+++ b/aiida_quantumespresso/parsers/neb.py
@@ -60,13 +60,12 @@ class NebParser(Parser):
         # load the neb input parameters dictionary
         neb_input_dict = self.node.inputs.parameters.get_dict()
 
-        stdout_abspath = os.path.join(out_folder._repository._get_base_folder().abspath, filename_stdout)
-
         # First parse the Neb output
         try:
-            neb_out_dict, iteration_data, raw_successful = parse_raw_output_neb(stdout_abspath, neb_input_dict)
+            stdout = out_folder.get_object_content(filename_stdout)
+            neb_out_dict, iteration_data, raw_successful = parse_raw_output_neb(stdout, neb_input_dict)
             # TODO: why do we ignore raw_successful ?
-        except QEOutputParsingError as exc:
+        except (OSError, QEOutputParsingError):
             return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
 
         for warn_type in ['warnings', 'parser_warnings']:

--- a/aiida_quantumespresso/parsers/parse_raw/cp.py
+++ b/aiida_quantumespresso/parsers/parse_raw/cp.py
@@ -149,30 +149,27 @@ def parse_cp_xml_counter_output(data):
     return parsed_data
 
 
-def parse_cp_raw_output(out_file, xml_file=None, xml_counter_file=None):
+def parse_cp_raw_output(stdout, output_xml=None, output_xml_counter=None):
 
     parser_info = get_parser_info(parser_info_template='aiida-quantumespresso parser cp.x v{}')
 
-    # analyze the xml
-    if xml_file is not None:
-        xml_data = parse_cp_xml_output(xml_file.read())
-    else:
+    if output_xml is None:
         parser_info['parser_warnings'].append('Skipping the parsing of the xml file.')
         xml_data = {}
-
-    # analyze the counter file, which keeps info on the steps
-    if xml_counter_file is not None:
-        xml_counter_data = parse_cp_xml_counter_output(xml_counter_file.read())
     else:
+        xml_data = parse_cp_xml_output(output_xml)
+
+    # XML counter file, which keeps info on the steps
+    if output_xml_counter is None:
         xml_counter_data = {}
+    else:
+        xml_counter_data = parse_cp_xml_counter_output(output_xml_counter)
 
-    # analyze the standard output
-    out_lines = out_file.readlines()
-
+    stdout = stdout.split('\n')
     # understand if the job ended smoothly
-    job_successful = any('JOB DONE' in line for line in reversed(out_lines))
+    job_successful = any('JOB DONE' in line for line in reversed(stdout))
 
-    out_data = parse_cp_text_output(out_lines, xml_data)
+    out_data = parse_cp_text_output(stdout, xml_data)
 
     for key in out_data.keys():
         if key in list(xml_data.keys()):


### PR DESCRIPTION
Fixes #548 

The following illegal uses have been fixed:

 * `Node.open` has to be use in a context manager
 * `Node._get_base_folder` will soon be removed and cannot be used.