### PR TITLE
`ProjwfcParser`: support kind names with numerals, dashes and underscores

### DIFF
--- a/aiida_quantumespresso/parsers/projwfc.py
+++ b/aiida_quantumespresso/parsers/projwfc.py
@@ -4,7 +4,7 @@ import fnmatch
 
 import numpy as np
 
-from aiida.common import NotExistent, LinkType
+from aiida.common import LinkType
 from aiida.orm import Dict, ProjectionData, BandsData, XyData, CalcJobNode
 from aiida.plugins import OrbitalFactory
 
@@ -46,7 +46,7 @@ def find_orbitals_from_statelines(out_info_dict):
 
     out_file = out_info_dict['out_file']
     atomnum_re = re.compile(r'atom\s*([0-9]+?)[^0-9]')
-    element_re = re.compile(r'atom\s*[0-9]+\s*\(\s*([A-Za-z]+?)\s*\)')
+    element_re = re.compile(r'atom\s*[0-9]+\s*\(\s*([A-Za-z0-9-_]+?)\s*\)')
     if out_info_dict['spinorbit']:
         # spinorbit
         lnum_re = re.compile(r'l=\s*([0-9]+?)[^0-9]')

--- a/tests/parsers/fixtures/projwfc/default/aiida.out
+++ b/tests/parsers/fixtures/projwfc/default/aiida.out
@@ -58,14 +58,14 @@ r3i1n10.cx2.hpc.ic.ac.uk:8
      Atomic states used for projection
      (read from pseudopotential files):
 
-     state #   1: atom   1 (Si ), wfc  1 (l=0 m= 1)
-     state #   2: atom   1 (Si ), wfc  2 (l=1 m= 1)
-     state #   3: atom   1 (Si ), wfc  2 (l=1 m= 2)
-     state #   4: atom   1 (Si ), wfc  2 (l=1 m= 3)
-     state #   5: atom   2 (Si ), wfc  1 (l=0 m= 1)
-     state #   6: atom   2 (Si ), wfc  2 (l=1 m= 1)
-     state #   7: atom   2 (Si ), wfc  2 (l=1 m= 2)
-     state #   8: atom   2 (Si ), wfc  2 (l=1 m= 3)
+     state #   1: atom   1 (Si1 ), wfc  1 (l=0 m= 1)
+     state #   2: atom   1 (Si1 ), wfc  2 (l=1 m= 1)
+     state #   3: atom   1 (Si1 ), wfc  2 (l=1 m= 2)
+     state #   4: atom   1 (Si1 ), wfc  2 (l=1 m= 3)
+     state #   5: atom   2 (Si1 ), wfc  1 (l=0 m= 1)
+     state #   6: atom   2 (Si1 ), wfc  2 (l=1 m= 1)
+     state #   7: atom   2 (Si1 ), wfc  2 (l=1 m= 2)
+     state #   8: atom   2 (Si1 ), wfc  2 (l=1 m= 3)
 
  k =   0.0000000000  0.0000000000  0.0000000000
 ==== e(   1) =    -5.51537 eV ====

--- a/tests/parsers/test_projwfc.py
+++ b/tests/parsers/test_projwfc.py
@@ -10,18 +10,26 @@ from aiida.common import AttributeDict, LinkType
 @pytest.fixture
 def generate_inputs(generate_calc_job_node, fixture_localhost, generate_structure, generate_kpoints_mesh):
     """Create the required inputs for the ``ProjwfcCalculation``."""
-    entry_point_name = 'quantumespresso.pw'
-    inputs = {'structure': generate_structure(), 'kpoints': generate_kpoints_mesh(4)}
 
-    parent_calcjob = generate_calc_job_node(entry_point_name, fixture_localhost, 'default', inputs=inputs)
-    params = orm.Dict(dict={'number_of_spin_components': 1})
-    params.add_incoming(parent_calcjob, link_type=LinkType.CREATE, link_label='output_parameters')
-    params.store()
-    inputs = {
-        'parent_folder': parent_calcjob.outputs.remote_folder,
-    }
+    def _generate_inputs(output_parameters=None):
+        entry_point_name = 'quantumespresso.pw'
 
