### PR TITLE
CI: revert workaround that installs Python 3.7.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7.7, 3.8]
+                python-version: [3.5, 3.6, 3.7, 3.8]
 
         services:
             postgres:


### PR DESCRIPTION
Sometime ago there was a bug on GHA that didn't work with the latest
path version of Python 3.7 and as a workaround we installed the previous
path 3.7.7 that did work. Reverting this change now so we test against
the latest patch version.