### PR TITLE
Implement parallelization options as explicit inputs.

### DIFF
--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -43,6 +43,8 @@ class PwCalculation(BasePwCpInputGenerator):
     # Not using symlink in pw to allow multiple nscf to run on top of the same scf
     _default_symlink_usage = False
 
+    _ENABLED_PARALLELIZATION_FLAGS = ('npool', 'nband', 'ntg', 'ndiag')
+
     @classproperty
     def xml_filepaths(cls):
         """Return a list of XML output filepaths relative to the remote working directory that should be retrieved."""

--- a/docs/source/user_guide/calculation_plugins/pw.rst
+++ b/docs/source/user_guide/calculation_plugins/pw.rst
@@ -99,6 +99,10 @@ This can then be used directly in the process builder of for example a ``PwCalcu
 * **settings**, class :py:class:`Dict <aiida.orm.nodes.data.dict.Dict>` (optional)
   An optional dictionary that activates non-default operations. For a list of possible
   values to pass, see the section on the :ref:`advanced features <pw-advanced-features>`.
+* **parallelization**, class :py:class:`Dict <aiida.orm.nodes.data.dict.Dict>` (optional)
+  An optional dictionary to specify the parallelization flags passed to `pw.x` on the
+  command line. The dictionary maps flag names (type `str`) to their values (type `int`).
+  Allowed flag names are `npool`, `nband`, `ntg`, and `ndiag`.
 * **parent_folder**, class :py:class:`RemoteData <aiida.orm.nodes.data.dict.Dict>` (optional)
   If specified, the scratch folder coming from a previous QE calculation is
   copied in the scratch of the new calculation.


### PR DESCRIPTION
Fixes #405.

If any parallelization option is already specified in the `settings['CMDLINE']`, a `DeprecationWarning` is issued. However, the value from `settings['CMDLINE']` still takes precedence. This allows us to implement the defaults at the level of the input
port, without having to care about it later on.

The `BasePwCpInputGenerator` is given three class attributes:
- `_ALLOWED_PARALLELIZATION_FLAGS` is a list of tuples (flag_name, default, help), of all possible flags
- `_ENABLED_PARALLELIZATION_FLAGS` is a list of flag names that are implemented in a particular code.
- `_PARALLELIZATION_FLAG_ALIASES` is used to detect all possible variations on a flag name.

TODO:
- [x] Testing
- [x] Documentation: Not sure where best to put this - the auto-generated help will be there in any case.
- [x] Check if flag names are case sensitive. If not, this needs to be taken into account when checking for existing flags. **Update:** If flags are capitalized differently (e.g. `-nPools`) QE will simply ignore them.
- [x] Set `_ENABLED_PARALLELIZATION_FLAGS` for codes other than pw.x. **Help needed:** I have no idea what flags other codes support.
- [x] PW accepts `-nimage`, but I'm not sure if passing that makes any sense (a PW calculation only treats one "image"). If it doesn't, we should probably disable `nimage` in the `PwCalculation`. **Update:** Disallowed `-nimage` for `pw.x` for now - if there is in fact a use case, we can always re-enable it.