### PR TITLE
Dependencies: update the `aiida-pseudo` requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ good-names = [
     'i',
     'j',
     'k',
+    'SsspFamily',
+    'StructureData',
     'UpfData',
     'HpCalculation',
     'PwCalculation',

--- a/setup.json
+++ b/setup.json
@@ -90,7 +90,7 @@
     },
     "install_requires": [
         "aiida_core[atomic_tools]~=1.4,>=1.4.2",
-        "aiida-pseudo~=0.1",
+        "aiida-pseudo~=0.3",
         "packaging",
         "qe-tools~=2.0rc1",
         "xmlschema~=1.2,>=1.2.5",

--- a/tests/cli/calculations/test_cp.py
+++ b/tests/cli/calculations/test_cp.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch cp`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.cp import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
-def test_command_base(run_cli_process_launch_command, fixture_code, generate_upf_family):
+def test_command_base(run_cli_process_launch_command, fixture_code, sssp):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.cp').store()
-    family = generate_upf_family()
-    options = ['-X', code.full_label, '-F', family.label]
+    options = ['-X', code.full_label, '-F', sssp.label]
     run_cli_process_launch_command(launch_calculation, options=options)

--- a/tests/cli/calculations/test_dos.py
+++ b/tests/cli/calculations/test_dos.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch dos`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.dos import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
 def test_command_base(run_cli_process_launch_command, fixture_code, generate_calc_job_node):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.dos').store()

--- a/tests/cli/calculations/test_epw.py
+++ b/tests/cli/calculations/test_epw.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch epw`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.epw import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
 def test_command_base(run_cli_process_launch_command, fixture_code, generate_calc_job_node):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.epw').store()

--- a/tests/cli/calculations/test_matdyn.py
+++ b/tests/cli/calculations/test_matdyn.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch matdyn`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.matdyn import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
 def test_command_base(run_cli_process_launch_command, fixture_code, generate_force_constants_data):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.matdyn').store()

--- a/tests/cli/calculations/test_neb.py
+++ b/tests/cli/calculations/test_neb.py
@@ -1,15 +1,11 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch neb`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.neb import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
-def test_command_base(run_cli_process_launch_command, fixture_code, generate_upf_family, generate_structure):
+def test_command_base(run_cli_process_launch_command, fixture_code, sssp, generate_structure):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.neb').store()
-    family = generate_upf_family()
     structures = [generate_structure().store().pk, generate_structure().store().pk]
-    options = ['-X', code.full_label, '-F', family.label, '-s'] + structures
+    options = ['-X', code.full_label, '-F', sssp.label, '-s'] + structures
     run_cli_process_launch_command(launch_calculation, options=options)

--- a/tests/cli/calculations/test_ph.py
+++ b/tests/cli/calculations/test_ph.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch ph`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.ph import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
 def test_command_base(run_cli_process_launch_command, fixture_code, generate_calc_job_node):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.ph').store()

--- a/tests/cli/calculations/test_pp.py
+++ b/tests/cli/calculations/test_pp.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch pp`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.pp import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
 def test_command_base(run_cli_process_launch_command, fixture_code, generate_calc_job_node):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.pp').store()

--- a/tests/cli/calculations/test_projwfc.py
+++ b/tests/cli/calculations/test_projwfc.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch projwfc`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.projwfc import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
 def test_command_base(run_cli_process_launch_command, fixture_code, generate_calc_job_node):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.projwfc').store()

--- a/tests/cli/calculations/test_pw.py
+++ b/tests/cli/calculations/test_pw.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch pw`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.pw import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
-def test_command_base(run_cli_process_launch_command, fixture_code, generate_upf_family):
+def test_command_base(run_cli_process_launch_command, fixture_code, sssp):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.pw').store()
-    family = generate_upf_family()
-    options = ['-X', code.full_label, '-F', family.label]
+    options = ['-X', code.full_label, '-F', sssp.label]
     run_cli_process_launch_command(launch_calculation, options=options)

--- a/tests/cli/calculations/test_pw2wannier90.py
+++ b/tests/cli/calculations/test_pw2wannier90.py
@@ -2,13 +2,11 @@
 """Tests for the ``calculation launch pw2wannier90`` command."""
 import io
 
-import pytest
 from aiida.orm import SinglefileData
 
 from aiida_quantumespresso.cli.calculations.pw2wannier90 import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
 def test_command_base(run_cli_process_launch_command, fixture_code, generate_calc_job_node):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.pw2wannier90').store()

--- a/tests/cli/calculations/test_q2r.py
+++ b/tests/cli/calculations/test_q2r.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch q2r`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.q2r import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
 def test_command_base(run_cli_process_launch_command, fixture_code, generate_calc_job_node):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.q2r').store()

--- a/tests/cli/workflows/pw/test_bands.py
+++ b/tests/cli/workflows/pw/test_bands.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``workflow launch pw-bands`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.workflows.pw.bands import launch_workflow
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
-def test_command_base(run_cli_process_launch_command, fixture_code, generate_upf_family, generate_structure):
+def test_command_base(run_cli_process_launch_command, fixture_code, sssp, generate_structure):
     """Test invoking the workflow launch command with only required inputs."""
     code = fixture_code('quantumespresso.pw').store()
-    family = generate_upf_family()
-    options = ['-X', code.full_label, '-F', family.label, '-S', generate_structure().store().pk]
+    options = ['-X', code.full_label, '-F', sssp.label, '-S', generate_structure().store().pk]
     run_cli_process_launch_command(launch_workflow, options=options)

--- a/tests/cli/workflows/pw/test_base.py
+++ b/tests/cli/workflows/pw/test_base.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``workflow launch pw-base`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.workflows.pw.base import launch_workflow
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
-def test_command_base(run_cli_process_launch_command, fixture_code, generate_upf_family):
+def test_command_base(run_cli_process_launch_command, fixture_code, sssp):
     """Test invoking the workflow launch command with only required inputs."""
     code = fixture_code('quantumespresso.pw').store()
-    family = generate_upf_family()
-    options = ['-X', code.full_label, '-F', family.label]
+    options = ['-X', code.full_label, '-F', sssp.label]
     run_cli_process_launch_command(launch_workflow, options=options)

--- a/tests/cli/workflows/pw/test_relax.py
+++ b/tests/cli/workflows/pw/test_relax.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``workflow launch pw-relax`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.workflows.pw.relax import launch_workflow
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
-def test_command_base(run_cli_process_launch_command, fixture_code, generate_upf_family, generate_structure):
+def test_command_base(run_cli_process_launch_command, fixture_code, generate_structure, sssp):
     """Test invoking the workflow launch command with only required inputs."""
     code = fixture_code('quantumespresso.pw').store()
-    family = generate_upf_family()
-    options = ['-X', code.full_label, '-F', family.label, '-S', generate_structure().store().pk]
+    options = ['-X', code.full_label, '-F', sssp.label, '-S', generate_structure().store().pk]
     run_cli_process_launch_command(launch_workflow, options=options)

--- a/tests/cli/workflows/test_matdyn.py
+++ b/tests/cli/workflows/test_matdyn.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch matdyn`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.matdyn import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
 def test_command_base(run_cli_process_launch_command, fixture_code, generate_force_constants_data):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.matdyn').store()

--- a/tests/cli/workflows/test_ph.py
+++ b/tests/cli/workflows/test_ph.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch ph`` command."""
-import pytest
-
 from aiida_quantumespresso.cli.calculations.ph import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
 def test_command_base(run_cli_process_launch_command, fixture_code, generate_calc_job_node):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.ph').store()

--- a/tests/cli/workflows/test_q2r.py
+++ b/tests/cli/workflows/test_q2r.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 """Tests for the ``calculation launch q2r`` command."""
-import pytest
 
 from aiida_quantumespresso.cli.calculations.q2r import launch_calculation
 
 
-@pytest.mark.usefixtures('clear_database_before_test')
 def test_command_base(run_cli_process_launch_command, fixture_code, generate_calc_job_node):
     """Test invoking the calculation launch command with only required inputs."""
     code = fixture_code('quantumespresso.q2r').store()

--- a/tests/fixtures/pseudos/Si.upf
+++ b/tests/fixtures/pseudos/Si.upf
@@ -1,1 +1,4 @@
-<UPF version="2.0.1"><PP_HEADER element="Si"/></UPF>
+<UPF version="2.0.1"><PP_HEADER
+element="Si"
+z_valence="1.0"
+/></UPF>


### PR DESCRIPTION
The new required version of `aiida-pseudo` allows multiple cutoff sets
to be defined on a pseudopotential family at different levels of
stringency. It also changes the CLI option to pass a pseudopotential
family to `-F`.

The `UpfData` class was also updated to now require the `z_valence`
value to be parsed in addition to the element, so the test fixtures are
updated to include that in the generated pseudo nodes.

The tests are adapted and a new fixture `sssp` is added, which for the
whole session creates an instance of `SsspFamily`. Since this is a
costly operation, it should only be done once and all tests should
reuse it. This means that tests can no longer blindly use the fixture
`clear_database_before_tests`, which anyway was not useful in terms of
efficiency.