### PR TITLE
`Parsers`: remove explicit check for the retrieved folder's existence

### DIFF
--- a/aiida_quantumespresso/calculations/cp.py
+++ b/aiida_quantumespresso/calculations/cp.py
@@ -132,8 +132,6 @@ class CpCalculation(BasePwCpInputGenerator):
         spec.output('output_parameters', valid_type=orm.Dict)
         spec.default_output_node = 'output_parameters'
 
-        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
         spec.exit_code(301, 'ERROR_NO_RETRIEVED_TEMPORARY_FOLDER',
             message='The retrieved temporary folder could not be accessed.')
         spec.exit_code(303, 'ERROR_MISSING_XML_FILE',

--- a/aiida_quantumespresso/calculations/dos.py
+++ b/aiida_quantumespresso/calculations/dos.py
@@ -26,8 +26,6 @@ class DosCalculation(NamelistsCalculation):
         spec.output('output_parameters', valid_type=orm.Dict)
         spec.output('output_dos', valid_type=orm.XyData)
         spec.default_output_node = 'output_parameters'
-        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
         spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
             message='The stdout output file could not be read.')
         spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',

--- a/aiida_quantumespresso/calculations/matdyn.py
+++ b/aiida_quantumespresso/calculations/matdyn.py
@@ -34,8 +34,6 @@ class MatdynCalculation(NamelistsCalculation):
         spec.output('output_parameters', valid_type=orm.Dict)
         spec.output('output_phonon_bands', valid_type=orm.BandsData)
         spec.default_output_node = 'output_parameters'
-        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
         spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
             message='The stdout output file could not be read.')
         spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',

--- a/aiida_quantumespresso/calculations/neb.py
+++ b/aiida_quantumespresso/calculations/neb.py
@@ -76,8 +76,6 @@ class NebCalculation(CalcJob):
         spec.output('output_mep', valid_type=orm.ArrayData,
             help='The original and interpolated energy profiles along the minimum-energy path (mep)')
         spec.default_output_node = 'output_parameters'
-        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
         spec.exit_code(303, 'ERROR_MISSING_XML_FILE',
             message='The required XML file is not present in the retrieved folder.')
         spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',

--- a/aiida_quantumespresso/calculations/ph.py
+++ b/aiida_quantumespresso/calculations/ph.py
@@ -59,8 +59,6 @@ class PhCalculation(CalcJob):
         spec.default_output_node = 'output_parameters'
 
         # Unrecoverable errors: required retrieved files could not be read, parsed or are otherwise incomplete
