### PR TITLE
Replace old format string interpolation with f-strings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,15 @@ repos:
                 tests/.*.in$
             )$
 
+-   repo: https://github.com/ikamensh/flynt/
+    rev: '0.55'
+    hooks:
+    -   id: flynt
+        args: [
+            '--line-length=120',
+            '--fail-on-change',
+        ]
+
 -   repo: https://github.com/PyCQA/pydocstyle
     rev: 5.0.2
     hooks:

--- a/aiida_quantumespresso/calculations/__init__.py
+++ b/aiida_quantumespresso/calculations/__init__.py
@@ -6,7 +6,6 @@ import os
 from aiida import orm
 from aiida.common import datastructures, exceptions
 from aiida.common.lang import classproperty
-
 from qe_tools.converters import get_parameters_from_cell
 
 from aiida_quantumespresso.utils.convert import convert_input_to_namelist_entry
@@ -163,7 +162,7 @@ class BasePwCpInputGenerator(CalcJob):
 
         # Create an `.EXIT` file if `only_initialization` flag in `settings` is set to `True`
         if settings.pop('ONLY_INITIALIZATION', False):
-            with folder.open('{}.EXIT'.format(self._PREFIX), 'w') as handle:
+            with folder.open(f'{self._PREFIX}.EXIT', 'w') as handle:
                 handle.write('\n')
 
         # Check if specific inputs for the ENVIRON module where specified
@@ -240,7 +239,7 @@ class BasePwCpInputGenerator(CalcJob):
 
         if settings:
             unknown_keys = ', '.join(list(settings.keys()))
-            raise exceptions.InputValidationError('`settings` contained unexpected keys: {}'.format(unknown_keys))
+            raise exceptions.InputValidationError(f'`settings` contained unexpected keys: {unknown_keys}')
 
         return calcinfo
 
@@ -332,7 +331,7 @@ class BasePwCpInputGenerator(CalcJob):
                 )
 
             kind_names.append(kind.name)
-            atomic_species_card_list.append('{} {} {}\n'.format(kind.name.ljust(6), kind.mass, filename))
+            atomic_species_card_list.append(f'{kind.name.ljust(6)} {kind.mass} {filename}\n')
 
         # I join the lines, but I resort them using the alphabetical order of
         # species, given by the kind_names list. I also store the mapping_species
@@ -370,13 +369,11 @@ class BasePwCpInputGenerator(CalcJob):
             for i, this_atom_fix in enumerate(fixed_coords):
                 if len(this_atom_fix) != 3:
                     raise exceptions.InputValidationError(
-                        'fixed_coords({:d}) has not length three'
-                        ''.format(i + 1))
+                        f'fixed_coords({i + 1:d}) has not length three')
                 for fixed_c in this_atom_fix:
                     if not isinstance(fixed_c, bool):
                         raise exceptions.InputValidationError(
-                            'fixed_coords({:d}) has non-boolean '
-                            'elements'.format(i + 1))
+                            f'fixed_coords({i + 1:d}) has non-boolean elements')
 
                 if_pos_values = [cls._if_pos(_) for _ in this_atom_fix]
                 fixed_coords_strings.append(
@@ -418,7 +415,7 @@ class BasePwCpInputGenerator(CalcJob):
 
                 # Checking that all 3 dimensions are specified:
                 if len(vector) != 3:
-                    raise exceptions.InputValidationError('Forces({}) for {} has not length three'.format(vector, site))
+                    raise exceptions.InputValidationError(f'Forces({vector}) for {site} has not length three')
 
                 lines.append('{0} {1:18.10f} {2:18.10f} {3:18.10f}\n'.format(site.kind_name.ljust(6), *vector))
 
@@ -444,7 +441,7 @@ class BasePwCpInputGenerator(CalcJob):
                 # Checking that all 3 dimensions are specified:
                 if len(vector) != 3:
                     raise exceptions.InputValidationError(
-                        'Velocities({}) for {} has not length three'.format(vector, site)
+                        f'Velocities({vector}) for {site} has not length three'
                     )
 
                 lines.append('{0} {1:18.10f} {2:18.10f} {3:18.10f}\n'.format(site.kind_name.ljust(6), *vector))
@@ -467,7 +464,7 @@ class BasePwCpInputGenerator(CalcJob):
                     tolerance=settings.pop('IBRAV_CELL_TOLERANCE', 1e-6)
                 )
             except ValueError as exc:
-                raise QEInputValidationError('Cannot get structure parameters from cell: {}'.format(exc)) from exc
+                raise QEInputValidationError(f'Cannot get structure parameters from cell: {exc}') from exc
             input_params['SYSTEM'].update(structure_parameters)
         input_params['SYSTEM']['nat'] = len(structure.sites)
         input_params['SYSTEM']['ntyp'] = len(structure.kinds)
@@ -526,7 +523,7 @@ class BasePwCpInputGenerator(CalcJob):
             else:
                 kpoints_type = 'crystal'
 
-            kpoints_card_list = ['K_POINTS {}\n'.format(kpoints_type)]
+            kpoints_card_list = [f'K_POINTS {kpoints_type}\n']
 
             if kpoints_type == 'automatic':
                 if any([i not in [0, 0.5] for i in offset]):
@@ -540,11 +537,10 @@ class BasePwCpInputGenerator(CalcJob):
                 # nothing to be written in this case
                 pass
             else:
-                kpoints_card_list.append('{:d}\n'.format(num_kpoints))
+                kpoints_card_list.append(f'{num_kpoints:d}\n')
                 for kpoint, weight in zip(kpoints_list, weights):
                     kpoints_card_list.append(
-                        '  {:18.10f} {:18.10f} {:18.10f} {:18.10f}'
-                        '\n'.format(kpoint[0], kpoint[1], kpoint[2], weight))
+                        f'  {kpoint[0]:18.10f} {kpoint[1]:18.10f} {kpoint[2]:18.10f} {weight:18.10f}\n')
 
             kpoints_card = ''.join(kpoints_card_list)
             del kpoints_card_list
@@ -577,7 +573,7 @@ class BasePwCpInputGenerator(CalcJob):
 
         inputfile = ''
         for namelist_name in namelists_toprint:
-            inputfile += '&{0}\n'.format(namelist_name)
+            inputfile += f'&{namelist_name}\n'
             # namelist content; set to {} if not present, so that we leave an empty namelist
             namelist = input_params.pop(namelist_name, {})
             for key, value in sorted(namelist.items()):
@@ -623,7 +619,7 @@ def _case_transform_dict(dictionary, dict_name, func_name, transform):
     from collections import Counter
 
     if not isinstance(dictionary, dict):
-        raise TypeError('{} accepts only dictionaries as argument, got {}'.format(func_name, type(dictionary)))
+        raise TypeError(f'{func_name} accepts only dictionaries as argument, got {type(dictionary)}')
     new_dict = dict((transform(str(k)), v) for k, v in dictionary.items())
     if len(new_dict) != len(dictionary):
         num_items = Counter(transform(str(k)) for k in dictionary.keys())

--- a/aiida_quantumespresso/calculations/cp.py
+++ b/aiida_quantumespresso/calculations/cp.py
@@ -31,7 +31,7 @@ class CpCalculation(BasePwCpInputGenerator):
     _FILE_XML_PRINT_COUNTER_BASENAME = 'print_counter.xml'
     _FILE_XML_PRINT_COUNTER = os.path.join(
         BasePwCpInputGenerator._OUTPUT_SUBFOLDER,
-        '{}_{}.save'.format(BasePwCpInputGenerator._PREFIX, _CP_WRITE_UNIT_NUMBER),
+        f'{BasePwCpInputGenerator._PREFIX}_{_CP_WRITE_UNIT_NUMBER}.save',
         _FILE_XML_PRINT_COUNTER_BASENAME,
     )
 
@@ -90,20 +90,20 @@ class CpCalculation(BasePwCpInputGenerator):
     _internal_retrieve_list = [
         os.path.join(
             BasePwCpInputGenerator._OUTPUT_SUBFOLDER,
-            '{}.{}'.format(BasePwCpInputGenerator._PREFIX, ext),
+            f'{BasePwCpInputGenerator._PREFIX}.{ext}',
         ) for ext in _cp_ext_list
     ] + [_FILE_XML_PRINT_COUNTER]
 
     # in restarts, it will copy from the parent the following
     _restart_copy_from = os.path.join(
         BasePwCpInputGenerator._OUTPUT_SUBFOLDER,
-        '{}_{}.save'.format(BasePwCpInputGenerator._PREFIX, _CP_WRITE_UNIT_NUMBER),
+        f'{BasePwCpInputGenerator._PREFIX}_{_CP_WRITE_UNIT_NUMBER}.save',
     )
 
     # in restarts, it will copy the previous folder in the following one
     _restart_copy_to = os.path.join(
         BasePwCpInputGenerator._OUTPUT_SUBFOLDER,
-        '{}_{}.save'.format(BasePwCpInputGenerator._PREFIX, _CP_READ_UNIT_NUMBER),
+        f'{BasePwCpInputGenerator._PREFIX}_{_CP_READ_UNIT_NUMBER}.save',
     )
 
     @classproperty
@@ -115,7 +115,7 @@ class CpCalculation(BasePwCpInputGenerator):
         for filename in cls.xml_filenames:
             filepath = os.path.join(
                 cls._OUTPUT_SUBFOLDER,
-                '{}_{}.save'.format(cls._PREFIX, cls._CP_WRITE_UNIT_NUMBER),
+                f'{cls._PREFIX}_{cls._CP_WRITE_UNIT_NUMBER}.save',
                 filename,
             )
             filepaths.append(filepath)

--- a/aiida_quantumespresso/calculations/epw.py
+++ b/aiida_quantumespresso/calculations/epw.py
@@ -86,7 +86,7 @@ class EpwCalculation(CalcJob):
         parent_calc_nscf = parent_folder_nscf.creator
 
         if parent_calc_nscf is None:
-            raise exceptions.NotExistent('parent_folder<{}> has no parent calculation'.format(parent_folder_nscf.pk))
+            raise exceptions.NotExistent(f'parent_folder<{parent_folder_nscf.pk}> has no parent calculation')
 
         # Also, the parent calculation must be on the same computer
         if not self.node.computer.uuid == parent_calc_nscf.computer.uuid:
@@ -188,13 +188,13 @@ class EpwCalculation(CalcJob):
 
         # add here the list of point coordinates
         if len(list_of_points) > 1:
-            postpend_text = '{} cartesian\n'.format(len(list_of_points))
+            postpend_text = f'{len(list_of_points)} cartesian\n'
             for points in list_of_points:
                 postpend_text += '{0:18.10f} {1:18.10f} {2:18.10f} \n'.format(*points)
 
         with folder.open(self.metadata.options.input_filename, 'w') as infile:
             for namelist_name in namelists_toprint:
-                infile.write('&{0}\n'.format(namelist_name))
+                infile.write(f'&{namelist_name}\n')
                 # namelist content; set to {} if not present, so that we leave an empty namelist
                 namelist = parameters.pop(namelist_name, {})
                 for key, value in sorted(namelist.items()):
@@ -282,6 +282,6 @@ class EpwCalculation(CalcJob):
 
         if settings:
             unknown_keys = ', '.join(list(settings.keys()))
-            raise exceptions.InputValidationError('`settings` contained unexpected keys: {}'.format(unknown_keys))
+            raise exceptions.InputValidationError(f'`settings` contained unexpected keys: {unknown_keys}')
 
         return calcinfo

--- a/aiida_quantumespresso/calculations/helpers/__init__.py
+++ b/aiida_quantumespresso/calculations/helpers/__init__.py
@@ -26,26 +26,26 @@ def _check_and_convert(keyword, val, expected_type):
         if isinstance(val, bool):
             outval = val
         else:
-            raise TypeError('Expected a boolean for keyword {}, found {} instead'.format(keyword, type(val)))
+            raise TypeError(f'Expected a boolean for keyword {keyword}, found {type(val)} instead')
     elif expected_type.upper() == 'REAL':
         if isinstance(val, int):
             outval = float(val)
         elif isinstance(val, float):
             outval = val
         else:
-            raise TypeError('Expected a float for keyword {}, found {} instead'.format(keyword, type(val)))
+            raise TypeError(f'Expected a float for keyword {keyword}, found {type(val)} instead')
     elif expected_type.upper() == 'INTEGER':
         if isinstance(val, int):
             outval = val
         else:
-            raise TypeError('Expected an integer for keyword {}, found {} instead'.format(keyword, type(val)))
+            raise TypeError(f'Expected an integer for keyword {keyword}, found {type(val)} instead')
     elif expected_type.upper() == 'CHARACTER':
         if isinstance(val, str):
             outval = val
         else:
-            raise TypeError('Expected a string for keyword {}, found {} instead'.format(keyword, type(val)))
+            raise TypeError(f'Expected a string for keyword {keyword}, found {type(val)} instead')
     else:
-        raise InternalError('Unexpected type check for keyword {}: {})'.format(keyword, expected_type.upper()))
+        raise InternalError(f'Unexpected type check for keyword {keyword}: {expected_type.upper()})')
 
     return outval
 
@@ -137,7 +137,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
         for namelist, content in input_params.items():
             if not isinstance(content, dict):
                 raise QEInputValidationError(
-                    "The content associated to the namelist '{}' must be a dictionary".format(namelist)
+                    f"The content associated to the namelist '{namelist}' must be a dictionary"
                 )
             all_input_namelists.add(namelist)
             for key, value in content.items():