-    return AttributeDict(inputs)
+        parent_inputs = {
+            'structure': generate_structure(),
+            'kpoints': generate_kpoints_mesh(4),
+        }
+        parent = generate_calc_job_node(entry_point_name, fixture_localhost, 'default', inputs=parent_inputs)
+        output_parameters = output_parameters or orm.Dict(dict={'number_of_spin_components': 1})
+        output_parameters.add_incoming(parent, link_type=LinkType.CREATE, link_label='output_parameters')
+        output_parameters.store()
+
+        inputs = {
+            'parent_folder': parent.outputs.remote_folder,
+        }
+
+        return AttributeDict(inputs)
+
+    return _generate_inputs
 
 
 def test_projwfc_default(fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression):
@@ -29,7 +37,7 @@ def test_projwfc_default(fixture_localhost, generate_calc_job_node, generate_par
     entry_point_calc_job = 'quantumespresso.projwfc'
     entry_point_parser = 'quantumespresso.projwfc'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, 'default', generate_inputs)
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, 'default', generate_inputs())
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -47,31 +55,13 @@ def test_projwfc_default(fixture_localhost, generate_calc_job_node, generate_par
     })
 
 
-@pytest.fixture
-def generate_inputs_spin(generate_calc_job_node, fixture_localhost, generate_structure, generate_kpoints_mesh):
-    """Create the required inputs for the ``ProjwfcCalculation`` with nspin=2."""
-    entry_point_name = 'quantumespresso.pw'
-    inputs = {'structure': generate_structure(), 'kpoints': generate_kpoints_mesh(4)}
-
-    parent_calcjob = generate_calc_job_node(entry_point_name, fixture_localhost, 'default', inputs=inputs)
-    params = orm.Dict(dict={'number_of_spin_components': 2})
-    params.add_incoming(parent_calcjob, link_type=LinkType.CREATE, link_label='output_parameters')
-    params.store()
-    inputs = {
-        'parent_folder': parent_calcjob.outputs.remote_folder,
-    }
-
-    return AttributeDict(inputs)
-
-
-def test_projwfc_spin(
-    fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_spin, data_regression
-):
+def test_projwfc_spin(fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression):
     """Test ``ProjwfcParser`` on the results of a LSDA ``projwfc.x`` calculation."""
     entry_point_calc_job = 'quantumespresso.projwfc'
     entry_point_parser = 'quantumespresso.projwfc'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, 'spin', generate_inputs_spin)
+    output_parameters = orm.Dict(dict={'number_of_spin_components': 2})
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, 'spin', generate_inputs(output_parameters))
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -92,31 +82,17 @@ def test_projwfc_spin(
     })
 
 
-@pytest.fixture
-def generate_inputs_noncollinear(generate_calc_job_node, fixture_localhost, generate_structure, generate_kpoints_mesh):
-    """Create the required inputs for the ``ProjwfcCalculation`` with noncolin=.true."""
-    entry_point_name = 'quantumespresso.pw'
-    inputs = {'structure': generate_structure(), 'kpoints': generate_kpoints_mesh(4)}
-
-    parent_calcjob = generate_calc_job_node(entry_point_name, fixture_localhost, 'default', inputs=inputs)
-    params = orm.Dict(dict={'number_of_spin_components': 4, 'non_colinear_calculation': True})
-    params.add_incoming(parent_calcjob, link_type=LinkType.CREATE, link_label='output_parameters')
-    params.store()
-    inputs = {
-        'parent_folder': parent_calcjob.outputs.remote_folder,
-    }
-
-    return AttributeDict(inputs)
-
-
 def test_projwfc_noncollinear(
-    fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_noncollinear, data_regression
+    fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
 ):
     """Test ``ProjwfcParser`` on the results of a noncollinear ``projwfc.x`` calculation."""
     entry_point_calc_job = 'quantumespresso.projwfc'
     entry_point_parser = 'quantumespresso.projwfc'
 
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, 'noncollinear', generate_inputs_noncollinear)
+    output_parameters = orm.Dict(dict={'number_of_spin_components': 4, 'non_colinear_calculation': True})
+    node = generate_calc_job_node(
+        entry_point_calc_job, fixture_localhost, 'noncollinear', generate_inputs(output_parameters)
+    )
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 
@@ -134,37 +110,23 @@ def test_projwfc_noncollinear(
     })
 
 
