### PR TITLE
projwfc parser allow digit in element name

### DIFF
--- a/aiida_quantumespresso/parsers/projwfc.py
+++ b/aiida_quantumespresso/parsers/projwfc.py
@@ -46,7 +46,7 @@ def find_orbitals_from_statelines(out_info_dict):
 
     out_file = out_info_dict['out_file']
     atomnum_re = re.compile(r'atom\s*([0-9]+?)[^0-9]')
-    element_re = re.compile(r'atom\s*[0-9]+\s*\(\s*(.*?)\s*\)')
+    element_re = re.compile(r'atom\s*[0-9]+\s*\(\s*([A-Za-z0-9_-]+?)\s*\)')
     if out_info_dict['spinorbit']:
         # spinorbit
         lnum_re = re.compile(r'l=\s*([0-9]+?)[^0-9]')

--- a/aiida_quantumespresso/parsers/projwfc.py
+++ b/aiida_quantumespresso/parsers/projwfc.py
@@ -46,7 +46,7 @@ def find_orbitals_from_statelines(out_info_dict):
 
     out_file = out_info_dict['out_file']
     atomnum_re = re.compile(r'atom\s*([0-9]+?)[^0-9]')
-    element_re = re.compile(r'atom\s*[0-9]+\s*\(\s*([A-Za-z]+?)\s*\)')
+    element_re = re.compile(r'atom\s*[0-9]+\s*\(\s*(.*?)\s*\)')
     if out_info_dict['spinorbit']:
         # spinorbit
         lnum_re = re.compile(r'l=\s*([0-9]+?)[^0-9]')


### PR DESCRIPTION
Hi again, I commonly use digits in the species names to mark the initial spin guess (e.g. C1, C2). Recently the projwfc parser stopped supporting these names. I reverted back to the old regex that was used.