### PR TITLE
`PwRelaxWorkChain`: expose `PwBaseWorkChain` separately for final SCF

### DIFF
--- a/aiida_quantumespresso/cli/workflows/pw/relax.py
+++ b/aiida_quantumespresso/cli/workflows/pw/relax.py
@@ -93,6 +93,12 @@ def launch_workflow(
         builder.clean_workdir = Bool(True)
 
     if final_scf:
-        builder.final_scf = Bool(True)
+        builder.base_final_scf.pseudo_family = Str(pseudo_family)
+        builder.base_final_scf.kpoints_distance = Float(kpoints_distance)
+        builder.base_final_scf.pw.code = code
+        builder.base_final_scf.pw.parameters = Dict(dict=parameters)
+        builder.base_final_scf.pw.metadata.options = get_default_options(
+            max_num_machines, max_wallclock_seconds, with_mpi
+        )
 
     launch.launch_process(builder, daemon)

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -11,6 +11,17 @@ PwCalculation = CalculationFactory('quantumespresso.pw')
 PwBaseWorkChain = WorkflowFactory('quantumespresso.pw.base')
 
 
+def validate_final_scf(value, _):
+    """Validate the final scf input."""
+    if isinstance(value, orm.Bool) and value:
+        import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning
+        warnings.warn(
+            'this input is deprecated and will be removed. If you want to run a final scf, specify the inputs that '
+            'should be used in the `base_final_scf` namespace.', AiidaDeprecationWarning
+        )
+
+
 class PwRelaxWorkChain(WorkChain):
     """Workchain to relax a structure using Quantum ESPRESSO pw.x."""
 
@@ -21,9 +32,13 @@ class PwRelaxWorkChain(WorkChain):
         super().define(spec)
         spec.expose_inputs(PwBaseWorkChain, namespace='base',
             exclude=('clean_workdir', 'pw.structure', 'pw.parent_folder'),
-            namespace_options={'help': 'Inputs for the `PwBaseWorkChain`.'})
+            namespace_options={'help': 'Inputs for the `PwBaseWorkChain` for the main relax loop.'})
+        spec.expose_inputs(PwBaseWorkChain, namespace='base_final_scf',
+            exclude=('clean_workdir', 'pw.structure', 'pw.parent_folder'),
+            namespace_options={'required': False, 'populate_defaults': False,
+                'help': 'Inputs for the `PwBaseWorkChain` for the final scf.'})
         spec.input('structure', valid_type=orm.StructureData, help='The inputs structure.')
-        spec.input('final_scf', valid_type=orm.Bool, default=lambda: orm.Bool(False),
+        spec.input('final_scf', valid_type=orm.Bool, default=lambda: orm.Bool(False), validator=validate_final_scf,
             help='If `True`, a final SCF calculation will be performed on the successfully relaxed structure.')
         spec.input('relaxation_scheme', valid_type=orm.Str, default=lambda: orm.Str('vc-relax'),
             help='The relaxation scheme to use: choose either `relax` or `vc-relax` for variable cell relax.')
@@ -63,6 +78,13 @@ class PwRelaxWorkChain(WorkChain):
         self.ctx.is_converged = False
         self.ctx.iteration = 0
 
+        if self.inputs.final_scf and 'base_final_scf' in self.inputs:
+            raise ValueError('cannot specify `final_scf=True` and `base_final_scf` at the same time.')
+        elif self.inputs.final_scf:
+            self.ctx.final_scf_inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, namespace='base'))
+        elif 'base_final_scf' in self.inputs:
+            self.ctx.final_scf_inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, namespace='base_final_scf'))
+
     def should_run_relax(self):
         """Return whether a relaxation workchain should be run.
 
@@ -77,7 +99,7 @@ class PwRelaxWorkChain(WorkChain):
         If the maximum number of meta convergence iterations has been exceeded and convergence has not been reached, the
         structure cannot be considered to be relaxed and the final scf should not be run.
         """
-        return self.inputs.final_scf.value and self.ctx.is_converged
+        return self.ctx.is_converged and 'final_scf_inputs' in self.ctx
 
     def run_relax(self):
         """Run the `PwBaseWorkChain` to run a relax `PwCalculation`."""
@@ -166,7 +188,7 @@ class PwRelaxWorkChain(WorkChain):
 
     def run_final_scf(self):
         """Run the `PwBaseWorkChain` to run a final scf `PwCalculation` for the relaxed structure."""
-        inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, namespace='base'))
+        inputs = self.ctx.final_scf_inputs
         inputs.pw.structure = self.ctx.current_structure
         inputs.pw.parameters = inputs.pw.parameters.get_dict()
 


### PR DESCRIPTION
Fixes #566 

This allows a user to specify different inputs for the final SCF step,
such as using different resources. This makes sense since the resources
required for the final SCF are often way less compared to the relaxation
steps in the main loop of the workflow.

The `final_scf` input, which was a boolean to trigger the computation of
the final SCF, is replaced by an input namespace that exposes the inputs
of the `PwBaseWorkChain`. If the namespace is defined, it signals that
the final SCF should be performed, otherwise it is skipped.