### PR TITLE
Remove parser information from output_parameters

### DIFF
--- a/aiida_quantumespresso/parsers/__init__.py
+++ b/aiida_quantumespresso/parsers/__init__.py
@@ -5,24 +5,3 @@ from aiida.common import OutputParsingError
 class QEOutputParsingError(OutputParsingError):
     """Exception raised when there is a parsing error in the QE parser."""
     pass
-
-
-def get_parser_info(parser_info_template=None):
-    """Return a template dictionary with details about the parser such as the version.
-
-    :param parser_info_template: template string with single placeholder to be replaced by current version number
-    :returns: dictionary with parser name, version and empty list for warnings
-    """
-    import aiida_quantumespresso
-
-    parser_version = aiida_quantumespresso.__version__
-    parser_info = {}
-    parser_info['parser_warnings'] = []
-    parser_info['parser_version'] = parser_version
-
-    if parser_info_template is None:
-        parser_info['parser_info'] = f'aiida-quantumespresso parser v{parser_version}'
-    else:
-        parser_info['parser_info'] = parser_info_template.format(parser_version)
-
-    return parser_info

--- a/aiida_quantumespresso/parsers/parse_raw/base.py
+++ b/aiida_quantumespresso/parsers/parse_raw/base.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """A basic parser for the common format of QE."""
-from aiida_quantumespresso.parsers import get_parser_info
 
 __all__ = ('parse_output_base', 'parse_output_error', 'convert_qe_time_to_sec', 'convert_qe2aiida_structure')
 
@@ -21,7 +20,7 @@ def parse_output_base(filecontent, codename=None, message_map=None):
         raise RuntimeError(f'invalid format `message_map`: should be dictionary with two keys {keys}')
 
     logs = get_logging_container()
-    parsed_data = get_parser_info(parser_info_template='aiida-quantumespresso parser simple v{}')
+    parsed_data = {}
 
     lines = filecontent if isinstance(filecontent, list) else filecontent.split('\n')
 

--- a/aiida_quantumespresso/parsers/parse_raw/cp.py
+++ b/aiida_quantumespresso/parsers/parse_raw/cp.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from xml.dom.minidom import parseString
-from aiida_quantumespresso.parsers import QEOutputParsingError, get_parser_info
+from aiida_quantumespresso.parsers import QEOutputParsingError
 from aiida_quantumespresso.parsers.parse_xml.pw.legacy import (
     read_xml_card, parse_xml_child_integer, xml_card_header, parse_xml_child_bool, parse_xml_child_str,
     parse_xml_child_float, parse_xml_child_attribute_str, xml_card_cell, xml_card_ions, xml_card_exchangecorrelation,
@@ -151,10 +151,10 @@ def parse_cp_xml_counter_output(data):
 
 def parse_cp_raw_output(stdout, output_xml=None, output_xml_counter=None):
 
-    parser_info = get_parser_info(parser_info_template='aiida-quantumespresso parser cp.x v{}')
+    parser_warnings = []
 
     if output_xml is None:
-        parser_info['parser_warnings'].append('Skipping the parsing of the xml file.')
+        parser_warnings.append('Skipping the parsing of the xml file.')
         xml_data = {}
     else:
         xml_data = parse_cp_xml_output(output_xml)
@@ -179,7 +179,10 @@ def parse_cp_raw_output(stdout, output_xml=None, output_xml_counter=None):
         # out_data keys take precedence and overwrite xml_data keys,
         # if the same key name is shared by both (but this should not happen!)
 
-    final_data = dict(list(xml_data.items()) + list(out_data.items()) + list(xml_counter_data.items()))
+    final_data = dict(
+        list(xml_data.items()) + list(out_data.items()) + list(xml_counter_data.items()) +
+        [('parser_warnings', parser_warnings)]
+    )
 
     # TODO: parse the trajectory and save them in a reasonable format
 

--- a/aiida_quantumespresso/parsers/parse_raw/ph.py
+++ b/aiida_quantumespresso/parsers/parse_raw/ph.py
@@ -8,7 +8,7 @@ import numpy
 
 from qe_tools import CONSTANTS
 
-from aiida_quantumespresso.parsers import QEOutputParsingError, get_parser_info
+from aiida_quantumespresso.parsers import QEOutputParsingError
 from aiida_quantumespresso.parsers.parse_raw.base import convert_qe_time_to_sec
 from aiida_quantumespresso.parsers.parse_xml.pw.legacy import parse_xml_child_bool, read_xml_card
 from aiida_quantumespresso.utils.mapping import get_logging_container
@@ -24,7 +24,6 @@ def parse_raw_ph_output(stdout, tensors=None, dynamical_matrices=None):
     """
     logs = get_logging_container()
     data_lines = stdout.split('\n')
-    parser_info = get_parser_info(parser_info_template='aiida-quantumespresso parser ph.x v{}')
 
     # First check whether the `JOB DONE` message was written, otherwise the job was interrupted
     for line in data_lines:
@@ -78,9 +77,7 @@ def parse_raw_ph_output(stdout, tensors=None, dynamical_matrices=None):
             raise AssertionError(f'{key} found in two dictionaries')
 
     # I don't check the dynmat_data and parser_info keys
-    parsed_data = dict(
-        list(dynmat_data.items()) + list(out_data.items()) + list(tensor_data.items()) + list(parser_info.items())
-    )
+    parsed_data = dict(list(dynmat_data.items()) + list(out_data.items()) + list(tensor_data.items()))
 
     return parsed_data, logs
 

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -339,12 +339,8 @@ class PwParser(Parser):
 
         :param parsed_stdout: the raw parsed data dictionary from the stdout output file
         :param parsed_xml: the raw parsed data dictionary from the XML output file
-        :return: the union of the two parsed raw and information about the parser
+        :return: the union of the two raw parsed data dictionaries
         """
-        from aiida_quantumespresso.parsers import get_parser_info
-
-        parsed_info = get_parser_info(parser_info_template='aiida-quantumespresso parser pw.x v{}')
-
         for key in list(parsed_stdout.keys()):
             if key in list(parsed_xml.keys()):
                 if parsed_stdout[key] != parsed_xml[key]:
@@ -354,7 +350,7 @@ class PwParser(Parser):
                         )
                     )
 