@@ -181,7 +181,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
     module_dir = os.path.dirname(__file__)
     if module_dir == '':
         module_dir = os.curdir
-    xml_path = os.path.join(module_dir, 'INPUT_PW-{}.xml'.format(version))
+    xml_path = os.path.join(module_dir, f'INPUT_PW-{version}.xml')
     try:
         with open(xml_path, 'r') as handle:
             dom = xml.dom.minidom.parse(handle)
@@ -200,10 +200,9 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
         if pos == 0:
             add_str = ' (the version you specified is too old)'
         else:
-            add_str = ' (the older, closest version you can use is {})'.format(strictversions[pos - 1])
+            add_str = f' (the older, closest version you can use is {strictversions[pos - 1]})'
         raise QEInputValidationError(
-            'Unknown Quantum Espresso version: {}. '
-            'Available versions: {};{}'.format(version, ', '.join(versions), add_str)
+            f"Unknown Quantum Espresso version: {version}. Available versions: {', '.join(versions)};{add_str}"
         ) from exception
 
     # ========== List of known PW variables (from XML file) ===============
@@ -271,7 +270,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
         start_val = dim.getAttribute('start')
         if start_val != '1':
             raise InternalError(
-                "Wrong start value '{}' in input array (dimension) {}".format(start_val, dim.getAttribute('name'))
+                f"Wrong start value '{start_val}' in input array (dimension) {dim.getAttribute('name')}"
             )
         # I save the string as it is; somewhere else I will check for its value
         valid_dims[dim.getAttribute('name').lower()]['end_val'] = dim.getAttribute('end')
@@ -322,7 +321,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
     # =================== Check for blocked keywords ===========================
     for keyword in input_params_internal:
         if keyword in blocked_kws:
-            err_str = "You should not provide explicitly keyword '{}'.".format(keyword)
+            err_str = f"You should not provide explicitly keyword '{keyword}'."
             if stop_at_first_error:
                 raise QEInputValidationError(err_str)
             else:
@@ -397,15 +396,13 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
                 internal_dict[namelist_name][keyword] = _check_and_convert(keyword, value, found_var['expected_type'])
             except KeyError as exception:
                 if namelist_name in all_namelists:
-                    err_str = 'Error, namelist {} not valid for calculation type {}'.format(
-                        namelist_name, calculation_type
-                    )
+                    err_str = f'Error, namelist {namelist_name} not valid for calculation type {calculation_type}'
                     if stop_at_first_error:
                         raise QEInputValidationError(err_str) from exception
                     else:
                         errors_list.append(err_str)
                 else:
-                    err_str = 'Error, unknown namelist {}'.format(namelist_name)
+                    err_str = f'Error, unknown namelist {namelist_name}'
                     if stop_at_first_error:
                         raise QEInputValidationError(err_str) from exception
                     else:
@@ -433,9 +430,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
             # I accept only ntyp or an integer as end_val
             if found_var['end_val'] == 'ntyp':
                 if not isinstance(value, dict):
-                    err_str = "Error, expected dictionary to associate each specie to a value for keyword '{}'.".format(
-                        keyword
-                    )
+                    err_str = f"Error, expected dictionary to associate each specie to a value for keyword '{keyword}'."
                     if stop_at_first_error:
                         raise QEInputValidationError(err_str)
                     else:
@@ -445,7 +440,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
                 outdict = {}
                 for kindname, found_item in value.items():
                     if kindname not in atomic_species_list:
-                        err_str = "Error, '{}' is not a valid kind name.".format(kindname)
+                        err_str = f"Error, '{kindname}' is not a valid kind name."
                         if stop_at_first_error:
                             raise QEInputValidationError(err_str)
                         else:
@@ -462,7 +457,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
                 try:
                     internal_dict[namelist_name][keyword] = outdict
                 except KeyError as exception:
-                    err_str = 'Error, unknown namelist {}'.format(namelist_name)
+                    err_str = f'Error, unknown namelist {namelist_name}'
                     if stop_at_first_error:
                         raise QEInputValidationError(err_str) from exception
                     else:
@@ -472,14 +467,14 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
                 try:
                     end_value = int(found_var['end_val'])
                 except ValueError as exception:
-                    err_str = "Error, invalid end value '{}' for keyword '{}'.".format(found_var['end_val'], keyword)
+                    err_str = f"Error, invalid end value '{found_var['end_val']}' for keyword '{keyword}'."
                     if stop_at_first_error:
                         raise QEInputValidationError(err_str) from exception
                     else:
                         errors_list.append(err_str)
                         continue
                 if not isinstance(value, list) or len(value) != end_value:
-                    err_str = "Error, expecting a list of length {} for keyword ' {}'.".format(end_value, keyword)
+                    err_str = f"Error, expecting a list of length {end_value} for keyword ' {keyword}'."
                     if stop_at_first_error:
                         raise QEInputValidationError(err_str)
                     else:
@@ -504,7 +499,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
                 try:
                     internal_dict[namelist_name][keyword] = outlist
                 except KeyError as exception:
-                    err_str = 'Error, unknown namelist {}'.format(namelist_name)
+                    err_str = f'Error, unknown namelist {namelist_name}'
                     if stop_at_first_error:
                         raise QEInputValidationError(err_str) from exception
                     else:
@@ -522,7 +517,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
             try:
                 internal_dict[namelist_name][keyword] = []
             except KeyError as exception:
-                err_str = 'Error, unknown namelist {}'.format(namelist_name)
+                err_str = f'Error, unknown namelist {namelist_name}'
                 if stop_at_first_error:
                     raise QEInputValidationError(err_str) from exception
                 else:
@@ -554,9 +549,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
                     try:
                         int(variable['start'][i])
                     except ValueError as exception:
-                        err_str = "Error, invalid start value '{}' for keyword '{}'.".format(
-                            variable['start'][i], keyword
-                        )
+                        err_str = f"Error, invalid start value '{variable['start'][i]}' for keyword '{keyword}'."
                         if stop_at_first_error:
                             raise QEInputValidationError(err_str) from exception
                         else:
@@ -570,7 +563,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
                         kindname = index_value
 
                         if kindname not in atomic_species_list:
-                            err_str = "Error, '{}' is not a valid kind name.".format(kindname)
+                            err_str = f"Error, '{kindname}' is not a valid kind name."
                             if stop_at_first_error:
                                 raise QEInputValidationError(err_str)
                             else:
@@ -583,9 +576,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
                         try:
                             index_value = int(index_value)
                         except ValueError as exception:
-                            err_str = 'Error, only integer types are supported for index {}, got {}'.format(
-                                index, index_value
-                            )
+                            err_str = f'Error, only integer types are supported for index {index}, got {index_value}'
                             if stop_at_first_error:
                                 raise QEInputValidationError(err_str) from exception
                             else:
@@ -600,12 +591,12 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
 
         else:
             # Neither a variable nor an array
-            err_str = 'Problem parsing keyword {}. '.format(keyword)
+            err_str = f'Problem parsing keyword {keyword}. '
             similar_kws = difflib.get_close_matches(keyword, valid_invars_list)
             if len(similar_kws) == 1:
-                err_str += 'Maybe you wanted to specify {}?'.format(similar_kws[0])
+                err_str += f'Maybe you wanted to specify {similar_kws[0]}?'
             elif len(similar_kws) > 1:
-                err_str += 'Maybe you wanted to specify one of these: {}?'.format(', '.join(similar_kws))
+                err_str += f"Maybe you wanted to specify one of these: {', '.join(similar_kws)}?"
             else:
                 err_str += '(No similar keywords found...)'
             if stop_at_first_error:
@@ -619,13 +610,13 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
     # ============== I check here compulsory variables ===========
     missing_kws = compulsory_kws - set(inserted_kws)
     if missing_kws:
-        err_str = 'Missing compulsory variables: {}.'.format(', '.join(missing_kws))
+        err_str = f"Missing compulsory variables: {', '.join(missing_kws)}."
         if stop_at_first_error:
             raise QEInputValidationError(err_str)
         else:
             errors_list.append(err_str)
 
     if errors_list:
-        raise QEInputValidationError('Errors! {} issues found:\n* '.format(len(errors_list)) + '\n* '.join(errors_list))
+        raise QEInputValidationError(f'Errors! {len(errors_list)} issues found:\n* ' + '\n* '.join(errors_list))
 
     return internal_dict

--- a/aiida_quantumespresso/calculations/matdyn.py
+++ b/aiida_quantumespresso/calculations/matdyn.py
@@ -54,7 +54,7 @@ class MatdynCalculation(NamelistsCalculation):
         except AttributeError:
             kpoints = self.inputs.kpoints.get_kpoints_mesh(print_list=True)
 
-        kpoints_string = ['{}'.format(len(kpoints))]
+        kpoints_string = [f'{len(kpoints)}']
         for kpoint in kpoints:
             kpoints_string.append('{:18.10f} {:18.10f} {:18.10f}'.format(*kpoint))
 

--- a/aiida_quantumespresso/calculations/namelists.py
+++ b/aiida_quantumespresso/calculations/namelists.py
@@ -122,7 +122,7 @@ class NamelistsCalculation(CalcJob):
 
         file_lines = []
         for namelist_name, namelist in parameters.items():
-            file_lines.append('&{0}'.format(namelist_name))
+            file_lines.append(f'&{namelist_name}')
             for key, value in sorted(namelist.items()):
                 file_lines.append(convert_input_to_namelist_entry(key, value)[:-1])
             file_lines.append('/')
@@ -230,6 +230,6 @@ class NamelistsCalculation(CalcJob):
 
         if settings:
             unknown_keys = ', '.join(list(settings.keys()))
-            raise exceptions.InputValidationError('`settings` contained unexpected keys: {}'.format(unknown_keys))
+            raise exceptions.InputValidationError(f'`settings` contained unexpected keys: {unknown_keys}')
 
         return calcinfo

--- a/aiida_quantumespresso/calculations/neb.py
+++ b/aiida_quantumespresso/calculations/neb.py
@@ -38,7 +38,7 @@ class NebCalculation(CalcJob):
         # pylint: disable=no-self-argument
         # I retrieve them all, even if I don't parse all of them
         _neb_ext_list = ['path', 'dat', 'int']
-        return ['{}.{}'.format(cls._PREFIX, ext) for ext in _neb_ext_list]
+        return [f'{cls._PREFIX}.{ext}' for ext in _neb_ext_list]
 
     @classproperty
     def xml_filepaths(cls):
@@ -112,7 +112,7 @@ class NebCalculation(CalcJob):
             if namelist in input_params:
                 if key in input_params[namelist]:
                     raise InputValidationError(
-                        "You cannot specify explicitly the '{}' key in the '{}' namelist.".format(key, namelist)
+                        f"You cannot specify explicitly the '{key}' key in the '{namelist}' namelist."
                     )
             else:
                 input_params[namelist] = {}
@@ -141,7 +141,7 @@ class NebCalculation(CalcJob):
         else:
             manual_climbing_image = False
             if climbing_image_list is not None:
-                raise InputValidationError("Climbing images are not accepted when 'ci_scheme' is {}.".format(ci_scheme))
+                raise InputValidationError(f"Climbing images are not accepted when 'ci_scheme' is {ci_scheme}.")
 
         input_data = '&PATH\n'
         # namelist content; set to {} if not present, so that we leave an empty namelist
@@ -233,7 +233,7 @@ class NebCalculation(CalcJob):
                 self.inputs.pw.parameters, this_settings_dict, self.inputs.pw.pseudos, structure, self.inputs.pw.kpoints
             )
             local_copy_pseudo_list += this_local_copy_pseudo_list
-            with folder.open('pw_{}.in'.format(i + 1), 'w') as handle:
+            with folder.open(f'pw_{i + 1}.in', 'w') as handle:
                 handle.write(pw_input_filecontent)
 
         # We need to pop the settings that were used in the PW calculations
@@ -276,8 +276,8 @@ class NebCalculation(CalcJob):
                 remote_symlink_list.append((
                     parent_calc_folder.computer.uuid,
                     os.path.join(parent_calc_folder.get_remote_path(),
-                                 '{}.path'.format(self._PREFIX)),
-                    '{}.path'.format(self._PREFIX)
+                                 f'{self._PREFIX}.path'),
+                    f'{self._PREFIX}.path'
                 ))
         else:
             # copy remote output dir and .path file, if specified
@@ -292,14 +292,14 @@ class NebCalculation(CalcJob):
                 remote_copy_list.append((
                     parent_calc_folder.computer.uuid,
                     os.path.join(parent_calc_folder.get_remote_path(),
-                                 '{}.path'.format(self._PREFIX)),
-                    '{}.path'.format(self._PREFIX)
+                                 f'{self._PREFIX}.path'),
+                    f'{self._PREFIX}.path'
                 ))
 
         # here we may create an aiida.EXIT file
         create_exit_file = settings_dict.pop('ONLY_INITIALIZATION', False)
         if create_exit_file:
-            exit_filename = '{}.EXIT'.format(self._PREFIX)
+            exit_filename = f'{self._PREFIX}.EXIT'
             with folder.open(exit_filename, 'w') as handle:
                 handle.write('\n')
 
@@ -337,6 +337,6 @@ class NebCalculation(CalcJob):
 
         if settings_dict:
             unknown_keys = ', '.join(list(settings_dict.keys()))
