### PR TITLE
Pp parser memory fix

### DIFF
--- a/aiida_quantumespresso/parsers/pp.py
+++ b/aiida_quantumespresso/parsers/pp.py
@@ -138,6 +138,7 @@ class PpParser(Parser):
                 try:
                     key = get_key_from_filename(filename)
                     data_parsed.append((key, parsers[iflag](data_raw)))
+                    del data_raw
                 except Exception:  # pylint: disable=broad-except
                     return self.exit_codes.ERROR_OUTPUT_DATAFILE_PARSE.format(filename=filename)
 

--- a/aiida_quantumespresso/parsers/pp.py
+++ b/aiida_quantumespresso/parsers/pp.py
@@ -123,7 +123,7 @@ class PpParser(Parser):
             pattern = r'{}_(.*){}'.format(filename_prefix, filename_suffix)
             matches = re.search(pattern, filename)
             return matches.group(1)
-        
+
         for filename in filenames:
             if filename.endswith(filename_suffix):
                 try:
@@ -131,13 +131,13 @@ class PpParser(Parser):
                         data_raw = handle.read()
                 except OSError:
                     return self.exit_codes.ERROR_OUTPUT_DATAFILE_READ.format(filename=filename)
-                
+
                 try:
                     key = get_key_from_filename(filename)
                     data_parsed.append((key, parsers[iflag](data_raw)))
                 except Exception:  # pylint: disable=broad-except
                     return self.exit_codes.ERROR_OUTPUT_DATAFILE_PARSE.format(filename=filename)
-        
+
         # If we don't have any parsed files, we exit. Note that this will not catch the case where there should be more
         # than one file, but the engine did not retrieve all of them. Since often we anyway don't know how many files
         # should be retrieved there really is no way to check this explicitly.

--- a/aiida_quantumespresso/parsers/pp.py
+++ b/aiida_quantumespresso/parsers/pp.py
@@ -125,13 +125,16 @@ class PpParser(Parser):
             return matches.group(1)
 
         for filename in filenames:
+            # Directly parse the retrieved files after reading them to memory (`data_raw`). `data_raw` is overwritten
+            # in each iteration to improve memory usage.
             if filename.endswith(filename_suffix):
+                # Read the file to memory
                 try:
                     with file_opener(filename) as handle:
                         data_raw = handle.read()
                 except OSError:
                     return self.exit_codes.ERROR_OUTPUT_DATAFILE_READ.format(filename=filename)
-
+                # Parse the file
                 try:
                     key = get_key_from_filename(filename)
                     data_parsed.append((key, parsers[iflag](data_raw)))

--- a/aiida_quantumespresso/parsers/pp.py
+++ b/aiida_quantumespresso/parsers/pp.py
@@ -125,8 +125,8 @@ class PpParser(Parser):
             return matches.group(1)
 
         for filename in filenames:
-            # Directly parse the retrieved files after reading them to memory (`data_raw`). `data_raw` is overwritten
-            # in each iteration to improve memory usage.
+            # Directly parse the retrieved files after reading them to memory (`data_raw`). The raw data
+            # of each file is released from memory after parsing, to improve memory usage.
             if filename.endswith(filename_suffix):
                 # Read the file to memory
                 try:

--- a/aiida_quantumespresso/parsers/pp.py
+++ b/aiida_quantumespresso/parsers/pp.py
@@ -66,8 +66,6 @@ class PpParser(Parser):
         except (IOError, OSError):
             return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
-        data_raw = []
-
         # Currently all plot output files should start with the `filplot` as prefix. If only one file was produced the
         # prefix is the entire filename, but in the case of multiple files, there will be pairs of two files where the
         # first has the format '{filename_prefix}.{some_random_suffix' and the second has the same name but with the
@@ -87,20 +85,6 @@ class PpParser(Parser):
         else:
             filenames = retrieved.list_object_names()
             file_opener = retrieved.open
-
-        for filename in filenames:
-            if filename.endswith(filename_suffix):
-                try:
-                    with file_opener(filename) as handle:
-                        data_raw.append((filename, handle.read()))
-                except OSError:
-                    return self.exit_codes.ERROR_OUTPUT_DATAFILE_READ.format(filename=filename)
-
-        # If we don't have any parsed files, we exit. Note that this will not catch the case where there should be more
-        # than one file, but the engine did not retrieve all of them. Since often we anyway don't know how many files
-        # should be retrieved there really is no way to check this explicitly.
-        if not data_raw:
-            return self.exit_codes.ERROR_OUTPUT_DATAFILE_MISSING.format(filename=filename_prefix)
 
         try:
             logs, self.output_parameters = self.parse_stdout(stdout_raw)
@@ -139,13 +123,26 @@ class PpParser(Parser):
             pattern = r'{}_(.*){}'.format(filename_prefix, filename_suffix)
             matches = re.search(pattern, filename)
             return matches.group(1)
-
-        for filename, data in data_raw:
-            try:
-                key = get_key_from_filename(filename)
-                data_parsed.append((key, parsers[iflag](data)))
-            except Exception:  # pylint: disable=broad-except
-                return self.exit_codes.ERROR_OUTPUT_DATAFILE_PARSE.format(filename=filename)
+        
+        for filename in filenames:
+            if filename.endswith(filename_suffix):
+                try:
+                    with file_opener(filename) as handle:
+                        data_raw = handle.read()
+                except OSError:
+                    return self.exit_codes.ERROR_OUTPUT_DATAFILE_READ.format(filename=filename)
+                
+                try:
+                    key = get_key_from_filename(filename)
+                    data_parsed.append((key, parsers[iflag](data_raw)))
+                except Exception:  # pylint: disable=broad-except
+                    return self.exit_codes.ERROR_OUTPUT_DATAFILE_PARSE.format(filename=filename)
+        
+        # If we don't have any parsed files, we exit. Note that this will not catch the case where there should be more
+        # than one file, but the engine did not retrieve all of them. Since often we anyway don't know how many files
+        # should be retrieved there really is no way to check this explicitly.
+        if not data_parsed:
+            return self.exit_codes.ERROR_OUTPUT_DATAFILE_MISSING.format(filename=filename_prefix)
 
         # Create output nodes
         if len(data_parsed) == 1:


### PR DESCRIPTION
Hello!

This PR considerably reduces the memory usage of the pp.x parser. Before, all the retrieved files were loaded into memory and then parsed. This quickly ate up all the RAM and made our system crash for some of our use cases (e.g. we were parsing many orbital cubes files). Now parsing happens right after each retrieved file is read (and the memory is freed when the next retrieved file is read).