### PR TITLE
Drop support for Python 3.5 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7, 3.8]
+                python-version: [3.6, 3.7, 3.8]
 
         services:
             postgres:

--- a/setup.json
+++ b/setup.json
@@ -3,7 +3,6 @@
     "author_email": "developers@aiida.net",
     "classifiers": [
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -97,7 +96,7 @@
     ],
     "license": "MIT License",
     "name": "aiida_quantumespresso",
-    "python_requires": ">=3.5",
+    "python_requires": ">=3.6",
     "url": "https://github.com/aiidateam/aiida-quantumespresso",
     "version": "3.2.0"
 }

--- a/tests/parsers/test_pp.py
+++ b/tests/parsers/test_pp.py
@@ -289,19 +289,16 @@ def test_pp_default_3d_keep_plot_file(generate_calc_job_node, generate_parser, g
     entry_point_calc_job = 'quantumespresso.pp'
     entry_point_parser = 'quantumespresso.pp'
 
-    # Need to cast the `tmpdir` which can be a `Path` object which is not yet supported in Python 3.5
-    dirpath = str(tmpdir)
-
     attributes = {'options': {'keep_plot_file': False}, 'retrieve_temporary_list': ['aiida.fileout']}
     node = generate_calc_job_node(
         entry_point_calc_job,
         test_name='default_3d',
         inputs=generate_inputs_3d,
         attributes=attributes,
-        retrieve_temporary=(dirpath, ['aiida.fileout'])
+        retrieve_temporary=(tmpdir, ['aiida.fileout'])
     )
     parser = generate_parser(entry_point_parser)
-    results, calcfunction = parser.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=dirpath)
+    results, calcfunction = parser.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=tmpdir)
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message


### PR DESCRIPTION
Fixes #575 

Python 3.5 is EOL as of September 13 2020. CI testing will now only be
done against Python 3.6 and 3.8.