-        parameters = dict(list(parsed_xml.items()) + list(parsed_stdout.items()) + list(parsed_info.items()))
+        parameters = dict(list(parsed_xml.items()) + list(parsed_stdout.items()))
 
         return parameters
 

--- a/tests/parsers/test_cp/test_cp_default.yml
+++ b/tests/parsers/test_cp/test_cp_default.yml
@@ -136,6 +136,7 @@ parameters:
   number_of_processors_per_taskgroup: 1
   number_of_species: 1
   number_of_spin_components: 1
+  parser_warnings: []
   pp_check_flag: true
   reciprocal_lattice_vectors:
   - - -0.1851851851851852

--- a/tests/parsers/test_dos/test_dos_default.yml
+++ b/tests/parsers/test_dos/test_dos_default.yml
@@ -11,8 +11,5 @@ dos:
   - states/eV
 parameters:
   code_version: v.6.4.1
-  parser_info: aiida-quantumespresso parser simple v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   wall_time: 0.41s
   wall_time_seconds: 0.41

--- a/tests/parsers/test_neb/test_neb_default.yml
+++ b/tests/parsers/test_neb/test_neb_default.yml
@@ -50,8 +50,6 @@ parameters:
   nstep_path: 20
   num_of_images: 3
   opt_scheme: broyden
-  parser_info: aiida-quantumespresso parser neb.x v3.2.1
-  parser_version: 3.2.1
   parser_warnings: []
   path_length: 2.95757141880951
   path_thr: 0.05
@@ -132,9 +130,6 @@ parameters:
     number_of_spin_components: 2
     number_of_symmetries: 8
     occupations: smearing
-    parser_info: aiida-quantumespresso parser pw.x v3.2.1
-    parser_version: 3.2.1
-    parser_warnings: []
     q_real_space: false
     rho_cutoff: 1360.56917253
     rho_cutoff_units: eV
@@ -231,9 +226,6 @@ parameters:
     number_of_spin_components: 2
     number_of_symmetries: 16
     occupations: smearing
-    parser_info: aiida-quantumespresso parser pw.x v3.2.1
-    parser_version: 3.2.1
-    parser_warnings: []
     q_real_space: false
     rho_cutoff: 1360.56917253
     rho_cutoff_units: eV
@@ -362,9 +354,6 @@ parameters:
     number_of_spin_components: 2
     number_of_symmetries: 8
     occupations: smearing