-        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
         spec.exit_code(302, 'ERROR_OUTPUT_STDOUT_MISSING',
             message='The retrieved folder did not contain the required stdout output file.')
         spec.exit_code(305, 'ERROR_OUTPUT_FILES',

--- a/aiida_quantumespresso/calculations/pp.py
+++ b/aiida_quantumespresso/calculations/pp.py
@@ -89,8 +89,6 @@ class PpCalculation(CalcJob):
         spec.default_output_node = 'output_parameters'
 
         # Standard exceptions
-        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
         spec.exit_code(301, 'ERROR_NO_RETRIEVED_TEMPORARY_FOLDER',
             message='The retrieved temporary folder could not be accessed.')
         spec.exit_code(302, 'ERROR_OUTPUT_STDOUT_MISSING',

--- a/aiida_quantumespresso/calculations/projwfc.py
+++ b/aiida_quantumespresso/calculations/projwfc.py
@@ -45,8 +45,6 @@ class ProjwfcCalculation(NamelistsCalculation):
         spec.output('projections', valid_type=ProjectionData, required=False)
         spec.output('bands', valid_type=BandsData, required=False)
         spec.default_output_node = 'output_parameters'
-        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
         spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
             message='The stdout output file could not be read.')
         spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -79,8 +79,6 @@ class PwCalculation(BasePwCpInputGenerator):
         spec.default_output_node = 'output_parameters'
 
         # Unrecoverable errors: required retrieved files could not be read, parsed or are otherwise incomplete
-        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
         spec.exit_code(301, 'ERROR_NO_RETRIEVED_TEMPORARY_FOLDER',
             message='The retrieved temporary folder could not be accessed.')
         spec.exit_code(302, 'ERROR_OUTPUT_STDOUT_MISSING',

--- a/aiida_quantumespresso/calculations/pw2gw.py
+++ b/aiida_quantumespresso/calculations/pw2gw.py
@@ -37,8 +37,6 @@ class Pw2gwCalculation(NamelistsCalculation):
         spec.output('eps', valid_type=orm.ArrayData,
             help='The `eps` output node containing 5 arrays `energy`, `epsX`, `epsY`, `epsZ`, `epsTOT`')
 
-        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
         spec.exit_code(302, 'ERROR_OUTPUT_STDOUT_MISSING',
             message='The retrieved folder did not contain the required stdout output file.')
         spec.exit_code(305, 'ERROR_OUTPUT_FILES',

--- a/aiida_quantumespresso/calculations/pw2wannier90.py
+++ b/aiida_quantumespresso/calculations/pw2wannier90.py
@@ -31,8 +31,6 @@ class Pw2wannier90Calculation(NamelistsCalculation):
                    help='The output folder of a pw.x calculation')
         spec.output('output_parameters', valid_type=Dict)
         spec.default_output_node = 'output_parameters'
-        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
         spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
             message='The stdout output file could not be read.')
         spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',

--- a/aiida_quantumespresso/calculations/q2r.py
+++ b/aiida_quantumespresso/calculations/q2r.py
@@ -31,8 +31,6 @@ class Q2rCalculation(NamelistsCalculation):
         super().define(spec)
         spec.input('parent_folder', valid_type=(orm.RemoteData, orm.FolderData), required=True)
         spec.output('force_constants', valid_type=ForceConstantsData)
-        spec.exit_code(300, 'ERROR_NO_RETRIEVED_FOLDER',
-            message='The retrieved folder data node could not be accessed.')
         spec.exit_code(310, 'ERROR_OUTPUT_STDOUT_READ',
             message='The stdout output file could not be read.')
         spec.exit_code(312, 'ERROR_OUTPUT_STDOUT_INCOMPLETE',

--- a/aiida_quantumespresso/parsers/dos.py
+++ b/aiida_quantumespresso/parsers/dos.py
@@ -2,7 +2,6 @@
 import numpy as np
 
 from aiida.orm import Dict, XyData
-from aiida.common import NotExistent
 
 from aiida_quantumespresso.parsers import QEOutputParsingError
 from aiida_quantumespresso.parsers.parse_raw.base import parse_output_base
@@ -17,15 +16,12 @@ class DosParser(Parser):
 
         Retrieves dos output, and some basic information from the out_file, such as warnings and wall_time
         """
-        try:
-            out_folder = self.retrieved
-        except NotExistent:
-            return self.exit(self.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
+        retrieved = self.retrieved
 
         # Read standard out
         try:
             filename_stdout = self.node.get_option('output_filename')  # or get_attribute(), but this is clearer
-            with out_folder.open(filename_stdout, 'r') as fil:
+            with retrieved.open(filename_stdout, 'r') as fil:
                 out_file = fil.readlines()
         except OSError:
             return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
@@ -41,7 +37,7 @@ class DosParser(Parser):
 
         # check that the dos file is present, if it is, read it
         try:
-            with out_folder.open(self.node.process_class._DOS_FILENAME, 'r') as fil:
+            with retrieved.open(self.node.process_class._DOS_FILENAME, 'r') as fil:
                 dos_file = fil.readlines()
         except OSError:
             return self.exit(self.exit_codes.ERROR_READING_DOS_FILE)

--- a/aiida_quantumespresso/parsers/matdyn.py
+++ b/aiida_quantumespresso/parsers/matdyn.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from aiida import orm
-from aiida.common import exceptions
 from qe_tools import CONSTANTS
 
 from aiida_quantumespresso.calculations.matdyn import MatdynCalculation
@@ -12,21 +11,17 @@ class MatdynParser(Parser):
 
     def parse(self, **kwargs):
         """Parse the retrieved files from a `MatdynCalculation`."""
-        try:
-            output_folder = self.retrieved
-        except exceptions.NotExistent:
-            return self.exit(self.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
-
+        retrieved = self.retrieved
         filename_stdout = self.node.get_option('output_filename')
         filename_frequencies = MatdynCalculation._PHONON_FREQUENCIES_NAME
 
-        if filename_stdout not in output_folder.list_object_names():
+        if filename_stdout not in retrieved.list_object_names():
             return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
 
-        if 'JOB DONE' not in output_folder.get_object_content(filename_stdout):
+        if 'JOB DONE' not in retrieved.get_object_content(filename_stdout):
             return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE)
 
-        if filename_frequencies not in output_folder.list_object_names():
+        if filename_frequencies not in retrieved.list_object_names():
             return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
 
         # Extract the kpoints from the input data and create the `KpointsData` for the `BandsData`
@@ -38,7 +33,7 @@ class MatdynParser(Parser):
             kpoints_for_bands = orm.KpointsData()
             kpoints_for_bands.set_kpoints(kpoints)
 
-        parsed_data = parse_raw_matdyn_phonon_file(output_folder.get_object_content(filename_frequencies))
+        parsed_data = parse_raw_matdyn_phonon_file(retrieved.get_object_content(filename_frequencies))
 
         try:
             num_kpoints = parsed_data.pop('num_kpoints')

--- a/aiida_quantumespresso/parsers/neb.py
+++ b/aiida_quantumespresso/parsers/neb.py
@@ -30,13 +30,8 @@ class NebParser(Parser):
 
         PREFIX = self.node.process_class._PREFIX
 
-        # Check that the retrieved folder is there
-        try:
-            out_folder = self.retrieved
-        except NotExistent:
-            return self.exit(self.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
-
-        list_of_files = out_folder.list_object_names()  # Note: this includes folders, but not the files they contain.
+        retrieved = self.retrieved
+        list_of_files = retrieved.list_object_names()  # Note: this includes folders, but not the files they contain.
 
         # The stdout is required for parsing
         filename_stdout = self.node.get_attribute('output_filename')
@@ -62,7 +57,7 @@ class NebParser(Parser):
 
         # First parse the Neb output
         try:
-            stdout = out_folder.get_object_content(filename_stdout)
+            stdout = retrieved.get_object_content(filename_stdout)
             neb_out_dict, iteration_data, raw_successful = parse_raw_output_neb(stdout, neb_input_dict)
             # TODO: why do we ignore raw_successful ?
         except (OSError, QEOutputParsingError):
@@ -99,7 +94,7 @@ class NebParser(Parser):
                 if xml_filename in retrieved_files:
                     xml_file_path = os.path.join(relative_output_folder, xml_filename)
                     try:
-                        with out_folder.open(xml_file_path) as xml_file:
+                        with retrieved.open(xml_file_path) as xml_file:
                             parsed_data_xml, logs_xml = parse_pw_xml(xml_file, None)
                     except IOError:
                         return self.exit(self.exit_codes.ERROR_OUTPUT_XML_READ)
@@ -120,7 +115,7 @@ class NebParser(Parser):
             # look for pw output and parse it
             pw_out_file = os.path.join(f'{PREFIX}_{i + 1}', 'PW.out')
             try:
-                with out_folder.open(pw_out_file, 'r') as f:
+                with retrieved.open(pw_out_file, 'r') as f:
                     pw_out_text = f.read()  # Note: read() and not readlines()
             except IOError:
                 return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
@@ -192,7 +187,7 @@ class NebParser(Parser):
         # Load the original and interpolated energy profile along the minimum-energy path (mep)
         try:
             filename = PREFIX + '.dat'
-            with out_folder.open(filename, 'r') as handle:
+            with retrieved.open(filename, 'r') as handle:
                 mep = numpy.loadtxt(handle)
         except Exception:
             self.logger.warning(f'could not open expected output file `{filename}`.')
@@ -200,7 +195,7 @@ class NebParser(Parser):
 
         try:
             filename = PREFIX + '.int'
-            with out_folder.open(filename, 'r') as handle:
+            with retrieved.open(filename, 'r') as handle:
                 interp_mep = numpy.loadtxt(handle)
         except Exception:
             self.logger.warning(f'could not open expected output file `{filename}`.')

--- a/aiida_quantumespresso/parsers/pp.py
+++ b/aiida_quantumespresso/parsers/pp.py
@@ -46,11 +46,7 @@ class PpParser(Parser):
         """
         Parse raw files retrieved from remote dir
         """
-        try:
-            self.retrieved
-        except exceptions.NotExistent:
-            return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
-
+        retrieved = self.retrieved
         retrieve_temporary_list = self.node.get_attribute('retrieve_temporary_list', None)
         filename_stdout = self.node.get_option('output_filename')
 
@@ -62,11 +58,11 @@ class PpParser(Parser):
                 return self.exit(self.exit_codes.ERROR_NO_RETRIEVED_TEMPORARY_FOLDER)
 
         # The stdout is required for parsing
-        if filename_stdout not in self.retrieved.list_object_names():
+        if filename_stdout not in retrieved.list_object_names():
             return self.exit_codes.ERROR_OUTPUT_STDOUT_MISSING
 
         try:
-            stdout_raw = self.retrieved.get_object_content(filename_stdout)
+            stdout_raw = retrieved.get_object_content(filename_stdout)
         except (IOError, OSError):
             return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
@@ -89,8 +85,8 @@ class PpParser(Parser):
             filenames = os.listdir(retrieved_temporary_folder)
             file_opener = lambda filename: open(os.path.join(retrieved_temporary_folder, filename))
         else:
-            filenames = self.retrieved.list_object_names()
-            file_opener = self.retrieved.open
+            filenames = retrieved.list_object_names()
+            file_opener = retrieved.open
 
         for filename in filenames:
             if filename.endswith(filename_suffix):

--- a/aiida_quantumespresso/parsers/projwfc.py
+++ b/aiida_quantumespresso/parsers/projwfc.py
@@ -122,10 +122,9 @@ def spin_dependent_subparser(out_info_dict):
     :param out_info_dict: contains various technical internals useful in parsing
     :return: ProjectionData, BandsData parsed from out_file
     """
-
     out_file = out_info_dict['out_file']
     spin_down = out_info_dict['spin_down']
-    od = out_info_dict  #using a shorter name for convenience
+    od = out_info_dict  # using a shorter name for convenience
     #   regular expressions needed for later parsing
     WaveFraction1_re = re.compile(r'\=(.*?)\*')  # state composition 1
     WaveFractionremain_re = re.compile(r'\+(.*?)\*')  # state comp 2
@@ -286,15 +285,12 @@ class ProjwfcParser(Parser):
         Retrieves projwfc output, and some basic information from the out_file, such as warnings and wall_time
         """
         # Check that the retrieved folder is there
-        try:
-            out_folder = self.retrieved
-        except NotExistent:
-            return self.exit(self.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
+        retrieved = self.retrieved
 
         # Read standard out
         try:
             filename_stdout = self.node.get_option('output_filename')  # or get_attribute(), but this is clearer
-            with out_folder.open(filename_stdout, 'r') as fil:
+            with retrieved.open(filename_stdout, 'r') as fil:
                 out_file = fil.readlines()
         except OSError:
             return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
@@ -314,10 +310,10 @@ class ProjwfcParser(Parser):
         self.out('output_parameters', Dict(dict=parsed_data))
 
         # check and read pdos_tot file
-        out_filenames = out_folder.list_object_names()
+        out_filenames = retrieved.list_object_names()
         try:
             pdostot_filename = fnmatch.filter(out_filenames, '*pdos_tot*')[0]
-            with out_folder.open(pdostot_filename, 'r') as pdostot_file:
+            with retrieved.open(pdostot_filename, 'r') as pdostot_file:
                 # Columns: Energy(eV), Ldos, Pdos
                 pdostot_array = np.atleast_2d(np.genfromtxt(pdostot_file))
                 energy = pdostot_array[:, 0]
@@ -329,7 +325,7 @@ class ProjwfcParser(Parser):
         pdos_atm_filenames = fnmatch.filter(out_filenames, '*pdos_atm*')
         pdos_atm_array_dict = {}
         for name in pdos_atm_filenames:
-            with out_folder.open(name, 'r') as pdosatm_file:
+            with retrieved.open(name, 'r') as pdosatm_file:
                 pdos_atm_array_dict[name] = np.atleast_2d(np.genfromtxt(pdosatm_file))
 
         # finding the bands and projections

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -28,11 +28,6 @@ class PwParser(Parser):
         self.exit_code_parser = None
 
         try:
-            self.retrieved
-        except exceptions.NotExistent:
-            return self.exit(self.exit(self.exit_codes.ERROR_NO_RETRIEVED_FOLDER))
-
-        try:
             settings = self.node.inputs.settings.get_dict()
         except exceptions.NotExistent:
             settings = {}

--- a/aiida_quantumespresso/parsers/pw2gw.py
+++ b/aiida_quantumespresso/parsers/pw2gw.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """`Parser` implementation for the `Pw2gwCalculation` calculation job class."""
+import io
 import numpy as np
-from io import StringIO
+
 from aiida import orm
-from aiida.common import exceptions
 
 from aiida_quantumespresso.calculations.pw2gw import Pw2gwCalculation
 from .base import Parser
@@ -21,11 +21,6 @@ class Pw2gwParser(Parser):
         """
         self.exit_code_stdout = None
         self.exit_code_eps = None
-
-        try:
-            self.retrieved
-        except exceptions.NotExistent:
-            return self.exit(self.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
 
         # Parse the pw2gw stout file
         data, logs_stdout = self.parse_stdout()
@@ -62,7 +57,7 @@ class Pw2gwParser(Parser):
             base = name.split('.')[0]
 
             try:
-                data = np.loadtxt(StringIO(content))
+                data = np.loadtxt(io.StringIO(content))
             except ValueError:
                 self.exit_code_eps = self.exit_codes.ERROR_OUTPUT_FILES
                 return

--- a/aiida_quantumespresso/parsers/pw2wannier90.py
+++ b/aiida_quantumespresso/parsers/pw2wannier90.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from aiida.common import NotExistent
 from aiida.orm import Dict
 
 from aiida_quantumespresso.parsers.parse_raw.base import parse_output_base
@@ -16,13 +15,8 @@ class Pw2wannier90Parser(Parser):
         permanently in the repository.
         """
         try:
-            out_folder = self.retrieved
-        except NotExistent:
-            return self.exit(self.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
-
-        try:
             filename_stdout = self.node.get_option('output_filename')  # or get_attribute(), but this is clearer
-            with out_folder.open(filename_stdout, 'r') as fil:
+            with self.retrieved.open(filename_stdout, 'r') as fil:
                 out_file = fil.read()
         except OSError:
             return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)

--- a/aiida_quantumespresso/parsers/q2r.py
+++ b/aiida_quantumespresso/parsers/q2r.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from aiida.common import exceptions
-
 from aiida_quantumespresso.calculations.q2r import Q2rCalculation
 from aiida_quantumespresso.data.force_constants import ForceConstantsData
 from .base import Parser
@@ -11,24 +9,20 @@ class Q2rParser(Parser):
 
     def parse(self, **kwargs):
         """Parse the retrieved files from a `Q2rCalculation`."""
-        try:
-            output_folder = self.retrieved
-        except exceptions.NotExistent:
-            return self.exit(self.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
-
+        retrieved = self.retrieved
         filename_stdout = self.node.get_option('output_filename')
         filename_force_constants = Q2rCalculation._FORCE_CONSTANTS_NAME
 
-        if filename_stdout not in output_folder.list_object_names():
+        if filename_stdout not in retrieved.list_object_names():
             return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_READ)
 
-        if filename_force_constants not in output_folder.list_object_names():
+        if filename_force_constants not in retrieved.list_object_names():
             return self.exit(self.exit_codes.ERROR_READING_FORCE_CONSTANTS_FILE)
 
-        if 'JOB DONE' not in output_folder.get_object_content(filename_stdout):
+        if 'JOB DONE' not in retrieved.get_object_content(filename_stdout):
             return self.exit(self.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE)
 
-        with output_folder.open(filename_force_constants, 'rb') as handle:
+        with retrieved.open(filename_force_constants, 'rb') as handle:
             self.out('force_constants', ForceConstantsData(file=handle))
 
         return

--- a/setup.json
+++ b/setup.json
@@ -89,7 +89,7 @@
         ]
     },
     "install_requires": [
-        "aiida_core[atomic_tools]~=1.3",
+        "aiida_core[atomic_tools]~=1.4,>=1.4.2",
         "packaging",
         "qe-tools~=2.0rc1",
         "xmlschema~=1.2",


### PR DESCRIPTION
Fixes #577 

As of `aiida-core==1.4.0`, the engine itself will check for the presence
of the retrieved folder. If it is missing, which is really just a bug in
`aiida-core` the engine will terminate the process and not call the
parser. Anyway there would be no point since there is nothing to parse.
This means that now if the parser is called, it is guaranteed that the
retrieve folder exists and so we no longer have to explicitly check for
it.

Since this is only valid from `aiida-core>=1.4` we update the dependency
requirement. We also require `aiida-core>=1.4.2` because `1.4.0` and
`1.4.1` contain a bug where the content of files in `local_copy_list`
are copied to the repository even though they shouldn't. For this plugin
this means that mostly the content of the pseudo potentials are
duplicated everytime in the repository, which will bloat the repository
unnecessarily.