### PR TITLE
`PwBaseWorkChain`: restart from scratch when convergence not reached

### DIFF
--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -454,7 +454,7 @@ class PwBaseWorkChain(BaseRestartWorkChain):
         mixing_beta = self.ctx.inputs.parameters.get('ELECTRONS', {}).get('mixing_beta', self.defaults.qe.mixing_beta)
         mixing_beta_new = mixing_beta * factor
 
-        self.ctx.restart_calc = calculation
+        self.ctx.restart_calc = None
         self.ctx.inputs.parameters.setdefault('ELECTRONS', {})['mixing_beta'] = mixing_beta_new
 
         action = f'reduced beta mixing from {mixing_beta} to {mixing_beta_new} and restarting from the last calculation'

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -72,6 +72,21 @@ def test_handle_out_of_walltime(generate_workchain_pw):
     assert result.status == 0
 
 
+def test_handle_electronic_convergence_not_reached(generate_workchain_pw):
+    """Test `PwBaseWorkChain.handle_electronic_convergence_not_achieved`."""
+    process = generate_workchain_pw(exit_code=PwCalculation.exit_codes.ERROR_ELECTRONIC_CONVERGENCE_NOT_REACHED)
+    process.setup()
+    process.validate_parameters()
+
+    result = process.handle_electronic_convergence_not_achieved(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert process.ctx.restart_calc is None
+
+    result = process.inspect_process()
+    assert result.status == 0
+
+
 def test_handle_known_unrecoverable_failure(generate_workchain_pw):
     """Test `PwBaseWorkChain.handle_known_unrecoverable_failure`."""
     process = generate_workchain_pw(exit_code=PwCalculation.exit_codes.ERROR_COMPUTING_CHOLESKY)


### PR DESCRIPTION
Fixes #602 

This was already being done by the handler for relax/vc-relax
calculations where electronic convergence was not reached, but for
normal scf/nscf calculations, the restart was done from the last
calculation. It is not yet clear which approach will guarantee a higher
convergency rate, as in some cases restarting from scratch is better,
whereas in others it is detrimental, but at least the approaches should
be the same. The handler for `ERROR_ELECTRONIC_CONVERGENCE_NOT_REACHED`
is therefore updated to also restart from scratch, as the docstring
already said it would do.