-    parser_info: aiida-quantumespresso parser pw.x v3.2.1
-    parser_version: 3.2.1
-    parser_warnings: []
     q_real_space: false
     rho_cutoff: 1360.56917253
     rho_cutoff_units: eV

--- a/tests/parsers/test_ph/test_ph_default.yml
+++ b/tests/parsers/test_ph/test_ph_default.yml
@@ -47,8 +47,5 @@ number_of_atoms: 2
 number_of_irr_representations_for_each_q:
 - 2
 number_of_qpoints: 1
-parser_info: aiida-quantumespresso parser ph.x v3.2.1
-parser_version: 3.2.1
-parser_warnings: []
 wall_time: '        15.25s '
 wall_time_seconds: 15.25

--- a/tests/parsers/test_ph/test_ph_not_converged.yml
+++ b/tests/parsers/test_ph/test_ph_not_converged.yml
@@ -3,8 +3,5 @@ number_of_irr_representations_for_each_q:
 - 2
 - 4
 number_of_qpoints: 8
-parser_info: aiida-quantumespresso parser ph.x v3.2.1
-parser_version: 3.2.1
-parser_warnings: []
 wall_time: '     3m21.58s '
 wall_time_seconds: 201.57999999999998

--- a/tests/parsers/test_ph/test_ph_out_of_walltime.yml
+++ b/tests/parsers/test_ph/test_ph_out_of_walltime.yml
@@ -3,8 +3,5 @@ number_of_irr_representations_for_each_q:
 - 2
 - 4
 number_of_qpoints: 3
-parser_info: aiida-quantumespresso parser ph.x v3.2.1
-parser_version: 3.2.1
-parser_warnings: []
 wall_time: '         7.13s '
 wall_time_seconds: 7.13

--- a/tests/parsers/test_pw/test_pw_default.yml
+++ b/tests/parsers/test_pw/test_pw_default.yml
@@ -80,9 +80,6 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   pp_check_flag: true
   q_real_space: false
   rho_cutoff: 3265.366014072

--- a/tests/parsers/test_pw/test_pw_default_no_xml.yml
+++ b/tests/parsers/test_pw/test_pw_default_no_xml.yml
@@ -25,9 +25,6 @@ output_parameters:
   number_of_bands: 4
   number_of_k_points: 3
   number_of_species: 1
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   scf_iterations: 5
   smooth_fft_grid:
   - 25

--- a/tests/parsers/test_pw/test_pw_default_xml_190304.yml
+++ b/tests/parsers/test_pw/test_pw_default_xml_190304.yml
@@ -93,9 +93,6 @@ output_parameters:
   number_of_spin_components: 1
   number_of_symmetries: 48
   occupations: fixed
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   q_real_space: false
   rho_cutoff: 3265.366014072
   rho_cutoff_units: eV

--- a/tests/parsers/test_pw/test_pw_default_xml_191206.yml
+++ b/tests/parsers/test_pw/test_pw_default_xml_191206.yml
@@ -99,9 +99,6 @@ output_parameters:
   number_of_spin_components: 1
   number_of_symmetries: 48
   occupations: fixed
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   q_real_space: false
   rho_cutoff: 272.113834506
   rho_cutoff_units: eV

--- a/tests/parsers/test_pw/test_pw_default_xml_200420.yml
+++ b/tests/parsers/test_pw/test_pw_default_xml_200420.yml
@@ -96,9 +96,6 @@ output_parameters:
   number_of_spin_components: 1
   number_of_symmetries: 48
   occupations: fixed
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   q_real_space: false
   rho_cutoff: 3265.366014072
   rho_cutoff_units: eV

--- a/tests/parsers/test_pw/test_pw_failed_interrupted.yml
+++ b/tests/parsers/test_pw/test_pw_failed_interrupted.yml
@@ -23,9 +23,6 @@ number_of_atoms: 2
 number_of_bands: 4
 number_of_k_points: 3
 number_of_species: 1
-parser_info: aiida-quantumespresso parser pw.x v3.2.1
-parser_version: 3.2.1
-parser_warnings: []
 scf_iterations: 5
 smooth_fft_grid:
 - 25

--- a/tests/parsers/test_pw/test_pw_failed_interrupted_stdout.yml
+++ b/tests/parsers/test_pw/test_pw_failed_interrupted_stdout.yml
@@ -58,9 +58,6 @@ number_of_k_points: 3
 number_of_species: 1
 number_of_spin_components: 1
 number_of_symmetries: 48
