### PR TITLE
`PwBaseWorkChain`: deprecate the `pseudo_family` input

### DIFF
--- a/aiida_quantumespresso/utils/pseudopotential.py
+++ b/aiida_quantumespresso/utils/pseudopotential.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Utilities for pseudo potentials."""
+import warnings
+from aiida.common.warnings import AiidaDeprecationWarning
 from aiida.orm.nodes.data.upf import UpfData, get_pseudos_from_structure
 
 
@@ -25,6 +27,8 @@ def validate_and_prepare_pseudos_inputs(structure, pseudos=None, pseudo_family=N
     :returns: a dictionary of UpfData nodes where the key is the kind name
     """
     from aiida.orm import Str
+
+    warnings.warn('this function is deprecated and will be removed in `v4.0.0`.', AiidaDeprecationWarning)
 
     if pseudos and pseudo_family:
         raise ValueError('you cannot specify both "pseudos" and "pseudo_family"')
@@ -54,6 +58,8 @@ def get_pseudos_of_calc(calc):
     :return: a dictionary where the key is the kind name and the value is the UpfData object.
     """
     from aiida.common.links import LinkType
+
+    warnings.warn('this function is deprecated and will be removed in `v4.0.0`.', AiidaDeprecationWarning)
 
     pseudos = {}
     # I create here a dictionary that associates each kind name to a pseudo
@@ -88,6 +94,8 @@ def get_pseudos_from_dict(structure, pseudos_uuids):
     """
     from aiida.common import NotExistent
     from aiida.orm import load_node
+
+    warnings.warn('this function is deprecated and will be removed in `v4.0.0`.', AiidaDeprecationWarning)
 
     pseudo_list = {}
     for kind in structure.kinds:

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -15,6 +15,14 @@ from aiida_quantumespresso.utils.resources import cmdline_remove_npools, create_
 PwCalculation = CalculationFactory('quantumespresso.pw')
 
 
+def validate_pseudo_family(value, _):
+    """Validate the `pseudo_family` input."""
+    if value is not None:
+        import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning
+        warnings.warn('`pseudo_family` is deprecated, use `pw.pseudos` instead.', AiidaDeprecationWarning)
+
+
 class PwBaseWorkChain(BaseRestartWorkChain):
     """Workchain to run a Quantum ESPRESSO pw.x calculation with automated error handling and restarts."""
 
@@ -48,10 +56,10 @@ class PwBaseWorkChain(BaseRestartWorkChain):
             help='Optional input when constructing the k-points based on a desired `kpoints_distance`. Setting this to '
                  '`True` will force the k-point mesh to have an even number of points along each lattice vector except '
                  'for any non-periodic directions.')
-        spec.input('pseudo_family', valid_type=orm.Str, required=False,
-            help='An alternative to specifying the pseudo potentials manually in `pseudos`: one can specify the name '
-                 'of an existing pseudo potential family and the work chain will generate the pseudos automatically '
-                 'based on the input structure.')
+        spec.input('pseudo_family', valid_type=orm.Str, required=False, validator=validate_pseudo_family,
+            help='[Deprecated: use `pw.pseudos` instead] An alternative to specifying the pseudo potentials manually in'
+                 ' `pseudos`: one can specify the name of an existing pseudo potential family and the work chain will '
+                 'generate the pseudos automatically based on the input structure.')
         spec.input('automatic_parallelization', valid_type=orm.Dict, required=False,
             help='When defined, the work chain will first launch an initialization calculation to determine the '
                  'dimensions of the problem, and based on this it will try to set optimal parallelization flags.')


### PR DESCRIPTION
Fixes #601 

The use of a `pseudo_family`, which has to be passed in as a `Str` node
to represent the name of a `Group`, is not robust with respect to the
provenance. Since groups are mutable, rerunning a workchain that used
the `pseudo_family` to determine what pseudos to run, can lead to a
rerun using different pseudos. This input exists for historical reasons
because it made the usage of the workflows easier for users, since they
wouldn't have to build the mapping of pseudos themselves, but with the
advent of `aiida-pseudo` and the input generators, this is no longer an
issue and it is preferable to directly pass the pseudos into the
`pseudos` input namespace.