-@pytest.fixture
-def generate_inputs_spinorbit(generate_calc_job_node, fixture_localhost, generate_structure, generate_kpoints_mesh):
-    """Create the required inputs for the ``ProjwfcCalculation`` with lspinorb=.true."""
-    entry_point_name = 'quantumespresso.pw'
-    inputs = {'structure': generate_structure(), 'kpoints': generate_kpoints_mesh(4)}
+def test_projwfc_spinorbit(
+    fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs, data_regression
+):
+    """Test ``ProjwfcParser`` on the results of a spinorbit ``projwfc.x`` calculation."""
+    entry_point_calc_job = 'quantumespresso.projwfc'
+    entry_point_parser = 'quantumespresso.projwfc'
 
-    parent_calcjob = generate_calc_job_node(entry_point_name, fixture_localhost, 'default', inputs=inputs)
-    params = orm.Dict(
+    output_parameters = orm.Dict(
         dict={
             'number_of_spin_components': 4,
             'non_colinear_calculation': True,
             'spin_orbit_calculation': True
         }
     )
-    params.add_incoming(parent_calcjob, link_type=LinkType.CREATE, link_label='output_parameters')
-    params.store()
-    inputs = {
-        'parent_folder': parent_calcjob.outputs.remote_folder,
-    }
-
-    return AttributeDict(inputs)
-
-
-def test_projwfc_spinorbit(
-    fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs_spinorbit, data_regression
-):
-    """Test ``ProjwfcParser`` on the results of a spinorbit ``projwfc.x`` calculation."""
-    entry_point_calc_job = 'quantumespresso.projwfc'
-    entry_point_parser = 'quantumespresso.projwfc'
-
-    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, 'spinorbit', generate_inputs_spinorbit)
+    node = generate_calc_job_node(
+        entry_point_calc_job, fixture_localhost, 'spinorbit', generate_inputs(output_parameters)
+    )
     parser = generate_parser(entry_point_parser)
     results, calcfunction = parser.parse_from_node(node, store_provenance=False)
 

--- a/tests/parsers/test_projwfc/test_projwfc_default.yml
+++ b/tests/parsers/test_projwfc/test_projwfc_default.yml
@@ -78,7 +78,7 @@ projections:
   - _orbital_type: realhydrogen
     angular_momentum: 0
     diffusivity: null
-    kind_name: Si
+    kind_name: Si1
     magnetic_number: 0
     position:
     - 0.0
@@ -92,7 +92,7 @@ projections:
   - _orbital_type: realhydrogen
     angular_momentum: 1
     diffusivity: null
-    kind_name: Si
+    kind_name: Si1
     magnetic_number: 0
     position:
     - 0.0
@@ -106,7 +106,7 @@ projections:
   - _orbital_type: realhydrogen
     angular_momentum: 1
     diffusivity: null
-    kind_name: Si
+    kind_name: Si1
     magnetic_number: 1
     position:
     - 0.0
@@ -120,7 +120,7 @@ projections:
   - _orbital_type: realhydrogen
     angular_momentum: 1
     diffusivity: null
-    kind_name: Si
+    kind_name: Si1
     magnetic_number: 2
     position:
     - 0.0
@@ -134,7 +134,7 @@ projections:
   - _orbital_type: realhydrogen
     angular_momentum: 0
     diffusivity: null
-    kind_name: Si
+    kind_name: Si1
     magnetic_number: 0
     position:
     - 1.3575
@@ -148,7 +148,7 @@ projections:
   - _orbital_type: realhydrogen
     angular_momentum: 1
     diffusivity: null
-    kind_name: Si
+    kind_name: Si1
     magnetic_number: 0
     position:
     - 1.3575
@@ -162,7 +162,7 @@ projections:
   - _orbital_type: realhydrogen
     angular_momentum: 1
     diffusivity: null
-    kind_name: Si
+    kind_name: Si1
     magnetic_number: 1
     position:
     - 1.3575
@@ -176,7 +176,7 @@ projections:
   - _orbital_type: realhydrogen
     angular_momentum: 1
     diffusivity: null
-    kind_name: Si
+    kind_name: Si1
     magnetic_number: 2
     position:
     - 1.3575


### PR DESCRIPTION
Fixes #590 

The regex defined in the `find_orbitals_from_statelines` parsing method
to parse the kind names, only matched alpha numeric characters, even
though the Quantum ESPRESSO spec clearly allows numbers, dashes and
underscores to be used as well. The regex is updated accordingly.

To test this, the output of the `default` test is modified manually to
use `Si1` as the kind name, which now functions as a regression test.

Co-authored-by: Kristjan Eimre <eimrek@users.noreply.github.com>