### PR TITLE
`PwRelaxWorkChain`: replace `relaxation_scheme` with `relax_type`

### DIFF
--- a/aiida_quantumespresso/cli/workflows/pw/relax.py
+++ b/aiida_quantumespresso/cli/workflows/pw/relax.py
@@ -47,6 +47,8 @@ def launch_workflow(
     """Run a `PwRelaxWorkChain`."""
     from aiida.orm import Bool, Float, Dict, Str
     from aiida.plugins import WorkflowFactory
+
+    from aiida_quantumespresso.common.types import RelaxType
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     builder = WorkflowFactory('quantumespresso.pw.relax').get_builder()
@@ -78,6 +80,7 @@ def launch_workflow(
         raise click.BadParameter(str(exception))
 
     builder.structure = structure
+    builder.relax_type = Str(RelaxType.ATOMS.value)
     builder.base.kpoints_distance = Float(kpoints_distance)
     builder.base.pw.code = code
     builder.base.pw.pseudos = pseudo_family.get_pseudos(structure=structure)

--- a/aiida_quantumespresso/common/types.py
+++ b/aiida_quantumespresso/common/types.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Module with common data types."""
+import enum
+
+
+class RelaxType(enum.Enum):
+    """Enumeration of known relax types."""
+
+    NONE = 'none'  # All degrees of freedom are fixed, essentially performs single point SCF calculation
+    ATOMS = 'atoms'  # Only the atomic positions are relaxed, cell is fixed
+    VOLUME = 'volume'  # Only the cell volume is optimized, cell shape and atoms are fixed
+    SHAPE = 'shape'  # Only the cell shape is optimized at a fixed volume and fixed atomic positions
+    CELL = 'cell'  # Only the cell is optimized, both shape and volume, while atomic positions are fixed
+    ATOMS_VOLUME = 'atoms_volume'  # Same as `VOLUME` but atomic positions are relaxed as well
+    ATOMS_SHAPE = 'atoms_shape'  # Same as `SHAPE`  but atomic positions are relaxed as well
+    ATOMS_CELL = 'atoms_cell'  # Same as `CELL`  but atomic positions are relaxed as well


### PR DESCRIPTION
Fixes #611 

The `relaxation_scheme` was used to communicate the type of relaxation
to be performed and accepted either `relax` or `vc-relax`, directly
modeled after the relax options that could be passed to the
`CONTROL.calculation` input parameter.

There are, however, many other relax modes possible, such as those
constraining parts of the degree of freedom of the cell. To support
these a new input is introduced `relax_type` that replaces the old
`relaxation_scheme` that is deprecated. The `relax_type` can take values
as specified by the `RelaxType` enum.