-            raise InputValidationError('`settings` contained unexpected keys: {}'.format(unknown_keys))
+            raise InputValidationError(f'`settings` contained unexpected keys: {unknown_keys}')
 
         return calcinfo

--- a/aiida_quantumespresso/calculations/ph.py
+++ b/aiida_quantumespresso/calculations/ph.py
@@ -104,10 +104,10 @@ class PhCalculation(CalcJob):
         parent_calcs = parent_folder.get_incoming(node_class=orm.CalcJobNode).all()
 
         if not parent_calcs:
-            raise exceptions.NotExistent('parent_folder<{}> has no parent calculation'.format(parent_folder.pk))
+            raise exceptions.NotExistent(f'parent_folder<{parent_folder.pk}> has no parent calculation')
         elif len(parent_calcs) > 1:
             raise exceptions.UniquenessError(
-                'parent_folder<{}> has multiple parent calculations'.format(parent_folder.pk))
+                f'parent_folder<{parent_folder.pk}> has multiple parent calculations')
 
         parent_calc = parent_calcs[0].node
 
@@ -148,7 +148,7 @@ class PhCalculation(CalcJob):
             if namelist in parameters:
                 if flag in parameters[namelist]:
                     raise exceptions.InputValidationError(
-                        "Cannot specify explicitly the '{}' flag in the '{}' namelist or card.".format(flag, namelist))
+                        f"Cannot specify explicitly the '{flag}' flag in the '{namelist}' namelist or card.")
 
         if 'INPUTPH' not in parameters:
             raise exceptions.InputValidationError('required namelist INPUTPH not specified')
@@ -200,7 +200,7 @@ class PhCalculation(CalcJob):
             if len(list_of_points) > 1:
                 parameters['INPUTPH']['qplot'] = True
                 parameters['INPUTPH']['ldisp'] = True
-                postpend_text = '{}\n'.format(len(list_of_points))
+                postpend_text = f'{len(list_of_points)}\n'
                 for points in list_of_points:
                     postpend_text += '{0:18.10f} {1:18.10f} {2:18.10f}  1\n'.format(*points)
 
@@ -229,7 +229,7 @@ class PhCalculation(CalcJob):
 
         with folder.open(self.metadata.options.input_filename, 'w') as infile:
             for namelist_name in namelists_toprint:
-                infile.write('&{0}\n'.format(namelist_name))
+                infile.write(f'&{namelist_name}\n')
                 # namelist content; set to {} if not present, so that we leave an empty namelist
                 namelist = parameters.pop(namelist_name, {})
                 for key, value in sorted(namelist.items()):
@@ -299,7 +299,7 @@ class PhCalculation(CalcJob):
 
         # Create an `.EXIT` file if `only_initialization` flag in `settings` is set to `True`
         if settings.pop('ONLY_INITIALIZATION', False):
