### PR TITLE
`PwCalculation`: fix bug when `hubbard_file` is specified

### DIFF
--- a/aiida_quantumespresso/calculations/__init__.py
+++ b/aiida_quantumespresso/calculations/__init__.py
@@ -122,9 +122,9 @@ class BasePwCpInputGenerator(CalcJob):
             local_copy_list.append((uuid, src_path, dst_path))
 
         if 'hubbard_file' in self.inputs:
-            uuid = self.inputs.hubbard_file.filename
+            uuid = self.inputs.hubbard_file.uuid
             src_path = self.inputs.hubbard_file.filename
-            dst_path = self.input_file_name_hubbard_file
+            dst_path = self.filename_input_hubbard_parameters
             local_copy_list.append((uuid, src_path, dst_path))
 
         arguments = [

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -145,7 +145,7 @@ class PwCalculation(BasePwCpInputGenerator):
             message='The variable cell optimization broke the symmetry of the k-points.')
 
     @classproperty
-    def input_file_name_hubbard_file(cls):
+    def filename_input_hubbard_parameters(cls):
         """Return the relative file name of the file containing the Hubbard parameters.
 
         .. note:: This only applies if they should be read from file instead of specified in the input file cards.
@@ -159,7 +159,7 @@ class PwCalculation(BasePwCpInputGenerator):
                 'this is determined by the aiida-quantumespresso-hp plugin but it is not installed'
             ) from exc
 
-        return HpCalculation.input_file_name_hubbard_file
+        return HpCalculation.filename_input_hubbard_parameters
 
     @classmethod
     def input_helper(cls, *args, **kwargs):


### PR DESCRIPTION
Fixes #595 

The `prepare_for_submission` was using the `filename` of the
`hubbard_file` input as the UUID in the `local_copy_list` which
obviously fails. In addition, the `input_file_name_hubbard_file`
classproperty of the `HpCalculation` clas was changed and adapted here
to `filename_input_hubbard_parameters`.

Note that a test cannot be added because it would have to depend on the
`aiida-quantumespresso-hp` plugin, which itself depends on
`aiida-quantumespresso`, creating a circular dependency. The test will
be added to the former to make sure this behavior works.