-parser_info: aiida-quantumespresso parser pw.x v3.2.1
-parser_version: 3.2.1
-parser_warnings: []
 pp_check_flag: true
 q_real_space: false
 rho_cutoff: 3265.366014072

--- a/tests/parsers/test_pw/test_pw_failed_interrupted_xml.yml
+++ b/tests/parsers/test_pw/test_pw_failed_interrupted_xml.yml
@@ -23,9 +23,6 @@ number_of_atoms: 2
 number_of_bands: 4
 number_of_k_points: 3
 number_of_species: 1
-parser_info: aiida-quantumespresso parser pw.x v3.2.1
-parser_version: 3.2.1
-parser_warnings: []
 scf_iterations: 5
 smooth_fft_grid:
 - 25

--- a/tests/parsers/test_pw/test_pw_failed_out_of_walltime.yml
+++ b/tests/parsers/test_pw/test_pw_failed_out_of_walltime.yml
@@ -46,9 +46,6 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   pp_check_flag: false
   q_real_space: false
   rho_cutoff: 3265.366014072

--- a/tests/parsers/test_pw/test_pw_failed_out_of_walltime_interrupted.yml
+++ b/tests/parsers/test_pw/test_pw_failed_out_of_walltime_interrupted.yml
@@ -1,7 +1,4 @@
-output_parameters:
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
+output_parameters: {}
 output_trajectory:
   array|cells:
   - 1

--- a/tests/parsers/test_pw/test_pw_failed_scf_not_converged.yml
+++ b/tests/parsers/test_pw/test_pw_failed_scf_not_converged.yml
@@ -47,9 +47,6 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   pp_check_flag: false
   q_real_space: false
   rho_cutoff: 3265.366014072

--- a/tests/parsers/test_pw/test_pw_initialization_xml_new.yml
+++ b/tests/parsers/test_pw/test_pw_initialization_xml_new.yml
@@ -52,9 +52,6 @@ output_parameters:
   number_of_spin_components: 1
   number_of_symmetries: 48
   occupations: fixed
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   q_real_space: false
   rho_cutoff: 3265.366014072
   rho_cutoff_units: eV

--- a/tests/parsers/test_pw/test_pw_relax_success.yml
+++ b/tests/parsers/test_pw/test_pw_relax_success.yml
@@ -79,9 +79,6 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   pp_check_flag: true
   q_real_space: false
   rho_cutoff: 3265.366014072

--- a/tests/parsers/test_pw/test_pw_vcrelax_success.yml
+++ b/tests/parsers/test_pw/test_pw_vcrelax_success.yml
@@ -81,9 +81,6 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   pp_check_flag: true
   q_real_space: false
   rho_cutoff: 3265.366014072

--- a/tests/parsers/test_pw/test_pw_vcrelax_success_fractional.yml
+++ b/tests/parsers/test_pw/test_pw_vcrelax_success_fractional.yml
@@ -81,9 +81,6 @@ output_parameters:
   number_of_species: 1
   number_of_spin_components: 1
   number_of_symmetries: 48
-  parser_info: aiida-quantumespresso parser pw.x v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   pointgroup_international: m-3m
   pointgroup_schoenflies: O_h
   pp_check_flag: true

--- a/tests/parsers/test_pw2wannier90/test_pw2wannier90_default.yml
+++ b/tests/parsers/test_pw2wannier90/test_pw2wannier90_default.yml
@@ -1,7 +1,4 @@
 parameters:
   code_version: v.6.4.1
-  parser_info: aiida-quantumespresso parser simple v3.2.1
-  parser_version: 3.2.1
-  parser_warnings: []
   wall_time: 2.18s
   wall_time_seconds: 2.18


### PR DESCRIPTION
Fixes #582 

Now that aiida-core [adds both the AiiDA and plugin version to the
CalcJob node attributes](https://github.com/aiidateam/aiida-core/commit/5058e23c93f1f5f7fbcdffe82ab5dd7dd1f01829), as well as the parser name, it is no longer
necessary to add this information to the output_parameters dictionary.
This PR removes the get_parser_info() function that generates this
output.

The `parser_warnings` are also removed for the base/pw/ph parsers, since
they were not used here. We leave the `parser_warnings` for the neb/cp
parsers, but these should be replaced in a future PR by the use of a
logging container.