-            with folder.open('{}.EXIT'.format(self._PREFIX), 'w') as handle:
+            with folder.open(f'{self._PREFIX}.EXIT', 'w') as handle:
                 handle.write('\n')
 
                 remote_copy_list.append((
@@ -321,7 +321,7 @@ class PhCalculation(CalcJob):
         calcinfo.remote_symlink_list = remote_symlink_list
 
         # Retrieve by default the output file and the xml file
-        filepath_xml_tensor = os.path.join(self._OUTPUT_SUBFOLDER, '_ph0', '{}.phsave'.format(self._PREFIX))
+        filepath_xml_tensor = os.path.join(self._OUTPUT_SUBFOLDER, '_ph0', f'{self._PREFIX}.phsave')
         calcinfo.retrieve_list = []
         calcinfo.retrieve_list.append(self.metadata.options.output_filename)
         calcinfo.retrieve_list.append(self._FOLDER_DYNAMICAL_MATRIX)
@@ -330,7 +330,7 @@ class PhCalculation(CalcJob):
 
         if settings:
             unknown_keys = ', '.join(list(settings.keys()))
-            raise exceptions.InputValidationError('`settings` contained unexpected keys: {}'.format(unknown_keys))
+            raise exceptions.InputValidationError(f'`settings` contained unexpected keys: {unknown_keys}')
 
         return calcinfo
 

--- a/aiida_quantumespresso/calculations/pp.py
+++ b/aiida_quantumespresso/calculations/pp.py
@@ -168,7 +168,7 @@ class PpCalculation(CalcJob):
         input_filename = self.inputs.metadata.options.input_filename
         with folder.open(input_filename, 'w') as infile:
             for namelist_name in namelists_toprint:
-                infile.write('&{0}\n'.format(namelist_name))
+                infile.write(f'&{namelist_name}\n')
                 # namelist content; set to {} if not present, so that we leave an empty namelist
                 namelist = parameters.pop(namelist_name, {})
                 for key, value in sorted(namelist.items()):
@@ -232,7 +232,7 @@ class PpCalculation(CalcJob):
         # value as a suffix.
         retrieve_tuples = [
             self._FILEOUT,
-            ('{}_*{}'.format(self._FILPLOT, self._FILEOUT), '.', 0)
+            (f'{self._FILPLOT}_*{self._FILEOUT}', '.', 0)
         ]
 
         if self.inputs.metadata.options.keep_plot_file:

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -50,7 +50,7 @@ class PwCalculation(BasePwCpInputGenerator):
         filepaths = []
 
         for filename in cls.xml_filenames:
-            filepath = os.path.join(cls._OUTPUT_SUBFOLDER, '{}.save'.format(cls._PREFIX), filename)
+            filepath = os.path.join(cls._OUTPUT_SUBFOLDER, f'{cls._PREFIX}.save', filename)
             filepaths.append(filepath)
 
         return filepaths

--- a/aiida_quantumespresso/calculations/pw2wannier90.py
+++ b/aiida_quantumespresso/calculations/pw2wannier90.py
@@ -57,7 +57,7 @@ class Pw2wannier90Calculation(NamelistsCalculation):
         # Put the nnkp in the folder, with the correct filename
         nnkp_file = self.inputs.nnkp_file
         calcinfo.local_copy_list.append(
-            (nnkp_file.uuid, nnkp_file.filename, '{}.nnkp'.format(self._SEEDNAME))
+            (nnkp_file.uuid, nnkp_file.filename, f'{self._SEEDNAME}.nnkp')
         )
 
         return calcinfo

--- a/aiida_quantumespresso/calculations/pwimmigrant.py
+++ b/aiida_quantumespresso/calculations/pwimmigrant.py
@@ -227,7 +227,7 @@ class PwimmigrantCalculation(PwCalculation):
             # Copy the pseudo files to the temp folder.
             for fnm in pwinputfile.atomic_species['pseudo_file_names']:
                 remote_path = os.path.join(
-                    self._get_remote_workdir(), self._OUTPUT_SUBFOLDER, '{}.save/'.format(self._PREFIX), fnm
+                    self._get_remote_workdir(), self._OUTPUT_SUBFOLDER, f'{self._PREFIX}.save/', fnm
                 )
                 open_transport.get(remote_path, folder.abspath)
 

--- a/aiida_quantumespresso/cli/calculations/pw.py
+++ b/aiida_quantumespresso/cli/calculations/pw.py
@@ -71,7 +71,7 @@ def launch_calculation(
     }
 
     if mode in CALCS_REQUIRING_PARENT and not parent_folder:
-        raise click.BadParameter("calculation '{}' requires a parent folder".format(mode), param_hint='--parent-folder')
+        raise click.BadParameter(f"calculation '{mode}' requires a parent folder", param_hint='--parent-folder')
 
     try:
         hubbard_file = validate.validate_hubbard_parameters(

--- a/aiida_quantumespresso/cli/data/structure.py
+++ b/aiida_quantumespresso/cli/data/structure.py
@@ -27,7 +27,7 @@ def cmd_import(filename, dry_run):
     formula = structure.get_formula()
 
     if dry_run:
-        echo.echo_success('parsed structure with formula {}'.format(formula))
+        echo.echo_success(f'parsed structure with formula {formula}')
     else:
         structure.store()
-        echo.echo_success('parsed and stored StructureData<{}> with formula {}'.format(structure.pk, formula))
+        echo.echo_success(f'parsed and stored StructureData<{structure.pk}> with formula {formula}')

--- a/aiida_quantumespresso/cli/utils/display.py
+++ b/aiida_quantumespresso/cli/utils/display.py
@@ -18,25 +18,25 @@ def echo_process_results(node):
     if hasattr(node, 'dry_run_info'):
         # It is a dry-run: get the information and print it
         rel_path = os.path.relpath(node.dry_run_info['folder'])
-        click.echo("-> Files created in folder '{}'".format(rel_path))
-        click.echo("-> Submission script filename: '{}'".format(node.dry_run_info['script_filename']))
+        click.echo(f"-> Files created in folder '{rel_path}'")
+        click.echo(f"-> Submission script filename: '{node.dry_run_info['script_filename']}'")
         return
 
     if node.is_finished and node.exit_message:
-        state = '{} [{}] `{}`'.format(node.process_state.value, node.exit_status, node.exit_message)
+        state = f'{node.process_state.value} [{node.exit_status}] `{node.exit_message}`'
     elif node.is_finished:
-        state = '{} [{}]'.format(node.process_state.value, node.exit_status)
+        state = f'{node.process_state.value} [{node.exit_status}]'
     else:
         state = node.process_state.value
 
-    click.echo('{}<{}> terminated with state: {}'.format(class_name, node.pk, state))
+    click.echo(f'{class_name}<{node.pk}> terminated with state: {state}')
 
     if not outputs:
-        click.echo('{}<{}> registered no outputs'.format(class_name, node.pk))
+        click.echo(f'{class_name}<{node.pk}> registered no outputs')
         return
 
-    click.echo('\n{link:25s} {node}'.format(link='Output link', node='Node pk and type'))
-    click.echo('{s}'.format(s='-' * 60))
+    click.echo(f"\n{'Output link':25s} Node pk and type")
+    click.echo(f"{'-' * 60}")
 
     for triple in sorted(outputs, key=lambda triple: triple.link_label):
-        click.echo('{:25s} {}<{}> '.format(triple.link_label, triple.node.__class__.__name__, triple.node.pk))
+        click.echo(f'{triple.link_label:25s} {triple.node.__class__.__name__}<{triple.node.pk}> ')

--- a/aiida_quantumespresso/cli/utils/launch.py
+++ b/aiida_quantumespresso/cli/utils/launch.py
@@ -21,15 +21,15 @@ def launch_process(process, daemon, **inputs):
     elif issubclass(process, Process):
         process_name = process.__name__
     else:
-        raise TypeError('invalid type for process: {}'.format(process))
+        raise TypeError(f'invalid type for process: {process}')
 
     if daemon:
         node = launch.submit(process, **inputs)
-        click.echo('Submitted {}<{}> to the daemon'.format(process_name, node.pk))
+        click.echo(f'Submitted {process_name}<{node.pk}> to the daemon')
     else:
         if inputs.get('metadata', {}).get('dry_run', False):
-            click.echo('Running a dry run for {}...'.format(process_name))
+            click.echo(f'Running a dry run for {process_name}...')
         else:
-            click.echo('Running a {}...'.format(process_name))
+            click.echo(f'Running a {process_name}...')
         _, node = launch.run_get_node(process, **inputs)
         echo_process_results(node)

--- a/aiida_quantumespresso/cli/utils/validate.py
+++ b/aiida_quantumespresso/cli/utils/validate.py
@@ -31,7 +31,7 @@ def validate_kpoints_mesh(ctx, param, value):
         kpoints = KpointsData()
         kpoints.set_kpoints_mesh(value)
     except ValueError as exception:
-        raise click.BadParameter('failed to create a KpointsData mesh out of {}\n{}'.format(value, exception))
+        raise click.BadParameter(f'failed to create a KpointsData mesh out of {value}\n{exception}')
 
     return kpoints
 
@@ -62,10 +62,10 @@ def validate_hubbard_parameters(structure, parameters, hubbard_u=None, hubbard_v
         try:
             hubbard_file = load_node(pk=hubbard_file_pk)
         except exceptions.NotExistent:
-            ValueError('{} is not a valid pk'.format(hubbard_file_pk))
+            ValueError(f'{hubbard_file_pk} is not a valid pk')
         else:
             if not isinstance(hubbard_file, SinglefileData):
-                ValueError('Node<{}> is not a SinglefileData but {}'.format(hubbard_file_pk, type(hubbard_file)))
+                ValueError(f'Node<{hubbard_file_pk}> is not a SinglefileData but {type(hubbard_file)}')
 
         parameters['SYSTEM']['lda_plus_u'] = True
         parameters['SYSTEM']['lda_plus_u_kind'] = 2

--- a/aiida_quantumespresso/data/force_constants.py
+++ b/aiida_quantumespresso/data/force_constants.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Sub class of `Data` to handle interatomic force constants produced by the Quantum ESPRESSO q2r.x code."""
 import numpy
+from qe_tools import CONSTANTS
 
 from aiida.orm import SinglefileData
-from qe_tools import CONSTANTS
 
 
 class ForceConstantsData(SinglefileData):
@@ -137,7 +137,7 @@ def parse_q2r_force_constants_file(lines, also_force_constants=False):
         if len(celldm) != 6:
             warnings.append('Wrong length for celldm')
         if ibrav != 0:
-            warnings.append('ibrav ({}) is not 0; q-points path for phonon dispersion might be wrong'.format(ibrav))
+            warnings.append(f'ibrav ({ibrav}) is not 0; q-points path for phonon dispersion might be wrong')
         if any([item != 0 for item in celldm[1:]]):
             warnings.append('celldm[1:] are not all zero; only celldm[0] will be used')
 

--- a/aiida_quantumespresso/parsers/__init__.py
+++ b/aiida_quantumespresso/parsers/__init__.py
@@ -21,7 +21,7 @@ def get_parser_info(parser_info_template=None):
     parser_info['parser_version'] = parser_version
 
     if parser_info_template is None:
-        parser_info['parser_info'] = 'aiida-quantumespresso parser v{}'.format(parser_version)
+        parser_info['parser_info'] = f'aiida-quantumespresso parser v{parser_version}'
     else:
         parser_info['parser_info'] = parser_info_template.format(parser_version)
 

--- a/aiida_quantumespresso/parsers/cp.py
+++ b/aiida_quantumespresso/parsers/cp.py
@@ -60,7 +60,7 @@ class CpParser(Parser):
         # Now prepare the reordering, as filex in the xml are  ordered
         reordering = self._generate_sites_ordering(out_dict['species'], out_dict['atoms'])
 
-        pos_filename = '{}.{}'.format(self.node.process_class._PREFIX, 'pos')
+        pos_filename = f'{self.node.process_class._PREFIX}.pos'
         if pos_filename not in list_of_files:
             return self.exit(self.exit_codes.ERROR_READING_POS_FILE)
 
@@ -75,27 +75,28 @@ class CpParser(Parser):
 
         for name, extension, scale, elements in trajectories:
             try:
-                with out_folder.open('{}.{}'.format(self.node.process_class._PREFIX, extension)) as datafile:
+                with out_folder.open(f'{self.node.process_class._PREFIX}.{extension}') as datafile:
                     data = [l.split() for l in datafile]
                     # POSITIONS stored in angstrom
                 traj_data = parse_cp_traj_stanzas(
-                    num_elements=elements, splitlines=data, prepend_name='{}_traj'.format(name), rescale=scale
+                    num_elements=elements, splitlines=data, prepend_name=f'{name}_traj', rescale=scale
                 )
                 # here initialize the dictionary. If the parsing of positions fails, though, I don't have anything
                 # out of the CP dynamics. Therefore, the calculation status is set to FAILED.
                 if extension != 'cel':
-                    raw_trajectory['{}_ordered'.format(name)
-                                   ] = self._get_reordered_array(traj_data['{}_traj_data'.format(name)], reordering)
+                    raw_trajectory[f'{name}_ordered'] = self._get_reordered_array(
+                        traj_data[f'{name}_traj_data'], reordering
+                    )
                 else:
                     raw_trajectory['cells'] = numpy.array(traj_data['cells_traj_data'])
                 if extension == 'pos':
-                    raw_trajectory['times'] = numpy.array(traj_data['{}_traj_times'.format(name)])
+                    raw_trajectory['times'] = numpy.array(traj_data[f'{name}_traj_times'])
             except IOError:
-                out_dict['warnings'].append('Unable to open the {} file... skipping.'.format(extension.upper()))
+                out_dict['warnings'].append(f'Unable to open the {extension.upper()} file... skipping.')
 
         # =============== EVP trajectory ============================
         try:
-            with out_folder.open('{}.evp'.format(self._node.process_class._PREFIX)) as handle:
+            with out_folder.open(f'{self._node.process_class._PREFIX}.evp') as handle:
                 matrix = numpy.genfromtxt(handle)
             # there might be a different format if the matrix has one row only
             try:

--- a/aiida_quantumespresso/parsers/neb.py
+++ b/aiida_quantumespresso/parsers/neb.py
@@ -70,7 +70,7 @@ class NebParser(Parser):
 
         for warn_type in ['warnings', 'parser_warnings']:
             for message in neb_out_dict[warn_type]:
-                self.logger.warning('parsing NEB output: {}'.format(message))
+                self.logger.warning(f'parsing NEB output: {message}')
 
         if 'QE neb run did not reach the end of the execution.' in neb_out_dict['parser_warnings']:
             return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE)
@@ -93,7 +93,7 @@ class NebParser(Parser):
         # for each image...
         for i in range(num_images):
             # check if any of the known XML output file names are present, and parse the first that we find
-            relative_output_folder = os.path.join('{}_{}'.format(PREFIX, i + 1), '{}.save'.format(PREFIX))
+            relative_output_folder = os.path.join(f'{PREFIX}_{i + 1}', f'{PREFIX}.save')
             retrieved_files = self.retrieved.list_object_names(relative_output_folder)
             for xml_filename in PwCalculation.xml_filenames:
                 if xml_filename in retrieved_files:
@@ -118,7 +118,7 @@ class NebParser(Parser):
                 return self.exit(self.exit_codes.ERROR_MISSING_XML_FILE)
 
             # look for pw output and parse it
-            pw_out_file = os.path.join('{}_{}'.format(PREFIX, i + 1), 'PW.out')
+            pw_out_file = os.path.join(f'{PREFIX}_{i + 1}', 'PW.out')
             try:
                 with out_folder.open(pw_out_file, 'r') as f:
                     pw_out_text = f.read()  # Note: read() and not readlines()
@@ -154,7 +154,7 @@ class NebParser(Parser):
 
             structure_data = convert_qe2aiida_structure(parsed_structure)
 
-            key = 'pw_output_image_{}'.format(i + 1)
+            key = f'pw_output_image_{i + 1}'
             image_data[key] = parsed_parameters
 
             positions.append([site.position for site in structure_data.sites])
@@ -163,7 +163,7 @@ class NebParser(Parser):
             # Add also PW warnings and errors to the neb output data, avoiding repetitions.
             for log_type in ['warning', 'error']:
                 for message in logs_stdout[log_type]:
-                    formatted_message = '{}: {}'.format(log_type, message)
+                    formatted_message = f'{log_type}: {message}'
                     if formatted_message not in neb_out_dict['warnings']:
                         neb_out_dict['warnings'].append(formatted_message)
 
@@ -195,7 +195,7 @@ class NebParser(Parser):
             with out_folder.open(filename, 'r') as handle:
                 mep = numpy.loadtxt(handle)
         except Exception:
-            self.logger.warning('could not open expected output file `{}`.'.format(filename))
+            self.logger.warning(f'could not open expected output file `{filename}`.')
             mep = numpy.array([[]])
 
         try:
@@ -203,7 +203,7 @@ class NebParser(Parser):
             with out_folder.open(filename, 'r') as handle:
                 interp_mep = numpy.loadtxt(handle)
         except Exception:
-            self.logger.warning('could not open expected output file `{}`.'.format(filename))
+            self.logger.warning(f'could not open expected output file `{filename}`.')
             interp_mep = numpy.array([[]])
 
         # Create an ArrayData with the energy profiles

--- a/aiida_quantumespresso/parsers/parse_raw/base.py
+++ b/aiida_quantumespresso/parsers/parse_raw/base.py
@@ -18,7 +18,7 @@ def parse_output_base(filecontent, codename=None, message_map=None):
     keys = ['error', 'warning']
 
     if message_map is not None and (not isinstance(message_map, dict) or any(key not in message_map for key in keys)):
-        raise RuntimeError('invalid format `message_map`: should be dictionary with two keys {}'.format(keys))
+        raise RuntimeError(f'invalid format `message_map`: should be dictionary with two keys {keys}')
 
     logs = get_logging_container()
     parsed_data = get_parser_info(parser_info_template='aiida-quantumespresso parser simple v{}')
@@ -33,7 +33,7 @@ def parse_output_base(filecontent, codename=None, message_map=None):
 
     if codename is not None:
 
-        codestring = 'Program {}'.format(codename)
+        codestring = f'Program {codename}'
 
         for line_number, line in enumerate(lines):
 
@@ -127,7 +127,7 @@ def convert_qe_time_to_sec(timestr):
         seconds = '0.'
 
     if rest.strip():
-        raise ValueError("Something remained at the end of the string '{}': '{}'".format(timestr, rest))
+        raise ValueError(f"Something remained at the end of the string '{timestr}': '{rest}'")
 
     num_seconds = (float(seconds) + float(minutes) * 60. + float(hours) * 3600. + float(days) * 86400.)
 

--- a/aiida_quantumespresso/parsers/parse_raw/cp.py
+++ b/aiida_quantumespresso/parsers/parse_raw/cp.py
@@ -44,18 +44,18 @@ def parse_cp_traj_stanzas(num_elements, splitlines, prepend_name, rescale=1.):
                     stanzas.append(this_stanza)
                     this_stanza = []
             else:
-                raise ValueError('Wrong line length ({})'.format(len(l)))
+                raise ValueError(f'Wrong line length ({len(l)})')
         if len(this_stanza) != 0:
-            raise ValueError('Wrong length of last block ({} lines instead of 0).'.format(len(this_stanza)))
+            raise ValueError(f'Wrong length of last block ({len(this_stanza)} lines instead of 0).')
         if len(steps) != len(stanzas):
             raise ValueError('Length mismatch between number of steps and number of defined stanzas.')
         return {
-            '{}_steps'.format(prepend_name): steps,
-            '{}_times'.format(prepend_name): times,
-            '{}_data'.format(prepend_name): stanzas,
+            f'{prepend_name}_steps': steps,
+            f'{prepend_name}_times': times,
+            f'{prepend_name}_data': stanzas,
         }
     except Exception as e:
-        e.message = 'At line {}: {}'.format(linenum + 1, e)
+        e.message = f'At line {linenum + 1}: {e}'
         raise e
 
 
@@ -173,9 +173,9 @@ def parse_cp_raw_output(stdout, output_xml=None, output_xml_counter=None):
 
     for key in out_data.keys():
         if key in list(xml_data.keys()):
-            raise AssertionError('%s found in both dictionaries' % key)
+            raise AssertionError(f'{key} found in both dictionaries')
         if key in list(xml_counter_data.keys()):
-            raise AssertionError('%s found in both dictionaries' % key)
+            raise AssertionError(f'{key} found in both dictionaries')
         # out_data keys take precedence and overwrite xml_data keys,
         # if the same key name is shared by both (but this should not happen!)
 
@@ -225,7 +225,7 @@ def parse_cp_xml_output(data):
     value = parse_xml_child_float(tagname, target_tags)
     units = parse_xml_child_attribute_str(tagname, attrname, target_tags)
     if units not in ['pico-seconds']:
-        raise QEOutputParsingError('Units {} are not supported by parser'.format(units))
+        raise QEOutputParsingError(f'Units {units} are not supported by parser')
     parsed_data[tagname.lower()] = value
 
     tagname = 'TITLE'
@@ -263,7 +263,7 @@ def parse_cp_xml_output(data):
     metric = parse_xml_child_attribute_str(tagname, attrname, target_tags)
     if metric not in ['2 pi / a']:
         raise QEOutputParsingError(
-            'Error parsing attribute %s, tag %s inside %s, units unknown' % (attrname, tagname, target_tags.tagName)
+            f'Error parsing attribute {attrname}, tag {tagname} inside {target_tags.tagName}, units unknown'
         )
     parsed_data[tagname.replace('-', '_').lower()] = metric
 
@@ -274,7 +274,7 @@ def parse_cp_xml_output(data):
         value = [int(a.getAttribute('nk' + str(i + 1))) for i in range(3)]
         parsed_data[tagname.replace('-', '_').lower()] = value
     except:
-        raise QEOutputParsingError('Error parsing tag %s inside %s.' % (tagname, target_tags.tagName))
+        raise QEOutputParsingError(f'Error parsing tag {tagname} inside {target_tags.tagName}.')
 
     tagname = 'MONKHORST_PACK_OFFSET'
     try:
@@ -282,7 +282,7 @@ def parse_cp_xml_output(data):
         value = [int(a.getAttribute('k' + str(i + 1))) for i in range(3)]
         parsed_data[tagname.replace('-', '_').lower()] = value
     except:
-        raise QEOutputParsingError('Error parsing tag %s inside %s.' % (tagname, target_tags.tagName))
+        raise QEOutputParsingError(f'Error parsing tag {tagname} inside {target_tags.tagName}.')
 
     try:
         kpoints = []
@@ -302,7 +302,7 @@ def parse_cp_xml_output(data):
 
         parsed_data['k_point'] = kpoints
     except:
-        raise QEOutputParsingError('Error parsing tag K-POINT.# inside %s.' % (target_tags.tagName))
+        raise QEOutputParsingError(f'Error parsing tag K-POINT.# inside {target_tags.tagName}.')
 
     tagname = 'NORM-OF-Q'
     # TODO decide if save this parameter
@@ -562,7 +562,7 @@ def parse_cp_xml_output(data):
             except:
                 pass
         except:
-            raise QEOutputParsingError('Error parsing CARD {}'.format(cardname))
+            raise QEOutputParsingError(f'Error parsing CARD {cardname}')
 
     # CARD BAND_STRUCTURE_INFO
 

--- a/aiida_quantumespresso/parsers/parse_raw/neb.py
+++ b/aiida_quantumespresso/parsers/parse_raw/neb.py
@@ -57,7 +57,7 @@ def parse_raw_output_neb(stdout, input_dict, parser_opts=None):
             iteration_data = {}
             critical_messages = []
         else:  # if it was finished and I got an error, it's a mistake of the parser
-            raise QEOutputParsingError('Error while parsing NEB text output: {}'.format(exc))
+            raise QEOutputParsingError(f'Error while parsing NEB text output: {exc}')
 
     # I add in the out_data all the last elements of iteration_data values.
     # I leave the possibility to skip some large arrays (None for the time being).

--- a/aiida_quantumespresso/parsers/parse_raw/ph.py
+++ b/aiida_quantumespresso/parsers/parse_raw/ph.py
@@ -67,15 +67,15 @@ def parse_raw_ph_output(stdout, tensors=None, dynamical_matrices=None):
             this_dynmat_data = parse_ph_dynmat(lines, logs)
 
             # join it with the previous dynmat info
-            dynmat_data['dynamical_matrix_%s' % dynmat_counter] = this_dynmat_data
+            dynmat_data[f'dynamical_matrix_{dynmat_counter}'] = this_dynmat_data
             # TODO: use the bands format?
 
     # join dictionaries, there should not be any twice repeated key
     for key in out_data.keys():
         if key in list(tensor_data.keys()):
-            raise AssertionError('{} found in two dictionaries'.format(key))
+            raise AssertionError(f'{key} found in two dictionaries')
         if key in list(dynmat_data.keys()):
-            raise AssertionError('{} found in two dictionaries'.format(key))
+            raise AssertionError(f'{key} found in two dictionaries')
 
     # I don't check the dynmat_data and parser_info keys
     parsed_data = dict(
@@ -332,21 +332,14 @@ def parse_ph_dynmat(data, logs, lattice_parameter=None, also_eigenvectors=False,
                 pieces = atom_line.split()
                 if len(pieces) != 5:
                     raise QEOutputParsingError(
-                        'Wrong # of elements for one of the atoms: {}, '
-                        'line {}: {}'.format(len(pieces), starting_line + idx, pieces)
+                        f'Wrong # of elements for one of the atoms: {len(pieces)}, line {starting_line + idx}: {pieces}'
                     )
                 try:
                     if int(pieces[0]) != idx:
-                        raise QEOutputParsingError(
-                            'Error with the indices of the atoms: '
-                            '{} vs {}'.format(int(pieces[0]), idx)
-                        )
+                        raise QEOutputParsingError(f'Error with the indices of the atoms: {int(pieces[0])} vs {idx}')
                     sp_idx = int(pieces[1])
                     if sp_idx > len(species):
-                        raise QEOutputParsingError(
-                            'Wrong index for the species: '
-                            '{}, but max={}'.format(sp_idx, len(species))
-                        )
+                        raise QEOutputParsingError(f'Wrong index for the species: {sp_idx}, but max={len(species)}')
                     atoms_labels.append(species[sp_idx - 1][0])
                     atoms_coords.append([float(pieces[2]) * alat, float(pieces[3]) * alat, float(pieces[4]) * alat])
                 except ValueError:

--- a/aiida_quantumespresso/parsers/parse_raw/pw.py
+++ b/aiida_quantumespresso/parsers/parse_raw/pw.py
@@ -99,7 +99,7 @@ def reduce_symmetries(parsed_parameters, parsed_structure, logger):
                             break
                     else:
                         index = None
-                        logger.error('Symmetry {} not found'.format(name))
+                        logger.error(f'Symmetry {name} not found')
 
                     new_dict = {}
                     if index is not None:
@@ -131,11 +131,11 @@ def reduce_symmetries(parsed_parameters, parsed_structure, logger):
 
                 parsed_parameters[symmetry_type] = new_symmetries  # and overwrite the old one
             except KeyError:
-                logger.warning("key '{}' is not present in raw output dictionary".format(symmetry_type))
+                logger.warning(f"key '{symmetry_type}' is not present in raw output dictionary")
         else:
             # backwards-compatiblity: 'lattice_symmetries' is not created in older versions of the parser
             if symmetry_type != 'lattice_symmetries':
-                logger.warning("key '{}' is not present in raw output dictionary".format(symmetry_type))
+                logger.warning(f"key '{symmetry_type}' is not present in raw output dictionary")
 
 
 def get_symmetry_mapping():
@@ -406,7 +406,7 @@ def parse_stdout(stdout, input_parameters, parser_options=None, parsed_xml=None)
             if match:
                 try:
                     parsed_data['estimated_ram_per_process'] = float(match.group(1))
-                    parsed_data['estimated_ram_per_process{}'.format(units_suffix)] = match.group(4)
+                    parsed_data[f'estimated_ram_per_process{units_suffix}'] = match.group(4)
                 except (IndexError, ValueError):
                     pass
 
@@ -417,7 +417,7 @@ def parse_stdout(stdout, input_parameters, parser_options=None, parsed_xml=None)
             if match:
                 try:
                     parsed_data['estimated_ram_total'] = float(match.group(1))
-                    parsed_data['estimated_ram_total{}'.format(units_suffix)] = match.group(4)
+                    parsed_data[f'estimated_ram_total{units_suffix}'] = match.group(4)
                 except (IndexError, ValueError):
                     pass
 
@@ -464,7 +464,7 @@ def parse_stdout(stdout, input_parameters, parser_options=None, parsed_xml=None)
                     parsed_data['pointgroup_schoenflies'] = pg_schoenflies
 
                 except Exception:
-                    warning = 'Problem parsing point group, I found: {}'.format(line.strip())
+                    warning = f'Problem parsing point group, I found: {line.strip()}'
                     logs.warning.append(warning)
 
         # special parsing of c_bands error
@@ -510,7 +510,7 @@ def parse_stdout(stdout, input_parameters, parser_options=None, parsed_xml=None)
                     lattice = line.split('(')[1].split(')')[0].split('=')
                     if lattice[0].lower() not in ['alat', 'bohr', 'angstrom']:
                         raise QEOutputParsingError(
-                            'Error while parsing cell_parameters: ' + 'unsupported units {}'.format(lattice[0])
+                            'Error while parsing cell_parameters: ' + f'unsupported units {lattice[0]}'
                         )
 
                     if 'alat' in lattice[0].lower():
@@ -520,7 +520,7 @@ def parse_stdout(stdout, input_parameters, parser_options=None, parsed_xml=None)
                         lattice_parameter_b = float(lattice[1])
                         if abs(lattice_parameter_b - alat) > lattice_tolerance:
                             raise QEOutputParsingError(
-                                'Lattice parameters mismatch! ' + '{} vs {}'.format(lattice_parameter_b, alat)
+                                'Lattice parameters mismatch! ' + f'{lattice_parameter_b} vs {alat}'
                             )
                     elif 'bohr' in lattice[0].lower():
                         lattice_parameter_b *= CONSTANTS.bohr_to_ang
@@ -569,7 +569,7 @@ def parse_stdout(stdout, input_parameters, parser_options=None, parsed_xml=None)
                     units = line2.split()[-1]
                     if default_dipole_units.lower() not in units.lower():  # only debye
                         raise QEOutputParsingError(
-                            'Error parsing the dipole correction. Units {} are not supported.'.format(units)
+                            f'Error parsing the dipole correction. Units {units} are not supported.'
                         )
                     value = float(line2.split()[-2])
                 except IndexError:  # on units
@@ -669,7 +669,7 @@ def parse_stdout(stdout, input_parameters, parser_options=None, parsed_xml=None)
                             else:
                                 break
                     else:
-                        raise KeyError('could not find and parse the line with `{}`'.format(marker))
+                        raise KeyError(f'could not find and parse the line with `{marker}`')
 
                     for key, value in [['energy', En], ['energy_accuracy', E_acc]]:
                         trajectory_data.setdefault(key, []).append(value)
@@ -797,7 +797,7 @@ def parse_stdout(stdout, input_parameters, parser_options=None, parsed_xml=None)
                         parsed_data['stress' + units_suffix] = default_stress_units
                 except Exception:
                     import traceback
-                    logs.warning.append('Error while parsing stress tensor: {}'.format(traceback.format_exc()))
+                    logs.warning.append(f'Error while parsing stress tensor: {traceback.format_exc()}')
 
             # Electronic and ionic dipoles when 'lelfield' was set to True in input parameters
             elif lelfield is True:

--- a/aiida_quantumespresso/parsers/parse_xml/pw/legacy.py
+++ b/aiida_quantumespresso/parsers/parse_xml/pw/legacy.py
@@ -96,8 +96,8 @@ def parse_pw_xml_pre_6_2(xml_file, dir_with_bands):
     attrname = 'UNITS'
     metric = parse_xml_child_attribute_str(tagname, attrname, target_tags)
     if metric not in ['2 pi / a']:
-        raise QEOutputParsingError('Error parsing attribute {},'.format(attrname) + \
-                ' tag {} inside {}, units unknown'.format(tagname, target_tags.tagName) )
+        raise QEOutputParsingError(f'Error parsing attribute {attrname},' + \
+                f' tag {tagname} inside {target_tags.tagName}, units unknown' )
     k_points_units = metric
 
     for tagname, param in [['MONKHORST_PACK_GRID', 'nk'], ['MONKHORST_PACK_OFFSET', 'k']]:
@@ -118,7 +118,7 @@ def parse_pw_xml_pre_6_2(xml_file, dir_with_bands):
     try:
         import numpy
         for i in range(parsed_data['number_of_k_points']):
-            tagname = '{}{}'.format(tagname_prefix, i + 1)
+            tagname = f'{tagname_prefix}{i + 1}'
             #a = target_tags.getElementsByTagName(tagname)[0]
             a = a_dict[tagname]
             b = a.getAttribute('XYZ').replace('\n', '').rsplit()
@@ -133,7 +133,7 @@ def parse_pw_xml_pre_6_2(xml_file, dir_with_bands):
         parsed_data['k_points' + units_suffix] = default_k_points_units
         parsed_data['k_points_weights'] = kpoints_weights
     except Exception:
-        raise QEOutputParsingError('Error parsing tag K-POINT.{} inside {}.'.format(i + 1, target_tags.tagName))
+        raise QEOutputParsingError(f'Error parsing tag K-POINT.{i + 1} inside {target_tags.tagName}.')
 
     # I skip this card until someone will have a need for this.
 #     try:
@@ -192,9 +192,7 @@ def parse_pw_xml_pre_6_2(xml_file, dir_with_bands):
     attrname = 'UNITS'
     units = parse_xml_child_attribute_str(tagname, attrname, target_tags)
     if units not in ['hartree']:
-        raise QEOutputParsingError(
-            'Expected energy units in Hartree. Got instead {}'.format(parsed_data['energy_units'])
-        )
+        raise QEOutputParsingError(f"Expected energy units in Hartree. Got instead {parsed_data['energy_units']}")
 
     try:
         tagname = 'TWO_FERMI_ENERGIES'
@@ -266,8 +264,8 @@ def parse_pw_xml_pre_6_2(xml_file, dir_with_bands):
         value = str(target_tags.getAttribute(attrname)).rstrip().replace('\n', '').lower()
         parsed_data[cardname.lower().rstrip().replace('-', '_')] = value
     except Exception:
-        raise QEOutputParsingError('Error parsing attribute {},'.format(attrname) + \
-                                   ' card {}.'.format(cardname))
+        raise QEOutputParsingError(f'Error parsing attribute {attrname},' + \
+                                   f' card {cardname}.')
 
     #CARD EIGENVALUES
     # Note: if this card is parsed, the dimension of the database grows very much!
@@ -298,7 +296,7 @@ def parse_pw_xml_pre_6_2(xml_file, dir_with_bands):
                     metric = str(a.getAttribute(attrname))
                     if metric not in ['Hartree']:
                         raise QEOutputParsingError('Error parsing eigenvalues xml file, ' + \
-                                                   'units {} not implemented.'.format(metric))
+                                                   f'units {metric} not implemented.')
 
                     tagname = 'EIGENVALUES'
                     a = eig_dom.getElementsByTagName(tagname)[0]
@@ -353,9 +351,7 @@ def parse_pw_xml_pre_6_2(xml_file, dir_with_bands):
             bands_dict['bands'] = bands
             bands_dict['bands' + units_suffix] = default_energy_units
         except Exception as exception:
-            raise QEOutputParsingError(
-                'Error parsing card {}: {} {}'.format(tagname, exception.__class__.__name__, exception)
-            )
+            raise QEOutputParsingError(f'Error parsing card {tagname}: {exception.__class__.__name__} {exception}')
 
 
 #     if dir_with_bands:
@@ -409,7 +405,7 @@ def read_xml_card(dom, cardname):
         return the_card
     except Exception as e:
         print(e)
-        raise QEOutputParsingError('Error parsing tag {}'.format(cardname))
+        raise QEOutputParsingError(f'Error parsing tag {cardname}')
 
 
 def parse_xml_child_integer(tagname, target_tags):
@@ -419,7 +415,7 @@ def parse_xml_child_integer(tagname, target_tags):
         b = a.childNodes[0]
         return int(b.data)
     except Exception:
-        raise QEOutputParsingError('Error parsing tag {} inside {}'.format(tagname, target_tags.tagName))
+        raise QEOutputParsingError(f'Error parsing tag {tagname} inside {target_tags.tagName}')
 
 
 def parse_xml_child_float(tagname, target_tags):
@@ -429,8 +425,7 @@ def parse_xml_child_float(tagname, target_tags):
         b = a.childNodes[0]
         return float(b.data)
     except Exception:
-        raise QEOutputParsingError('Error parsing tag {} inside {}'\
-                                   .format(tagname, target_tags.tagName ) )
+        raise QEOutputParsingError(f'Error parsing tag {tagname} inside {target_tags.tagName}')
 
 
 def parse_xml_child_bool(tagname, target_tags):
@@ -440,8 +435,7 @@ def parse_xml_child_bool(tagname, target_tags):
         b = a.childNodes[0]
         return str2bool(b.data)
     except Exception:
-        raise QEOutputParsingError('Error parsing tag {} inside {}'\
-                                   .format(tagname, target_tags.tagName) )
+        raise QEOutputParsingError(f'Error parsing tag {tagname} inside {target_tags.tagName}')
 
 
 def str2bool(string):
@@ -454,7 +448,7 @@ def str2bool(string):
         if string in true_items:
             return True
         else:
-            raise QEOutputParsingError('Error converting string {} to boolean value.'.format(string))
+            raise QEOutputParsingError(f'Error converting string {string} to boolean value.')
     except Exception:
         raise QEOutputParsingError('Error converting string to boolean.')
 
@@ -466,8 +460,7 @@ def parse_xml_child_str(tagname, target_tags):
         b = a.childNodes[0]
         return str(b.data).rstrip().replace('\n', '')
     except Exception:
-        raise QEOutputParsingError('Error parsing tag {} inside {}'\
-                                   .format(tagname, target_tags.tagName) )
+        raise QEOutputParsingError(f'Error parsing tag {tagname} inside {target_tags.tagName}')
 
 
 def parse_xml_child_attribute_str(tagname, attributename, target_tags):
@@ -478,7 +471,7 @@ def parse_xml_child_attribute_str(tagname, attributename, target_tags):
         return value.rstrip().replace('\n', '').lower()
     except Exception:
         raise QEOutputParsingError(
-            'Error parsing attribute {}, tag {} inside {}'.format(attributename, tagname, target_tags.tagName)
+            f'Error parsing attribute {attributename}, tag {tagname} inside {target_tags.tagName}'
         )
 
 
@@ -490,7 +483,7 @@ def parse_xml_child_attribute_int(tagname, attributename, target_tags):
         return value
     except Exception:
         raise QEOutputParsingError(
-            'Error parsing attribute {}, tag {} inside {}'.format(attributename, tagname, target_tags.tagName)
+            f'Error parsing attribute {attributename}, tag {tagname} inside {target_tags.tagName}'
         )
 
 
@@ -515,9 +508,7 @@ def xml_card_cell(parsed_data, dom):
     metric = parse_xml_child_attribute_str(tagname, attrname, target_tags)
     if metric not in ['bohr', 'angstrom']:
         raise QEOutputParsingError(
-            'Error parsing attribute {}, tag {} inside {}, units not found'.format(
-                attrname, tagname, target_tags.tagName
-            )
+            f'Error parsing attribute {attrname}, tag {tagname} inside {target_tags.tagName}, units not found'
         )
     if metric == 'bohr':
         value *= CONSTANTS.bohr_to_ang
@@ -532,7 +523,7 @@ def xml_card_cell(parsed_data, dom):
         value = [float(i) for i in c]
         parsed_data[tagname.replace('-', '_').lower()] = value
     except Exception:
-        raise QEOutputParsingError('Error parsing tag {} inside {}.'.format(tagname, target_tags.tagName))
+        raise QEOutputParsingError(f'Error parsing tag {tagname} inside {target_tags.tagName}.')
 
     tagname = 'DIRECT_LATTICE_VECTORS'
     lattice_vectors = []
@@ -547,7 +538,7 @@ def xml_card_cell(parsed_data, dom):
         metric = value
         if metric not in ['bohr', 'angstroms']:  # REMEMBER TO CHECK THE UNITS AT THE END OF THE FUNCTION
             raise QEOutputParsingError(
-                'Error parsing tag {} inside {}: units not supported: {}'.format(tagname, target_tags.tagName, metric)
+                f'Error parsing tag {tagname} inside {target_tags.tagName}: units not supported: {metric}'
             )
 
         lattice_vectors = []
@@ -564,9 +555,7 @@ def xml_card_cell(parsed_data, dom):
         volume = cell_volume(lattice_vectors[0], lattice_vectors[1], lattice_vectors[2])
 
     except Exception:
-        raise QEOutputParsingError(
-            'Error parsing tag {} inside {} inside {}.'.format(tagname, target_tags.tagName, cardname)
-        )
+        raise QEOutputParsingError(f'Error parsing tag {tagname} inside {target_tags.tagName} inside {cardname}.')
     # NOTE: lattice_vectors will be saved later together with card IONS.atom
 
     tagname = 'RECIPROCAL_LATTICE_VECTORS'
@@ -583,7 +572,7 @@ def xml_card_cell(parsed_data, dom):
         # NOTE: output is given in 2 pi / a [ang ^ -1]
         if metric not in ['2 pi / a']:
             raise QEOutputParsingError(
-                'Error parsing tag {} inside {}: units {} not supported'.format(tagname, target_tags.tagName, metric)
+                f'Error parsing tag {tagname} inside {target_tags.tagName}: units {metric} not supported'
             )
 
         # reciprocal_lattice_vectors
@@ -599,7 +588,7 @@ def xml_card_cell(parsed_data, dom):
         parsed_data['reciprocal_lattice_vectors'] = this_matrix
 
     except Exception:
-        raise QEOutputParsingError('Error parsing tag {} inside {}.'.format(tagname, target_tags.tagName))
+        raise QEOutputParsingError(f'Error parsing tag {tagname} inside {target_tags.tagName}.')
     return parsed_data, lattice_vectors, volume
 
 
@@ -640,7 +629,7 @@ def xml_card_ions(parsed_data, dom, lattice_vectors, volume):
         attrname = 'UNITS'
         parsed_data[tagname.lower()] = parse_xml_child_attribute_str(tagname, attrname, target_tags)
     except:
-        raise QEOutputParsingError('Error parsing tag SPECIE.# inside %s.' % (target_tags.tagName))
+        raise QEOutputParsingError(f'Error parsing tag SPECIE.# inside {target_tags.tagName}.')
 
 
 # TODO convert the units
@@ -678,7 +667,7 @@ def xml_card_ions(parsed_data, dom, lattice_vectors, volume):
             tau = [float(s) for s in b.rstrip().replace('\n', '').split()]
             metric = parsed_data['units_for_atomic_positions']
             if metric not in ['alat', 'bohr', 'angstrom']:  # REMEMBER TO CONVERT AT THE END
-                raise QEOutputParsingError('Error parsing tag %s inside %s' % (tagname, target_tags.tagName))
+                raise QEOutputParsingError(f'Error parsing tag {tagname} inside {target_tags.tagName}')
             if metric == 'alat':
                 tau = [parsed_data['lattice_parameter_xml'] * float(s) for s in tau]
             elif metric == 'bohr':
@@ -698,7 +687,7 @@ def xml_card_ions(parsed_data, dom, lattice_vectors, volume):
         cell['tagslist'] = tagslist
         parsed_data['cell'] = cell
     except Exception:
-        raise QEOutputParsingError('Error parsing tag ATOM.# inside %s.' % (target_tags.tagName))
+        raise QEOutputParsingError(f'Error parsing tag ATOM.# inside {target_tags.tagName}.')
     # saving data together with cell parameters. Did so for better compatibility with ASE.
 
     # correct some units that have been converted in
@@ -742,7 +731,7 @@ def xml_card_planewaves(parsed_data, dom, calctype):
     units = parse_xml_child_attribute_str(tagname, attrname, target_tags).lower()
     if 'hartree' not in units:
         if 'rydberg' not in units:
-            raise QEOutputParsingError('Units {} are not supported by parser'.format(units))
+            raise QEOutputParsingError(f'Units {units} are not supported by parser')
     else:
         if 'hartree' in units:
             conv_fac = CONSTANTS.hartree_to_ev
@@ -797,9 +786,9 @@ def xml_card_symmetries(parsed_data, dom):
     attrname = 'UNITS'
     metric = parse_xml_child_attribute_str(tagname, attrname, target_tags)
     if metric not in ['crystal']:
-        raise QEOutputParsingError('Error parsing attribute {},'.format(attrname) + \
-                                   ' tag {} inside '.format(tagname) + \
-                                   '{}, units unknown'.format(target_tags.tagName ) )
+        raise QEOutputParsingError(f'Error parsing attribute {attrname},' + \
+                                   f' tag {tagname} inside ' + \
+                                   f'{target_tags.tagName}, units unknown' )
     parsed_data['symmetries' + units_suffix] = metric
 
     # parse the symmetry matrices
@@ -874,7 +863,7 @@ def xml_card_exchangecorrelation(parsed_data, dom):
             parsed_data[tagname.lower()] = value
         except Exception:
             raise QEOutputParsingError('Error parsing tag '+\
-                                       '{} inside {}.'.format(tagname, target_tags.tagName) )
+                                       f'{tagname} inside {target_tags.tagName}.' )
 
         for tagname in ['HUBBARD_U', 'HUBBARD_ALPHA', 'HUBBARD_BETA', 'HUBBARD_J0']:
             try:
@@ -886,7 +875,7 @@ def xml_card_exchangecorrelation(parsed_data, dom):
                 parsed_data[tagname.lower()] = value
             except Exception:
                 raise QEOutputParsingError('Error parsing tag '+\
-                                           '{} inside {}.'.format(tagname, target_tags.tagName))
+                                           f'{tagname} inside {target_tags.tagName}.')
 
         tagname = 'LDA_PLUS_U_KIND'
         try:

--- a/aiida_quantumespresso/parsers/parse_xml/pw/parse.py
+++ b/aiida_quantumespresso/parsers/parse_xml/pw/parse.py
@@ -25,7 +25,7 @@ def parser_assert(condition, message, log_func=raise_parsing_error):
 
 def parser_assert_equal(val1, val2, message, log_func=raise_parsing_error):
     if not (val1 == val2):
-        msg = 'Violated assertion: {} == {}'.format(val1, val2)
+        msg = f'Violated assertion: {val1} == {val2}'
         if message:
             msg += ' - '
             msg += message
@@ -82,7 +82,7 @@ def parse_pw_xml_post_6_2(xml):
             xsd = XMLSchema(schema_filepath_default)
         except URLError:
             raise XMLParseError(
-                'Could not open or parse the XSD files {} and {}'.format(schema_filepath, schema_filepath_default)
+                f'Could not open or parse the XSD files {schema_filepath} and {schema_filepath_default}'
             )
         else:
             schema_filepath = schema_filepath_default
@@ -97,7 +97,7 @@ def parse_pw_xml_post_6_2(xml):
 
     xml_dictionary, errors = xsd.to_dict(xml, validation='lax')
     if errors:
-        logs.error.append('{} XML schema validation error(s) schema: {}:'.format(len(errors), schema_filepath))
+        logs.error.append(f'{len(errors)} XML schema validation error(s) schema: {schema_filepath}:')
         for err in errors:
             logs.error.append(str(err))
 
@@ -209,7 +209,7 @@ def parse_pw_xml_post_6_2(xml):
         elif symmetry_type == 'lattice_symmetry':
             lattice_symmetries.append(sym)
         else:
-            raise XMLParseError('Unexpected type of symmetry: {}'.format(symmetry_type))
+            raise XMLParseError(f'Unexpected type of symmetry: {symmetry_type}')
 
     if (nsym != len(symmetries)) or (nrot != len(symmetries) + len(lattice_symmetries)):
         logs.warning.append(
@@ -321,9 +321,7 @@ def parse_pw_xml_post_6_2(xml):
         else:
             spins = True
             if num_bands_up != num_bands_down:
-                raise XMLParseError(
-                    'different number of bands for spin channels: {} and {}'.format(num_bands_up, num_bands_down)
-                )
+                raise XMLParseError(f'different number of bands for spin channels: {num_bands_up} and {num_bands_down}')
 
             if num_bands is not None and num_bands != num_bands_up + num_bands_down:
                 raise XMLParseError(
@@ -475,7 +473,7 @@ def parse_pw_xml_post_6_2(xml):
         polarization_modulus = berry_phase['totalPolarization']['modulus']
         parser_assert(
             polarization_units in ['e/bohr^2', 'C/m^2'],
-            "Unsupported units '{}' of total polarization".format(polarization_units)
+            f"Unsupported units '{polarization_units}' of total polarization"
         )
         if polarization_units == 'e/bohr^2':
             polarization *= e_bohr2_to_coulomb_m2

--- a/aiida_quantumespresso/parsers/projwfc.py
+++ b/aiida_quantumespresso/parsers/projwfc.py
@@ -341,7 +341,7 @@ class ProjwfcParser(Parser):
         try:
             new_nodes_list = self._parse_bands_and_projections(out_info_dict)
         except QEOutputParsingError as err:
-            self.logger.error('Error parsing bands and projections: {}'.format(err))
+            self.logger.error(f'Error parsing bands and projections: {err}')
             return self.exit(self.exit_codes.ERROR_PARSING_PROJECTIONS)
         for linkname, node in new_nodes_list:
             self.out(linkname, node)
@@ -394,7 +394,7 @@ class ProjwfcParser(Parser):
                                                             link_type=LinkType.CREATE).one().node
             )
         except ValueError as e:
-            raise QEOutputParsingError('Could not get parent calculation of input folder: {}'.format(e))
+            raise QEOutputParsingError(f'Could not get parent calculation of input folder: {e}')
         out_info_dict['parent_calc'] = parent_calc
         try:
             parent_param = parent_calc.get_outgoing(link_label_filter='output_parameters').one().node

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -242,7 +242,7 @@ class PwParser(Parser):
             converged_final = verify_convergence_trajectory(trajectory, -1, *values)
             return converged_relax and (converged_final or except_final_scf)
 
-        raise RuntimeError('unknown relax_type: {}'.format(relax_type))
+        raise RuntimeError(f'unknown relax_type: {relax_type}')
 
     def parse_xml(self, dir_with_bands=None, parser_options=None):
         """Parse the XML output file.

--- a/aiida_quantumespresso/tools/base.py
+++ b/aiida_quantumespresso/tools/base.py
@@ -53,7 +53,7 @@ class StructureParseMixin:
                 symbols = valid_elements_regex.search(pseudo).group('ele').capitalize()
             except Exception as exception:
                 raise InputValidationError(
-                    'could not determine element name from pseudo name: {}'.format(pseudo)
+                    f'could not determine element name from pseudo name: {pseudo}'
                 ) from exception
             structure.append_kind(Kind(name=name, symbols=symbols, mass=mass))
 

--- a/aiida_quantumespresso/tools/calculations/pw.py
+++ b/aiida_quantumespresso/tools/calculations/pw.py
@@ -25,24 +25,22 @@ class PwCalculationTools(CalculationTools):
         try:
             trajectory = self._node.outputs.output_trajectory
         except exceptions.NotExistent as exc:
-            raise ValueError('{} does not have the `output_trajectory` output node'.format(self._node)) from exc
+            raise ValueError(f'{self._node} does not have the `output_trajectory` output node') from exc
 
         try:
             scf_accuracy = trajectory.get_array('scf_accuracy')
         except KeyError as exc:
-            raise ValueError('{} does not contain the required `scf_accuracy` array'.format(trajectory)) from exc
+            raise ValueError(f'{trajectory} does not contain the required `scf_accuracy` array') from exc
 
         try:
             scf_iterations = trajectory.get_array('scf_iterations')
         except KeyError as exc:
-            raise ValueError('{} does not contain the required `scf_iterations` array'.format(trajectory)) from exc
+            raise ValueError(f'{trajectory} does not contain the required `scf_iterations` array') from exc
 
         number_of_frames = len(scf_iterations)
 
         if index < -number_of_frames or index >= number_of_frames:
-            raise IndexError(
-                'invalid index {}, must be between {} and {}'.format(index, -number_of_frames, number_of_frames - 1)
-            )
+            raise IndexError(f'invalid index {index}, must be between {-number_of_frames} and {number_of_frames - 1}')
 
         # building an scf_accuracy_index for easier manipulation
         scf_accuracy_index = [0]

--- a/aiida_quantumespresso/tools/data/orbital/spinorbithydrogen.py
+++ b/aiida_quantumespresso/tools/data/orbital/spinorbithydrogen.py
@@ -129,15 +129,13 @@ class SpinorbitHydrogenOrbital(Orbital):
         accepted_range = [abs(angular_momentum - 0.5), angular_momentum + 0.5]
         if total_angular_momentum < min(accepted_range) or total_angular_momentum > max(accepted_range):
             raise ValidationError(
-                'the total angular momentum must be in the range [{}, {}]'.format(
-                    min(accepted_range), max(accepted_range)
-                )
+                f'the total angular momentum must be in the range [{min(accepted_range)}, {max(accepted_range)}]'
             )
         magnetic_number = validated_dict['magnetic_number']  # m quantum number, must be there
         accepted_range = [-total_angular_momentum, total_angular_momentum]
         if magnetic_number < min(accepted_range) or magnetic_number > max(accepted_range):
             raise ValidationError(
-                'the magnetic number must be in the range [{}, {}]'.format(min(accepted_range), max(accepted_range))
+                f'the magnetic number must be in the range [{min(accepted_range)}, {max(accepted_range)}]'
             )
 
         return validated_dict

--- a/aiida_quantumespresso/tools/dbexporters/tcod_plugins/pw.py
+++ b/aiida_quantumespresso/tools/dbexporters/tcod_plugins/pw.py
@@ -56,7 +56,7 @@ class PwTcodtranslator(BaseTcodtranslator):
         if energy_type not in parameters.attrs():
             return None
         if energy_type + '_units' not in parameters.attrs():
-            raise ValueError('energy units for {} are unknown'.format(energy_type))
+            raise ValueError(f'energy units for {energy_type} are unknown')
         if parameters.get_attr(energy_type + '_units') != 'eV':
             raise ValueError(
                 'energy units for {} are {} instead of eV -- unit conversion is not possible yet'.format(

--- a/aiida_quantumespresso/tools/pwinputparser.py
+++ b/aiida_quantumespresso/tools/pwinputparser.py
@@ -54,7 +54,7 @@ class PwInputFile(StructureParseMixin, BasePwInputFile):
         elif self.k_points['type'] == 'gamma':
             kpoints.set_kpoints_mesh([1, 1, 1])
         else:
-            raise NotImplementedError('support for units {} not yet implemented'.format(self.k_points['type']))
+            raise NotImplementedError(f"support for units {self.k_points['type']} not yet implemented")
 
         return kpoints
 

--- a/aiida_quantumespresso/utils/bands.py
+++ b/aiida_quantumespresso/utils/bands.py
@@ -33,7 +33,7 @@ def get_highest_occupied_band(bands, threshold=0.005):
     from aiida.orm import BandsData
 
     if not isinstance(bands, BandsData):
-        raise ValueError('bands should be a `{}` node'.format(BandsData.__name__))
+        raise ValueError(f'bands should be a `{BandsData.__name__}` node')
 
     try:
         occupations = bands.get_array('occupations')

--- a/aiida_quantumespresso/utils/convert.py
+++ b/aiida_quantumespresso/utils/convert.py
@@ -17,19 +17,17 @@ def conv_to_fortran(val, quote_strings=True):
         else:
             val_str = '.false.'
     elif isinstance(val, numbers.Integral):
-        val_str = '{:d}'.format(val)
+        val_str = f'{val:d}'
     elif isinstance(val, numbers.Real):
-        val_str = ('{:18.10e}'.format(val)).replace('e', 'd')
+        val_str = f'{val:18.10e}'.replace('e', 'd')
     elif isinstance(val, str):
         if quote_strings:
-            val_str = "'{!s}'".format(val)
+            val_str = f"'{val!s}'"
         else:
-            val_str = '{!s}'.format(val)
+            val_str = f'{val!s}'
     else:
         raise ValueError(
-            "Invalid value '{}' of type '{}' passed, accepts only bools, ints, floats and strings".format(
-                val, type(val)
-            )
+            f"Invalid value '{val}' of type '{type(val)}' passed, accepts only bools, ints, floats and strings"
         )
 
     return val_str
@@ -54,16 +52,16 @@ def conv_to_fortran_withlists(val, quote_strings=True):
         return '.false.'
 
     if isinstance(val, int):
-        return '{:d}'.format(val)
+        return f'{val:d}'
 
     if isinstance(val, float):
-        return '{:18.10e}'.format(val).replace('e', 'd')
+        return f'{val:18.10e}'.replace('e', 'd')
 
     if isinstance(val, str):
         if quote_strings:
-            return "'{!s}'".format(val)
+            return f"'{val!s}'"
 
-        return '{!s}'.format(val)
+        return f'{val!s}'
 
     raise ValueError('Invalid value passed, accepts only bools, ints, floats and strings')
 
@@ -170,9 +168,9 @@ def convert_input_to_namelist_entry(key, val, mapping=None):
             try:
                 idx = mapping[elemk]
             except KeyError as exception:
-                raise ValueError("Unable to find the key '{}' in the mapping dictionary".format(elemk)) from exception
+                raise ValueError(f"Unable to find the key '{elemk}' in the mapping dictionary") from exception
 
-            list_of_strings.append((idx, '  {0}({2}) = {1}\n'.format(key, conv_to_fortran(itemval), idx)))
+            list_of_strings.append((idx, f'  {key}({idx}) = {conv_to_fortran(itemval)}\n'))
 
         # I first have to resort, then to remove the index from the first column, finally to join the strings
         list_of_strings = list(zip(*sorted(list_of_strings)))[1]
@@ -200,8 +198,7 @@ def convert_input_to_namelist_entry(key, val, mapping=None):
 
                         if value not in mapping:
                             raise ValueError(
-                                'the nested list contained string {} but this is not a key in the mapping'.
-                                format(value)
+                                f'the nested list contained string {value} but this is not a key in the mapping'
                             )
                         else:
                             values.append(str(mapping[value]))
@@ -211,12 +208,12 @@ def convert_input_to_namelist_entry(key, val, mapping=None):
                 idx_string = ','.join(values)
                 itemval = itemval.pop()
             else:
-                idx_string = '{}'.format(idx + 1)
+                idx_string = f'{idx + 1}'
 
-            list_of_strings.append('  {0}({2}) = {1}\n'.format(key, conv_to_fortran(itemval), idx_string))
+            list_of_strings.append(f'  {key}({idx_string}) = {conv_to_fortran(itemval)}\n')
 
         return ''.join(list_of_strings)
 
     # Single value
     else:
-        return '  {0} = {1}\n'.format(key, conv_to_fortran(val))
+        return f'  {key} = {conv_to_fortran(val)}\n'

--- a/aiida_quantumespresso/utils/protocols/pw.py
+++ b/aiida_quantumespresso/utils/protocols/pw.py
@@ -91,7 +91,7 @@ class ProtocolManager:
         try:
             self.modifiers = _get_all_protocol_modifiers()[name]
         except KeyError as exception:
-            raise ValueError("Unknown protocol '{}'".format(name)) from exception
+            raise ValueError(f"Unknown protocol '{name}'") from exception
 
     def get_protocol_data(self, modifiers=None):
         """Return the full info on the specific protocol, using the (optional) modifiers.
@@ -136,7 +136,7 @@ class ProtocolManager:
 
         # Check that there are no unknown modifiers
         if modifiers_copy:
-            raise ValueError('Unknown modifiers specified: {}'.format(','.join(sorted(modifiers_copy))))
+            raise ValueError(f"Unknown modifiers specified: {','.join(sorted(modifiers_copy))}")
 
         retdata = self.get_parameters_data(parameters_modifier_name)
         retdata['pseudo_data'] = pseudo_data

--- a/aiida_quantumespresso/utils/pseudopotential.py
+++ b/aiida_quantumespresso/utils/pseudopotential.py
@@ -38,9 +38,9 @@ def validate_and_prepare_pseudos_inputs(structure, pseudos=None, pseudo_family=N
 
     for kind in structure.get_kind_names():
         if kind not in pseudos:
-            raise ValueError('no pseudo available for element {}'.format(kind))
+            raise ValueError(f'no pseudo available for element {kind}')
         elif not isinstance(pseudos[kind], UpfData):
-            raise ValueError('pseudo for element {} is not of type UpfData'.format(kind))
+            raise ValueError(f'pseudo for element {kind} is not of type UpfData')
 
     return pseudos
 
@@ -95,7 +95,7 @@ def get_pseudos_from_dict(structure, pseudos_uuids):
         try:
             uuid = pseudos_uuids[symbol]
         except KeyError as exception:
-            msg = 'No UPF for element {} found in the provided pseudos_uuids dictionary'.format(symbol)
+            msg = f'No UPF for element {symbol} found in the provided pseudos_uuids dictionary'
             raise NotExistent(msg) from exception
         try:
             upf = load_node(uuid)
@@ -105,11 +105,9 @@ def get_pseudos_from_dict(structure, pseudos_uuids):
                 'in the provided pseudos_uuids dictionary'.format(uuid, symbol)
             ) from exception
         if not isinstance(upf, UpfData):
-            raise ValueError('Node with UUID {} is not a UpfData'.format(uuid))
+            raise ValueError(f'Node with UUID {uuid} is not a UpfData')
         if upf.element != symbol:
-            raise ValueError(
-                'Node<{}> is associated to element {} and not to {} as expected'.format(uuid, upf.element, symbol)
-            )
+            raise ValueError(f'Node<{uuid}> is associated to element {upf.element} and not to {symbol} as expected')
 
         pseudo_list[kind.name] = upf
 

--- a/aiida_quantumespresso/utils/resources.py
+++ b/aiida_quantumespresso/utils/resources.py
@@ -31,7 +31,7 @@ def create_scheduler_resources(scheduler, base, goal):
     try:
         job_resource = scheduler.create_job_resource(**resources)
     except TypeError as exception:
-        raise ValueError('failed to create job resources for {} scheduler'.format(scheduler.__class__)) from exception
+        raise ValueError(f'failed to create job resources for {scheduler.__class__} scheduler') from exception
 
     return {key: value for key, value in job_resource.items() if value is not None}
 

--- a/aiida_quantumespresso/utils/restart.py
+++ b/aiida_quantumespresso/utils/restart.py
@@ -26,7 +26,7 @@ def get_builder_restart(node, from_scratch=False, use_symlink=False):
     supported = (CpCalculation, NebCalculation, PhCalculation, PwCalculation)
 
     if node.process_class not in supported:
-        raise TypeError('calculation class `{}` of {} is not one of {}'.format(node.process_class, node, supported))
+        raise TypeError(f'calculation class `{node.process_class}` of {node} is not one of {supported}')
 
     builder = node.get_builder_restart()
 

--- a/aiida_quantumespresso/workflows/matdyn/base.py
+++ b/aiida_quantumespresso/workflows/matdyn/base.py
@@ -50,7 +50,7 @@ class MatdynBaseWorkChain(BaseRestartWorkChain):
         """
         arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
         self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
-        self.report('Action taken: {}'.format(action))
+        self.report(f'Action taken: {action}')
 
     @process_handler(priority=600)
     def handle_unrecoverable_failure(self, node):

--- a/aiida_quantumespresso/workflows/ph/base.py
+++ b/aiida_quantumespresso/workflows/ph/base.py
@@ -108,7 +108,7 @@ class PhBaseWorkChain(BaseRestartWorkChain):
         """
         arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
         self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
-        self.report('Action taken: {}'.format(action))
+        self.report(f'Action taken: {action}')
 
     @process_handler(priority=600)
     def handle_unrecoverable_failure(self, node):
@@ -134,6 +134,6 @@ class PhBaseWorkChain(BaseRestartWorkChain):
         self.ctx.restart_calc = node
         self.ctx.inputs.parameters.setdefault('INPUTPH', {})['alpha_mix(1)'] = alpha_mix_new
 
-        action = 'reduced alpha_mix from {} to {} and restarting'.format(alpha_mix, alpha_mix_new)
+        action = f'reduced alpha_mix from {alpha_mix} to {alpha_mix_new} and restarting'
         self.report_error_handled(node, action)
         return ProcessHandlerReport(True)

--- a/aiida_quantumespresso/workflows/pw/band_structure.py
+++ b/aiida_quantumespresso/workflows/pw/band_structure.py
@@ -73,7 +73,7 @@ class PwBandStructureWorkChain(WorkChain):
         Based on the specified protocol, we define values for variables that affect the execution of the calculations.
         """
         protocol, protocol_modifiers = self._get_protocol()
-        self.report('running the workchain with the "{}" protocol'.format(protocol.name))
+        self.report(f'running the workchain with the "{protocol.name}" protocol')
         self.ctx.protocol = protocol.get_protocol_data(modifiers=protocol_modifiers)
 
     def setup_parameters(self):
@@ -89,7 +89,7 @@ class PwBandStructureWorkChain(WorkChain):
                 ecutwfc.append(cutoff)
                 ecutrho.append(cutrho)
             except KeyError:
-                self.report('failed to retrieve the cutoff or dual factor for {}'.format(kind))
+                self.report(f'failed to retrieve the cutoff or dual factor for {kind}')
                 return self.exit_codes.ERROR_INVALID_INPUT_UNRECOGNIZED_KIND
 
         self.ctx.parameters = orm.Dict(dict={
@@ -158,7 +158,7 @@ class PwBandStructureWorkChain(WorkChain):
 
         running = self.submit(PwBandsWorkChain, **inputs)
 
-        self.report('launching PwBandsWorkChain<{}>'.format(running.pk))
+        self.report(f'launching PwBandsWorkChain<{running.pk}>')
 
         return ToContext(workchain_bands=running)
 
@@ -167,7 +167,7 @@ class PwBandStructureWorkChain(WorkChain):
         workchain = self.ctx.workchain_bands
 
         if not self.ctx.workchain_bands.is_finished_ok:
-            self.report('sub process PwBandsWorkChain<{}> failed'.format(workchain.pk))
+            self.report(f'sub process PwBandsWorkChain<{workchain.pk}> failed')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_BANDS
 
         self.report('workchain successfully completed')

--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -131,7 +131,7 @@ class PwBandsWorkChain(WorkChain):
 
         running = self.submit(PwRelaxWorkChain, **inputs)
 
-        self.report('launching PwRelaxWorkChain<{}>'.format(running.pk))
+        self.report(f'launching PwRelaxWorkChain<{running.pk}>')
 
         return ToContext(workchain_relax=running)
 
@@ -140,7 +140,7 @@ class PwBandsWorkChain(WorkChain):
         workchain = self.ctx.workchain_relax
 
         if not workchain.is_finished_ok:
-            self.report('PwRelaxWorkChain failed with exit status {}'.format(workchain.exit_status))
+            self.report(f'PwRelaxWorkChain failed with exit status {workchain.exit_status}')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_RELAX
 
         self.ctx.current_structure = workchain.outputs.output_structure
@@ -179,7 +179,7 @@ class PwBandsWorkChain(WorkChain):
         inputs = prepare_process_inputs(PwBaseWorkChain, inputs)
         running = self.submit(PwBaseWorkChain, **inputs)
 
-        self.report('launching PwBaseWorkChain<{}> in {} mode'.format(running.pk, 'scf'))
+        self.report(f'launching PwBaseWorkChain<{running.pk}> in scf mode')
 
         return ToContext(workchain_scf=running)
 
@@ -188,7 +188,7 @@ class PwBandsWorkChain(WorkChain):
         workchain = self.ctx.workchain_scf
 
         if not workchain.is_finished_ok:
-            self.report('scf PwBaseWorkChain failed with exit status {}'.format(workchain.exit_status))
+            self.report(f'scf PwBaseWorkChain failed with exit status {workchain.exit_status}')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_SCF
 
         self.ctx.current_folder = workchain.outputs.remote_folder
@@ -236,7 +236,7 @@ class PwBandsWorkChain(WorkChain):
         inputs = prepare_process_inputs(PwBaseWorkChain, inputs)
         running = self.submit(PwBaseWorkChain, **inputs)
 
-        self.report('launching PwBaseWorkChain<{}> in {} mode'.format(running.pk, 'bands'))
+        self.report(f'launching PwBaseWorkChain<{running.pk}> in bands mode')
 
         return ToContext(workchain_bands=running)
 
@@ -245,7 +245,7 @@ class PwBandsWorkChain(WorkChain):
         workchain = self.ctx.workchain_bands
 
         if not workchain.is_finished_ok:
-            self.report('bands PwBaseWorkChain failed with exit status {}'.format(workchain.exit_status))
+            self.report(f'bands PwBaseWorkChain failed with exit status {workchain.exit_status}')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_BANDS
 
     def results(self):
@@ -274,4 +274,4 @@ class PwBandsWorkChain(WorkChain):
                     pass
 
         if cleaned_calcs:
-            self.report('cleaned remote folders of calculations: {}'.format(' '.join(map(str, cleaned_calcs))))
+            self.report(f"cleaned remote folders of calculations: {' '.join(map(str, cleaned_calcs))}")

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -96,12 +96,12 @@ class PwRelaxWorkChain(WorkChain):
             inputs.pw.parameters.setdefault('SYSTEM', {})['nbnd'] = self.ctx.current_number_of_bands
 
         # Set the `CALL` link label
-        inputs.metadata.call_link_label = 'iteration_{:02d}'.format(self.ctx.iteration)
+        inputs.metadata.call_link_label = f'iteration_{self.ctx.iteration:02d}'
 
         inputs = prepare_process_inputs(PwBaseWorkChain, inputs)
         running = self.submit(PwBaseWorkChain, **inputs)
 
-        self.report('launching PwBaseWorkChain<{}>'.format(running.pk))
+        self.report(f'launching PwBaseWorkChain<{running.pk}>')
 
         return ToContext(workchains=append_(running))
 
@@ -122,7 +122,7 @@ class PwRelaxWorkChain(WorkChain):
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_RELAX
 
         if workchain.is_failed and workchain.exit_status not in PwBaseWorkChain.get_exit_statuses(acceptable_statuses):
-            self.report('relax PwBaseWorkChain failed with exit status {}'.format(workchain.exit_status))
+            self.report(f'relax PwBaseWorkChain failed with exit status {workchain.exit_status}')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_RELAX
 
         try:
@@ -137,8 +137,7 @@ class PwRelaxWorkChain(WorkChain):
         # Set relaxed structure as input structure for next iteration
         self.ctx.current_structure = structure
         self.ctx.current_number_of_bands = workchain.outputs.output_parameters.get_dict()['number_of_bands']
-        self.report('after iteration {} cell volume of relaxed structure is {}'
-            .format(self.ctx.iteration, curr_cell_volume))
+        self.report(f'after iteration {self.ctx.iteration} cell volume of relaxed structure is {curr_cell_volume}')
 
         # After first iteration, simply set the cell volume and restart the next base workchain
         if not prev_cell_volume:
@@ -183,7 +182,7 @@ class PwRelaxWorkChain(WorkChain):
         inputs = prepare_process_inputs(PwBaseWorkChain, inputs)
         running = self.submit(PwBaseWorkChain, **inputs)
 
-        self.report('launching PwBaseWorkChain<{}> for final scf'.format(running.pk))
+        self.report(f'launching PwBaseWorkChain<{running.pk}> for final scf')
 
         return ToContext(workchain_scf=running)
 
@@ -192,13 +191,13 @@ class PwRelaxWorkChain(WorkChain):
         workchain = self.ctx.workchain_scf
 
         if not workchain.is_finished_ok:
-            self.report('final scf PwBaseWorkChain failed with exit status {}'.format(workchain.exit_status))
+            self.report(f'final scf PwBaseWorkChain failed with exit status {workchain.exit_status}')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_FINAL_SCF
 
     def results(self):
         """Attach the output parameters and structure of the last workchain to the outputs."""
         if self.ctx.is_converged and self.ctx.iteration <= self.inputs.max_meta_convergence_iterations.value:
-            self.report('workchain completed after {} iterations'.format(self.ctx.iteration))
+            self.report(f'workchain completed after {self.ctx.iteration} iterations')
         else:
             self.report('maximum number of meta convergence iterations exceeded')
 
@@ -232,4 +231,4 @@ class PwRelaxWorkChain(WorkChain):
                     pass
 
         if cleaned_calcs:
-            self.report('cleaned remote folders of calculations: {}'.format(' '.join(map(str, cleaned_calcs))))
+            self.report(f"cleaned remote folders of calculations: {' '.join(map(str, cleaned_calcs))}")

--- a/aiida_quantumespresso/workflows/q2r/base.py
+++ b/aiida_quantumespresso/workflows/q2r/base.py
@@ -50,7 +50,7 @@ class Q2rBaseWorkChain(BaseRestartWorkChain):
         """
         arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
         self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
-        self.report('Action taken: {}'.format(action))
+        self.report(f'Action taken: {action}')
 
     @process_handler(priority=600)
     def handle_unrecoverable_failure(self, node):

--- a/docs/source/user_guide/get_started/examples/pw_short_example.py
+++ b/docs/source/user_guide/get_started/examples/pw_short_example.py
@@ -90,4 +90,4 @@ builder.kpoints = kpoints
 
 calc = submit(builder)
 
-print('created calculation with PK={}'.format(calc.pk))
+print(f'created calculation with PK={calc.pk}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,7 +197,7 @@ def generate_upf_data(filepath_tests):
         """Return `UpfData` node."""
         from aiida.orm import UpfData
 
-        filepath = os.path.join(filepath_tests, 'fixtures', 'pseudos', '{}.upf'.format(element))
+        filepath = os.path.join(filepath_tests, 'fixtures', 'pseudos', f'{element}.upf')
 
         with io.open(filepath, 'r') as handle:
             upf = UpfData(file=handle.name)

--- a/tests/parsers/test_dos.py
+++ b/tests/parsers/test_dos.py
@@ -38,7 +38,7 @@ def test_dos_default(fixture_localhost, generate_calc_job_node, generate_parser,
             'units': dos_units,
         }
     })
-    num_regression.check({'dos_val_{}'.format(i): val for i, val in enumerate(dos_values)},
+    num_regression.check({f'dos_val_{i}': val for i, val in enumerate(dos_values)},
                          default_tolerance=dict(atol=0, rtol=1e-18))
 
 

--- a/utils/validate_version_number.py
+++ b/utils/validate_version_number.py
@@ -37,9 +37,9 @@ def validate_version():
 
     if version != setup_content['version']:
         click.echo('Version number mismatch detected:')
-        click.echo("Version number in '{}': {}".format(FILENAME_SETUP_JSON, setup_content['version']))
-        click.echo("Version number in '{}/__init__.py': {}".format('aiida_quantumespresso', version))
-        click.echo("Updating version in '{}' to: {}".format(FILENAME_SETUP_JSON, version))
+        click.echo(f"Version number in '{FILENAME_SETUP_JSON}': {setup_content['version']}")
+        click.echo(f"Version number in 'aiida_quantumespresso/__init__.py': {version}")
+        click.echo(f"Updating version in '{FILENAME_SETUP_JSON}' to: {version}")
 
         setup_content['version'] = version
         with open(FILEPATH_SETUP_JSON, 'w') as handle:


### PR DESCRIPTION
Fixes #576 

Since Python 3.5 is no longer supported, format string interpolations
can now be replaced by f-strings, introduced in Python 3.6, which are
more readable, require less characters and are more efficient.

Note that `pylint` issues a warning when using f-strings for log
messages, just as it does for format interpolated strings. The reasoning
is that this is slightly inefficient as the strings are always
interpolated even if the log is discarded, but also by not passing the
formatting parameters as arguments, the available metadata is reduced.
I feel these inefficiencies are premature optimizations as they are
really minimal and don't weigh up against the improved readability and
maintainability of using f-strings. That is why the `pylint` config is
update to ignore the warning `logging-fstring-interpolation` which
replaces `logging-format-interpolation` that was ignored before.

The majority of the conversions were done automatically with the linting
tool `flynt` which is also added as a pre-commit hook. It is added
before the `yapf` step because since `flynt` will touch formatting,
`yapf` will then get a chance to check it.