### PR TITLE
Re-enable formatting after `define` methods

### DIFF
--- a/aiida_quantumespresso/calculations/__init__.py
+++ b/aiida_quantumespresso/calculations/__init__.py
@@ -124,6 +124,7 @@ class BasePwCpInputGenerator(CalcJob):
             help='Optional van der Waals table contained in a `SinglefileData`.')
         spec.input_namespace('pseudos', valid_type=(LegacyUpfData, UpfData), dynamic=True,
             help='A mapping of `UpfData` nodes onto the kind name to which they should apply.')
+        # yapf: enable
         spec.input(
             'parallelization',
             valid_type=orm.Dict,
@@ -149,10 +150,7 @@ class BasePwCpInputGenerator(CalcJob):
                 )
             invalid_values = [val for val in value_dict.values() if not isinstance(val, numbers.Integral)]
             if invalid_values:
-                return (
-                    f'Parallelization values must be integers; got invalid values {invalid_values}.'
-                )
-
+                return f'Parallelization values must be integers; got invalid values {invalid_values}.'
 
     def prepare_for_submission(self, folder):
         """Create the input files from the input nodes passed to this instance of the `CalcJob`.
@@ -171,7 +169,8 @@ class BasePwCpInputGenerator(CalcJob):
         if set(kinds) != set(self.inputs.pseudos.keys()):
             raise exceptions.InputValidationError(
                 'Mismatch between the defined pseudos and the list of kinds of the structure.\n'
-                'Pseudos: {};\nKinds: {}'.format(', '.join(list(self.inputs.pseudos.keys())), ', '.join(list(kinds))))
+                'Pseudos: {};\nKinds: {}'.format(', '.join(list(self.inputs.pseudos.keys())), ', '.join(list(kinds)))
+            )
 
         local_copy_list = []
         remote_copy_list = []
@@ -217,16 +216,16 @@ class BasePwCpInputGenerator(CalcJob):
                 # I put the symlink to the old parent ./out folder
                 remote_symlink_list.append((
                     self.inputs.parent_folder.computer.uuid,
-                    os.path.join(self.inputs.parent_folder.get_remote_path(), self._restart_copy_from),
-                    self._restart_copy_to
+                    os.path.join(self.inputs.parent_folder.get_remote_path(),
+                                 self._restart_copy_from), self._restart_copy_to
                 ))
         else:
             # copy remote output dir, if specified
             if 'parent_folder' in self.inputs:
                 remote_copy_list.append((
                     self.inputs.parent_folder.computer.uuid,
-                    os.path.join(self.inputs.parent_folder.get_remote_path(), self._restart_copy_from),
-                    self._restart_copy_to
+                    os.path.join(self.inputs.parent_folder.get_remote_path(),
+                                 self._restart_copy_from), self._restart_copy_to
                 ))
 
         # Create an `.EXIT` file if `only_initialization` flag in `settings` is set to `True`
@@ -262,18 +261,16 @@ class BasePwCpInputGenerator(CalcJob):
             self.node.logger.warning(
                 "The '{}' setting is deprecated as bands are now parsed by default. "
                 "If you do not want the bands to be parsed set the '{}' to True {}. "
-                'Note that the eigenvalue.xml files are also no longer stored in the repository'
-                .format('also_bands', 'no_bands', type(self))
+                'Note that the eigenvalue.xml files are also no longer stored in the repository'.format(
+                    'also_bands', 'no_bands', type(self)
+                )
             )
 
         calcinfo = datastructures.CalcInfo()
 
         calcinfo.uuid = str(self.uuid)
         # Start from an empty command line by default
-        cmdline_params = self._add_parallelization_flags_to_cmdline_params(
-            cmdline_params=settings.pop('CMDLINE', [])
-        )
-
+        cmdline_params = self._add_parallelization_flags_to_cmdline_params(cmdline_params=settings.pop('CMDLINE', []))
 
         # we commented calcinfo.stin_name and added it here in cmdline_params
         # in this way the mpirun ... pw.x ... < aiida.in
@@ -397,12 +394,12 @@ class BasePwCpInputGenerator(CalcJob):
             if namelist in input_params:
                 # The following lines is meant to avoid putting in input the
                 # parameters like celldm(*)
-                stripped_inparams = [re.sub('[(0-9)]', '', _)
-                                     for _ in input_params[namelist].keys()]
+                stripped_inparams = [re.sub('[(0-9)]', '', _) for _ in input_params[namelist].keys()]
                 if flag in stripped_inparams:
                     raise exceptions.InputValidationError(
                         "You cannot specify explicitly the '{}' flag in the '{}' "
-                        'namelist or card.'.format(flag, namelist))
+                        'namelist or card.'.format(flag, namelist)
+                    )
                 if defaultvalue is not None:
                     if namelist not in input_params:
                         input_params[namelist] = {}
@@ -423,8 +420,7 @@ class BasePwCpInputGenerator(CalcJob):
         if input_params.get('SYSTEM', {}).get('ibrav', cls._DEFAULT_IBRAV) == 0:
             cell_parameters_card = 'CELL_PARAMETERS angstrom\n'
             for vector in structure.cell:
-                cell_parameters_card += ('{0:18.10f} {1:18.10f} {2:18.10f}'
-                                        '\n'.format(*vector))
+                cell_parameters_card += ('{0:18.10f} {1:18.10f} {2:18.10f}' '\n'.format(*vector))
         else:
             cell_parameters_card = ''
 
@@ -445,9 +441,11 @@ class BasePwCpInputGenerator(CalcJob):
             # the list of keys of pseudos and kinds coincides
             pseudo = pseudos[kind.name]
             if kind.is_alloy or kind.has_vacancies:
-                raise exceptions.InputValidationError("Kind '{}' is an alloy or has "
-                                           'vacancies. This is not allowed for pw.x input structures.'
-                                           ''.format(kind.name))
+                raise exceptions.InputValidationError(
+                    "Kind '{}' is an alloy or has "
+                    'vacancies. This is not allowed for pw.x input structures.'
+                    ''.format(kind.name)
+                )
 
             try:
                 # If it is the same pseudopotential file, use the same filename
@@ -466,17 +464,13 @@ class BasePwCpInputGenerator(CalcJob):
         # I join the lines, but I resort them using the alphabetical order of
         # species, given by the kind_names list. I also store the mapping_species
         # list, with the order of species used in the file
-        mapping_species, sorted_atomic_species_card_list = list(zip(
-            *sorted(zip(kind_names, atomic_species_card_list))))
+        mapping_species, sorted_atomic_species_card_list = list(zip(*sorted(zip(kind_names, atomic_species_card_list))))
         # The format of mapping_species required later is a dictionary, whose
         # values are the indices, so I convert to this format
         # Note the (idx+1) to convert to fortran 1-based lists
-        mapping_species = {sp_name: (idx + 1) for idx, sp_name
-                           in enumerate(mapping_species)}
+        mapping_species = {sp_name: (idx + 1) for idx, sp_name in enumerate(mapping_species)}
         # I add the first line
-        sorted_atomic_species_card_list = (['ATOMIC_SPECIES\n'] +
-                                           list(
-                                               sorted_atomic_species_card_list))
+        sorted_atomic_species_card_list = (['ATOMIC_SPECIES\n'] + list(sorted_atomic_species_card_list))
         atomic_species_card = ''.join(sorted_atomic_species_card_list)
         # Free memory
         del sorted_atomic_species_card_list
@@ -493,21 +487,18 @@ class BasePwCpInputGenerator(CalcJob):
             if len(fixed_coords) != len(structure.sites):
                 raise exceptions.InputValidationError(
                     'Input structure contains {:d} sites, but '
-                    'fixed_coords has length {:d}'.format(len(structure.sites),
-                                                          len(fixed_coords)))
+                    'fixed_coords has length {:d}'.format(len(structure.sites), len(fixed_coords))
+                )
 
             for i, this_atom_fix in enumerate(fixed_coords):
                 if len(this_atom_fix) != 3:
-                    raise exceptions.InputValidationError(
-                        f'fixed_coords({i + 1:d}) has not length three')
+                    raise exceptions.InputValidationError(f'fixed_coords({i + 1:d}) has not length three')
                 for fixed_c in this_atom_fix:
                     if not isinstance(fixed_c, bool):
-                        raise exceptions.InputValidationError(
-                            f'fixed_coords({i + 1:d}) has non-boolean elements')
+                        raise exceptions.InputValidationError(f'fixed_coords({i + 1:d}) has non-boolean elements')
 
                 if_pos_values = [cls._if_pos(_) for _ in this_atom_fix]
-                fixed_coords_strings.append(
-                    '  {:d} {:d} {:d}'.format(*if_pos_values))
+                fixed_coords_strings.append('  {:d} {:d} {:d}'.format(*if_pos_values))
 
         abs_pos = [_.position for _ in structure.sites]
         if use_fractional:
@@ -518,12 +509,12 @@ class BasePwCpInputGenerator(CalcJob):
             atomic_positions_card_list = ['ATOMIC_POSITIONS angstrom\n']
             coordinates = abs_pos
 
-        for site, site_coords, fixed_coords_string in zip(
-                structure.sites, coordinates, fixed_coords_strings):
+        for site, site_coords, fixed_coords_string in zip(structure.sites, coordinates, fixed_coords_strings):
             atomic_positions_card_list.append(
                 '{0} {1:18.10f} {2:18.10f} {3:18.10f} {4}\n'.format(
-                    site.kind_name.ljust(6), site_coords[0], site_coords[1],
-                    site_coords[2], fixed_coords_string))
+                    site.kind_name.ljust(6), site_coords[0], site_coords[1], site_coords[2], fixed_coords_string
+                )
+            )
 
         atomic_positions_card = ''.join(atomic_positions_card_list)
         del atomic_positions_card_list
@@ -570,9 +561,7 @@ class BasePwCpInputGenerator(CalcJob):
 
                 # Checking that all 3 dimensions are specified:
                 if len(vector) != 3:
-                    raise exceptions.InputValidationError(
-                        f'Velocities({vector}) for {site} has not length three'
-                    )
+                    raise exceptions.InputValidationError(f'Velocities({vector}) for {site} has not length three')
 
                 lines.append('{0} {1:18.10f} {2:18.10f} {3:18.10f}\n'.format(site.kind_name.ljust(6), *vector))
 
@@ -633,17 +622,18 @@ class BasePwCpInputGenerator(CalcJob):
 
             if gamma_only:
                 if has_mesh:
-                    if tuple(mesh) != (1, 1, 1) or tuple(offset) != (
-                            0., 0., 0.):
+                    if tuple(mesh) != (1, 1, 1) or tuple(offset) != (0., 0., 0.):
                         raise exceptions.InputValidationError(
                             'If a gamma_only calculation is requested, the '
-                            'kpoint mesh must be (1,1,1),offset=(0.,0.,0.)')
+                            'kpoint mesh must be (1,1,1),offset=(0.,0.,0.)'
+                        )
 
                 else:
                     if (len(kpoints_list) != 1 or tuple(kpoints_list[0]) != tuple(0., 0., 0.)):
                         raise exceptions.InputValidationError(
                             'If a gamma_only calculation is requested, the '
-                            'kpoints coordinates must only be (0.,0.,0.)')
+                            'kpoints coordinates must only be (0.,0.,0.)'
+                        )
 
                 kpoints_type = 'gamma'
 
@@ -660,8 +650,7 @@ class BasePwCpInputGenerator(CalcJob):
                     raise exceptions.InputValidationError('offset list must only be made of 0 or 0.5 floats')
                 the_offset = [0 if i == 0. else 1 for i in offset]
                 the_6_integers = list(mesh) + the_offset
-                kpoints_card_list.append('{:d} {:d} {:d} {:d} {:d} {:d}\n'
-                                         ''.format(*the_6_integers))
+                kpoints_card_list.append('{:d} {:d} {:d} {:d} {:d} {:d}\n' ''.format(*the_6_integers))
 
             elif kpoints_type == 'gamma':
                 # nothing to be written in this case
@@ -670,7 +659,8 @@ class BasePwCpInputGenerator(CalcJob):
                 kpoints_card_list.append(f'{num_kpoints:d}\n')
                 for kpoint, weight in zip(kpoints_list, weights):
                     kpoints_card_list.append(
-                        f'  {kpoint[0]:18.10f} {kpoint[1]:18.10f} {kpoint[2]:18.10f} {weight:18.10f}\n')
+                        f'  {kpoint[0]:18.10f} {kpoint[1]:18.10f} {kpoint[2]:18.10f} {weight:18.10f}\n'
+                    )
 
             kpoints_card = ''.join(kpoints_card_list)
             del kpoints_card_list
@@ -681,7 +671,8 @@ class BasePwCpInputGenerator(CalcJob):
             if not isinstance(namelists_toprint, list):
                 raise exceptions.InputValidationError(
                     "The 'NAMELISTS' value, if specified in the settings input "
-                    'node, must be a list of strings')
+                    'node, must be a list of strings'
+                )
         except KeyError:  # list of namelists not specified; do automatic detection
             try:
                 control_nl = input_params['CONTROL']
@@ -691,15 +682,18 @@ class BasePwCpInputGenerator(CalcJob):
                     "No 'calculation' in CONTROL namelist."
                     'It is required for automatic detection of the valid list '
                     'of namelists. Otherwise, specify the list of namelists '
-                    "using the NAMELISTS key inside the 'settings' input node.") from exception
+                    "using the NAMELISTS key inside the 'settings' input node."
+                ) from exception
 
             try:
                 namelists_toprint = cls._automatic_namelists[calculation_type]
             except KeyError as exception:
-                raise exceptions.InputValidationError("Unknown 'calculation' value in "
-                                           'CONTROL namelist {}. Otherwise, specify the list of '
-                                           "namelists using the NAMELISTS inside the 'settings' input "
-                                           'node'.format(calculation_type)) from exception
+                raise exceptions.InputValidationError(
+                    "Unknown 'calculation' value in "
+                    'CONTROL namelist {}. Otherwise, specify the list of '
+                    "namelists using the NAMELISTS inside the 'settings' input "
+                    'node'.format(calculation_type)
+                ) from exception
 
         inputfile = ''
         for namelist_name in namelists_toprint:
@@ -726,7 +720,8 @@ class BasePwCpInputGenerator(CalcJob):
             raise exceptions.InputValidationError(
                 'The following namelists are specified in input_params, but are '
                 'not valid namelists for the current type of calculation: '
-                '{}'.format(','.join(list(input_params.keys()))))
+                '{}'.format(','.join(list(input_params.keys())))
+            )
 
         return inputfile, local_copy_list_to_append
 
@@ -762,7 +757,8 @@ def _case_transform_dict(dictionary, dict_name, func_name, transform):
         raise exceptions.InputValidationError(
             "Inside the dictionary '{}' there are the following keys that "
             'are repeated more than once when compared case-insensitively: {}.'
-            'This is not allowed.'.format(dict_name, double_keys))
+            'This is not allowed.'.format(dict_name, double_keys)
+        )
     return new_dict
 
 

--- a/aiida_quantumespresso/calculations/base.py
+++ b/aiida_quantumespresso/calculations/base.py
@@ -45,3 +45,4 @@ class CalcJob(_BaseCalcJob):  # pylint: disable=abstract-method
         # yapf: disable
         super().define(spec)
         spec.inputs['metadata']['options']['resources'].default = lambda: {'num_machines': 1}
+        # yapf: enable

--- a/aiida_quantumespresso/calculations/cp.py
+++ b/aiida_quantumespresso/calculations/cp.py
@@ -157,6 +157,7 @@ class CpCalculation(BasePwCpInputGenerator):
             message='The required POS file could not be read.')
         spec.exit_code(340, 'ERROR_READING_TRAJECTORY_DATA',
             message='The required trajectory data could not be read.')
+        # yapf: enable
 
     @staticmethod
     def _generate_PWCP_input_tail(*args, **kwargs):

--- a/aiida_quantumespresso/calculations/dos.py
+++ b/aiida_quantumespresso/calculations/dos.py
@@ -32,3 +32,4 @@ class DosCalculation(NamelistsCalculation):
             message='The stdout output file was incomplete probably because the calculation got interrupted.')
         spec.exit_code(330, 'ERROR_READING_DOS_FILE',
             message='The dos file could not be read from the retrieved folder.')
+        # yapf: enable

--- a/aiida_quantumespresso/calculations/epw.py
+++ b/aiida_quantumespresso/calculations/epw.py
@@ -52,6 +52,7 @@ class EpwCalculation(CalcJob):
         spec.input('parent_folder_nscf', valid_type=orm.RemoteData,
                  help='the folder of a completed nscf `PwCalculation`')
         spec.input('parent_folder_ph', valid_type=orm.RemoteData, help='the folder of a completed `PhCalculation`')
+        # yapf: enable
 
     def prepare_for_submission(self, folder):  # pylint: disable=too-many-statements,too-many-branches
         """Prepare the calculation job for submission by transforming input nodes into input files.
@@ -69,7 +70,8 @@ class EpwCalculation(CalcJob):
             if any([i != 0. for i in offset]):
                 raise NotImplementedError(
                     'Computation of electron-phonon on a mesh with non zero offset is not implemented, '
-                    'at the level of epw.x')
+                    'at the level of epw.x'
+                )
 
         # pylint: disable=too-many-statements,too-many-branches
         local_copy_list = []
@@ -92,10 +94,12 @@ class EpwCalculation(CalcJob):
         if not self.node.computer.uuid == parent_calc_nscf.computer.uuid:
             raise exceptions.InputValidationError(
                 'Calculation has to be launched on the same computer as that of the parent: {}'.format(
-                    parent_calc_nscf.computer.get_name()))
+                    parent_calc_nscf.computer.get_name()
+                )
+            )
 
         # put by default, default_parent_output_folder = ./out
-        parent_calc_out_subfolder_nscf = parent_calc_nscf.process_class._OUTPUT_SUBFOLDER # pylint: disable=protected-access
+        parent_calc_out_subfolder_nscf = parent_calc_nscf.process_class._OUTPUT_SUBFOLDER  # pylint: disable=protected-access
 
         # Now phonon folder
         parent_folder_ph = self.inputs.parent_folder_ph
@@ -105,7 +109,9 @@ class EpwCalculation(CalcJob):
         if not self.node.computer.uuid == parent_calc_ph.computer.uuid:
             raise exceptions.InputValidationError(
                 'Calculation has to be launched on the same computer as that of the parent: {}'.format(
-                    parent_calc_ph.computer.get_name()))
+                    parent_calc_ph.computer.get_name()
+                )
+            )
 
         # I put the first-level keys as uppercase (i.e., namelist and card names) and the second-level keys as lowercase
         parameters = _uppercase_dict(self.inputs.parameters.get_dict(), dict_name='parameters')
@@ -158,17 +164,16 @@ class EpwCalculation(CalcJob):
         except NotImplementedError as exception:
             raise exceptions.InputValidationError('Cannot get the fine k-point grid') from exception
 
-
         # customized namelists, otherwise not present in the distributed epw code
         try:
             namelists_toprint = settings.pop('NAMELISTS')
             if not isinstance(namelists_toprint, list):
                 raise exceptions.InputValidationError(
                     "The 'NAMELISTS' value, if specified in the settings input "
-                    'node, must be a list of strings')
+                    'node, must be a list of strings'
+                )
         except KeyError:  # list of namelists not specified in the settings; do automatic detection
             namelists_toprint = self._compulsory_namelists
-
 
         # create the save folder with dvscf and dyn files.
         folder.get_subfolder(self._FOLDER_SAVE, create=True)
@@ -209,7 +214,8 @@ class EpwCalculation(CalcJob):
             raise exceptions.InputValidationError(
                 'The following namelists are specified in parameters, but are '
                 'not valid namelists for the current type of calculation: '
-                '{}'.format(','.join(list(parameters.keys()))))
+                '{}'.format(','.join(list(parameters.keys())))
+            )
 
         # copy the parent scratch
         symlink = settings.pop('PARENT_FOLDER_SYMLINK', self._default_symlink_usage)  # a boolean
@@ -219,50 +225,51 @@ class EpwCalculation(CalcJob):
 
             remote_symlink_list.append((
                 parent_folder_nscf.computer.uuid,
-                os.path.join(parent_folder_nscf.get_remote_path(), parent_calc_out_subfolder_nscf, '*'),
-                self._OUTPUT_SUBFOLDER
+                os.path.join(parent_folder_nscf.get_remote_path(), parent_calc_out_subfolder_nscf,
+                             '*'), self._OUTPUT_SUBFOLDER
             ))
 
         else:
             # here I copy the whole folder ./out
             remote_copy_list.append((
                 parent_folder_nscf.computer.uuid,
-                os.path.join(parent_folder_nscf.get_remote_path(), parent_calc_out_subfolder_nscf),
-                self._OUTPUT_SUBFOLDER
+                os.path.join(parent_folder_nscf.get_remote_path(),
+                             parent_calc_out_subfolder_nscf), self._OUTPUT_SUBFOLDER
             ))
 
         prefix = self._PREFIX
 
-        for iqpt in range(1, nqpt+1):
+        for iqpt in range(1, nqpt + 1):
             label = str(iqpt)
             tmp_path = os.path.join(self._FOLDER_DYNAMICAL_MATRIX, 'dynamical-matrix-0')
             remote_copy_list.append((
-                parent_folder_ph.computer.uuid,
-                os.path.join(parent_folder_ph.get_remote_path(), tmp_path),
-                'save/'+prefix+'.dyn_q0'))
-            tmp_path = os.path.join(self._FOLDER_DYNAMICAL_MATRIX, 'dynamical-matrix-'+label)
+                parent_folder_ph.computer.uuid, os.path.join(parent_folder_ph.get_remote_path(),
+                                                             tmp_path), 'save/' + prefix + '.dyn_q0'
+            ))
+            tmp_path = os.path.join(self._FOLDER_DYNAMICAL_MATRIX, 'dynamical-matrix-' + label)
             remote_copy_list.append((
-                parent_folder_ph.computer.uuid,
-                os.path.join(parent_folder_ph.get_remote_path(), tmp_path),
-                'save/'+prefix+'.dyn_q'+label))
+                parent_folder_ph.computer.uuid, os.path.join(parent_folder_ph.get_remote_path(),
+                                                             tmp_path), 'save/' + prefix + '.dyn_q' + label
+            ))
 
             if iqpt == 1:
-                tmp_path = os.path.join(self._OUTPUT_SUBFOLDER, '_ph0/'+prefix+'.dvscf*')
+                tmp_path = os.path.join(self._OUTPUT_SUBFOLDER, '_ph0/' + prefix + '.dvscf*')
                 remote_copy_list.append((
-                    parent_folder_ph.computer.uuid,
-                    os.path.join(parent_folder_ph.get_remote_path(), tmp_path),
-                    'save/'+prefix+'.dvscf_q'+label))
-                tmp_path = os.path.join(self._OUTPUT_SUBFOLDER, '_ph0/'+prefix+'.phsave')
+                    parent_folder_ph.computer.uuid, os.path.join(parent_folder_ph.get_remote_path(),
+                                                                 tmp_path), 'save/' + prefix + '.dvscf_q' + label
+                ))
+                tmp_path = os.path.join(self._OUTPUT_SUBFOLDER, '_ph0/' + prefix + '.phsave')
                 remote_copy_list.append((
-                    parent_folder_ph.computer.uuid,
-                    os.path.join(parent_folder_ph.get_remote_path(), tmp_path),
-                    'save/'))
+                    parent_folder_ph.computer.uuid, os.path.join(parent_folder_ph.get_remote_path(), tmp_path), 'save/'
+                ))
             else:
-                tmp_path = os.path.join(self._OUTPUT_SUBFOLDER, '_ph0/'+prefix+'.q_'+label+'/'+prefix+'.dvscf*')
+                tmp_path = os.path.join(
+                    self._OUTPUT_SUBFOLDER, '_ph0/' + prefix + '.q_' + label + '/' + prefix + '.dvscf*'
+                )
                 remote_copy_list.append((
-                    parent_folder_ph.computer.uuid,
-                    os.path.join(parent_folder_ph.get_remote_path(), tmp_path),
-                    'save/'+prefix+'.dvscf_q'+label))
+                    parent_folder_ph.computer.uuid, os.path.join(parent_folder_ph.get_remote_path(),
+                                                                 tmp_path), 'save/' + prefix + '.dvscf_q' + label
+                ))
 
         codeinfo = datastructures.CodeInfo()
         codeinfo.cmdline_params = (list(settings.pop('CMDLINE', [])) + ['-in', self.metadata.options.input_filename])

--- a/aiida_quantumespresso/calculations/matdyn.py
+++ b/aiida_quantumespresso/calculations/matdyn.py
@@ -44,6 +44,7 @@ class MatdynCalculation(NamelistsCalculation):
             message='Number of kpoints not found in the output data')
         spec.exit_code(411, 'ERROR_OUTPUT_KPOINTS_INCOMMENSURATE',
             message='Number of kpoints in the inputs is not commensurate with those in the output')
+        # yapf: enable
 
     def _get_following_text(self):
         """Add the kpoints after the namelist."""

--- a/aiida_quantumespresso/calculations/namelists.py
+++ b/aiida_quantumespresso/calculations/namelists.py
@@ -58,6 +58,7 @@ class NamelistsCalculation(CalcJob):
             help='Use an additional node for special settings')
         spec.input('parent_folder', valid_type=(RemoteData, FolderData, SinglefileData), required=False,
             help='Use a local or remote folder as parent folder (for restarts and similar)')
+        # yapf: enable
 
     def _get_following_text(self):
         """Return any optional text that is to be written after the normal namelists in the input file.
@@ -79,7 +80,8 @@ class NamelistsCalculation(CalcJob):
                 if key in parameters[namelist]:
                     raise exceptions.InputValidationError(
                         "You cannot specify explicitly the '{}' key in the '{}' "
-                        'namelist.'.format(key, namelist))
+                        'namelist.'.format(key, namelist)
+                    )
             else:
                 parameters[namelist] = {}
             parameters[namelist][key] = value
@@ -107,7 +109,8 @@ class NamelistsCalculation(CalcJob):
             raise exceptions.InputValidationError(
                 'The following namelists are specified in parameters, but are '
                 'not valid namelists for the current type of calculation: '
-                '{}'.format(','.join(list(parameters.keys()))))
+                '{}'.format(','.join(list(parameters.keys())))
+            )
 
         return filtered
 
@@ -154,13 +157,13 @@ class NamelistsCalculation(CalcJob):
         else:
             parameters = {}
 
-
         # =================== NAMELISTS AND CARDS ========================
         try:
             namelists_toprint = settings.pop('NAMELISTS')
             if not isinstance(namelists_toprint, list):
                 raise exceptions.InputValidationError(
-                    "The 'NAMELISTS' value, if specified in the settings input node, must be a list of strings")
+                    "The 'NAMELISTS' value, if specified in the settings input node, must be a list of strings"
+                )
         except KeyError:  # list of namelists not specified; do automatic detection
             namelists_toprint = self._default_namelists
 
@@ -187,21 +190,17 @@ class NamelistsCalculation(CalcJob):
                 parent_calc_out_subfolder = settings.pop('PARENT_CALC_OUT_SUBFOLDER', self._INPUT_SUBFOLDER)
                 ptr.append((
                     parent_calc_folder.computer.uuid,
-                    os.path.join(parent_calc_folder.get_remote_path(), parent_calc_out_subfolder),
-                    self._OUTPUT_SUBFOLDER
+                    os.path.join(parent_calc_folder.get_remote_path(),
+                                 parent_calc_out_subfolder), self._OUTPUT_SUBFOLDER
                 ))
             elif isinstance(parent_calc_folder, FolderData):
                 for filename in parent_calc_folder.list_object_names():
-                    local_copy_list.append((
-                        parent_calc_folder.uuid,
-                        filename,
-                        os.path.join(self._OUTPUT_SUBFOLDER, filename)
-                    ))
+                    local_copy_list.append(
+                        (parent_calc_folder.uuid, filename, os.path.join(self._OUTPUT_SUBFOLDER, filename))
+                    )
             elif isinstance(parent_calc_folder, SinglefileData):
                 single_file = parent_calc_folder
-                local_copy_list.append(
-                    (single_file.uuid, single_file.filename, single_file.filename)
-                )
+                local_copy_list.append((single_file.uuid, single_file.filename, single_file.filename))
 
         codeinfo = datastructures.CodeInfo()
         codeinfo.cmdline_params = settings.pop('CMDLINE', [])

--- a/aiida_quantumespresso/calculations/neb.py
+++ b/aiida_quantumespresso/calculations/neb.py
@@ -92,6 +92,7 @@ class NebCalculation(CalcJob):
             message='The XML output file has an unsupported format.')
         spec.exit_code(350, 'ERROR_UNEXPECTED_PARSER_EXCEPTION',
             message='The parser raised an unexpected exception.')
+        # yapf: enable
 
     @classmethod
     def _generate_input_files(cls, neb_parameters, settings_dict):
@@ -126,14 +127,18 @@ class NebCalculation(CalcJob):
         if ci_scheme == 'manual':
             manual_climbing_image = True
             if climbing_image_list is None:
-                raise InputValidationError("'ci_scheme' is {}, but no climbing images were specified for this "
-                                           'calculation.'.format(ci_scheme))
+                raise InputValidationError(
+                    "'ci_scheme' is {}, but no climbing images were specified for this "
+                    'calculation.'.format(ci_scheme)
+                )
             if not isinstance(climbing_image_list, list):
                 raise InputValidationError('Climbing images should be provided as a list.')
             num_of_images = input_params['PATH'].get('num_of_images', 2)
             if any([(i < 2 or i >= num_of_images) for i in climbing_image_list]):
-                raise InputValidationError('The climbing images should be in the range between the first '
-                                           'and the last image (excluded).')
+                raise InputValidationError(
+                    'The climbing images should be in the range between the first '
+                    'and the last image (excluded).'
+                )
             climbing_image_card = 'CLIMBING_IMAGES\n'
             climbing_image_card += ', '.join([str(_) for _ in climbing_image_list]) + '\n'
         else:
@@ -156,7 +161,8 @@ class NebCalculation(CalcJob):
             raise InputValidationError(
                 'The following namelists are specified in input_params, but are '
                 'not valid namelists for the current type of calculation: '
-                '{}'.format(','.join(list(input_params.keys()))))
+                '{}'.format(','.join(list(input_params.keys())))
+            )
 
         return input_data
 
@@ -187,8 +193,7 @@ class NebCalculation(CalcJob):
         last_structure = self.inputs.last_structure
 
         # Check that the first and last image have the same cell
-        if abs(np.array(first_structure.cell)-
-               np.array(last_structure.cell)).max() > 1.e-4:
+        if abs(np.array(first_structure.cell) - np.array(last_structure.cell)).max() > 1.e-4:
             raise InputValidationError('Different cell in the fist and last image')
 
         # Check that the first and last image have the same number of sites
@@ -197,8 +202,10 @@ class NebCalculation(CalcJob):
 
         # Check that sites in the initial and final structure have the same kinds
         if first_structure.get_site_kindnames() != last_structure.get_site_kindnames():
-            raise InputValidationError('Mismatch between the kind names and/or order between '
-                                       'the first and final image')
+            raise InputValidationError(
+                'Mismatch between the kind names and/or order between '
+                'the first and final image'
+            )
 
         # Check that a pseudo potential was specified for each kind present in the `StructureData`
         # self.inputs.pw.pseudos is a plumpy.utils.AttributesFrozendict
@@ -206,7 +213,8 @@ class NebCalculation(CalcJob):
         if set(kindnames) != set(self.inputs.pw.pseudos.keys()):
             raise InputValidationError(
                 'Mismatch between the defined pseudos and the list of kinds of the structure.\nPseudos: {};\n'
-                'Kinds: {}'.format(', '.join(list(self.inputs.pw.pseudos.keys())), ', '.join(list(kindnames))))
+                'Kinds: {}'.format(', '.join(list(self.inputs.pw.pseudos.keys())), ', '.join(list(kindnames)))
+            )
 
         ##############################
         # END OF INITIAL INPUT CHECK #
@@ -252,11 +260,9 @@ class NebCalculation(CalcJob):
         # but should be the one expected by Quantum ESPRESSO.
         vdw_table = self.inputs.get('pw.vdw_table', None)
         if vdw_table:
-            local_copy_list.append((
-                vdw_table.uuid,
-                vdw_table.filename,
-                os.path.join(self._PSEUDO_SUBFOLDER, vdw_table.filename)
-            ))
+            local_copy_list.append(
+                (vdw_table.uuid, vdw_table.filename, os.path.join(self._PSEUDO_SUBFOLDER, vdw_table.filename))
+            )
 
         # operations for restart
         parent_calc_folder = self.inputs.get('parent_folder', None)
@@ -266,32 +272,27 @@ class NebCalculation(CalcJob):
                 # I put the symlink to the old parent ./out folder
                 remote_symlink_list.append((
                     parent_calc_folder.computer.uuid,
-                    os.path.join(parent_calc_folder.get_remote_path(),
-                                 self._OUTPUT_SUBFOLDER, '*'),  # asterisk: make individual symlinks for each file
+                    os.path.join(parent_calc_folder.get_remote_path(), self._OUTPUT_SUBFOLDER,
+                                 '*'),  # asterisk: make individual symlinks for each file
                     self._OUTPUT_SUBFOLDER
                 ))
                 # and to the old parent prefix.path
                 remote_symlink_list.append((
                     parent_calc_folder.computer.uuid,
-                    os.path.join(parent_calc_folder.get_remote_path(),
-                                 f'{self._PREFIX}.path'),
-                    f'{self._PREFIX}.path'
+                    os.path.join(parent_calc_folder.get_remote_path(), f'{self._PREFIX}.path'), f'{self._PREFIX}.path'
                 ))
         else:
             # copy remote output dir and .path file, if specified
             if parent_calc_folder is not None:
                 remote_copy_list.append((
                     parent_calc_folder.computer.uuid,
-                    os.path.join(parent_calc_folder.get_remote_path(),
-                                 self._OUTPUT_SUBFOLDER, '*'),
-                    self._OUTPUT_SUBFOLDER
+                    os.path.join(parent_calc_folder.get_remote_path(), self._OUTPUT_SUBFOLDER,
+                                 '*'), self._OUTPUT_SUBFOLDER
                 ))
                 # and copy the old parent prefix.path
                 remote_copy_list.append((
                     parent_calc_folder.computer.uuid,
-                    os.path.join(parent_calc_folder.get_remote_path(),
-                                 f'{self._PREFIX}.path'),
-                    f'{self._PREFIX}.path'
+                    os.path.join(parent_calc_folder.get_remote_path(), f'{self._PREFIX}.path'), f'{self._PREFIX}.path'
                 ))
 
         # here we may create an aiida.EXIT file

--- a/aiida_quantumespresso/calculations/ph.py
+++ b/aiida_quantumespresso/calculations/ph.py
@@ -77,6 +77,7 @@ class PhCalculation(CalcJob):
             message='The calculation stopped prematurely because it ran out of walltime.')
         spec.exit_code(410, 'ERROR_CONVERGENCE_NOT_REACHED',
             message='The minimization cycle did not reach self-consistency.')
+        # yapf: enable
 
     def prepare_for_submission(self, folder):
         """Prepare the calculation job for submission by transforming input nodes into input files.
@@ -104,8 +105,7 @@ class PhCalculation(CalcJob):
         if not parent_calcs:
             raise exceptions.NotExistent(f'parent_folder<{parent_folder.pk}> has no parent calculation')
         elif len(parent_calcs) > 1:
-            raise exceptions.UniquenessError(
-                f'parent_folder<{parent_folder.pk}> has multiple parent calculations')
+            raise exceptions.UniquenessError(f'parent_folder<{parent_folder.pk}> has multiple parent calculations')
 
         parent_calc = parent_calcs[0].node
 
@@ -116,7 +116,9 @@ class PhCalculation(CalcJob):
         if not self.node.computer.uuid == parent_calc.computer.uuid:
             raise exceptions.InputValidationError(
                 'Calculation has to be launched on the same computer as that of the parent: {}'.format(
-                    parent_calc.computer.get_name()))
+                    parent_calc.computer.get_name()
+                )
+            )
 
         # put by default, default_parent_output_folder = ./out
         try:
@@ -135,18 +137,15 @@ class PhCalculation(CalcJob):
 
         prepare_for_d3 = settings.pop('PREPARE_FOR_D3', False)
         if prepare_for_d3:
-            self._blocked_keywords += [
-                ('INPUTPH', 'fildrho'),
-                ('INPUTPH', 'drho_star%open'),
-                ('INPUTPH', 'drho_star%ext'),
-                ('INPUTPH', 'drho_star%dir')
-            ]
+            self._blocked_keywords += [('INPUTPH', 'fildrho'), ('INPUTPH', 'drho_star%open'),
+                                       ('INPUTPH', 'drho_star%ext'), ('INPUTPH', 'drho_star%dir')]
 
         for namelist, flag in self._blocked_keywords:
             if namelist in parameters:
                 if flag in parameters[namelist]:
                     raise exceptions.InputValidationError(
-                        f"Cannot specify explicitly the '{flag}' flag in the '{namelist}' namelist or card.")
+                        f"Cannot specify explicitly the '{flag}' flag in the '{namelist}' namelist or card."
+                    )
 
         if 'INPUTPH' not in parameters:
             raise exceptions.InputValidationError('required namelist INPUTPH not specified')
@@ -172,7 +171,8 @@ class PhCalculation(CalcJob):
 
             if any([i != 0. for i in offset]):
                 raise NotImplementedError(
-                    'Computation of phonons on a mesh with non zero offset is not implemented, at the level of ph.x')
+                    'Computation of phonons on a mesh with non zero offset is not implemented, at the level of ph.x'
+                )
 
             parameters['INPUTPH']['ldisp'] = True
             parameters['INPUTPH']['nq1'] = mesh[0]
@@ -217,7 +217,8 @@ class PhCalculation(CalcJob):
             if not isinstance(namelists_toprint, list):
                 raise exceptions.InputValidationError(
                     "The 'NAMELISTS' value, if specified in the settings input "
-                    'node, must be a list of strings')
+                    'node, must be a list of strings'
+                )
         except KeyError:  # list of namelists not specified in the settings; do automatic detection
             namelists_toprint = self._compulsory_namelists
 
@@ -242,7 +243,8 @@ class PhCalculation(CalcJob):
             raise exceptions.InputValidationError(
                 'The following namelists are specified in parameters, but are '
                 'not valid namelists for the current type of calculation: '
-                '{}'.format(','.join(list(parameters.keys()))))
+                '{}'.format(','.join(list(parameters.keys())))
+            )
 
         # copy the parent scratch
         symlink = settings.pop('PARENT_FOLDER_SYMLINK', self._default_symlink_usage)  # a boolean
@@ -252,38 +254,34 @@ class PhCalculation(CalcJob):
 
             remote_symlink_list.append((
                 parent_folder.computer.uuid,
-                os.path.join(parent_folder.get_remote_path(), parent_calc_out_subfolder, '*'),
-                self._OUTPUT_SUBFOLDER
+                os.path.join(parent_folder.get_remote_path(), parent_calc_out_subfolder, '*'), self._OUTPUT_SUBFOLDER
             ))
 
             # I also create a symlink for the ./pseudo folder
             # Remove this when the recover option of QE will be fixed (bug when trying to find pseudo file)
             remote_symlink_list.append((
-                parent_folder.computer.uuid,
-                os.path.join(parent_folder.get_remote_path(), self._get_pseudo_folder()),
-                self._get_pseudo_folder()
+                parent_folder.computer.uuid, os.path.join(parent_folder.get_remote_path(),
+                                                          self._get_pseudo_folder()), self._get_pseudo_folder()
             ))
         else:
             # here I copy the whole folder ./out
             remote_copy_list.append((
-                parent_folder.computer.uuid,
-                os.path.join(parent_folder.get_remote_path(), parent_calc_out_subfolder),
-                self._OUTPUT_SUBFOLDER
+                parent_folder.computer.uuid, os.path.join(parent_folder.get_remote_path(),
+                                                          parent_calc_out_subfolder), self._OUTPUT_SUBFOLDER
             ))
             # I also copy the ./pseudo folder
             # Remove this when the recover option of QE will be fixed (bug when trying to find pseudo file)
             remote_copy_list.append((
-                parent_folder.computer.uuid,
-                os.path.join(parent_folder.get_remote_path(), self._get_pseudo_folder()),
-                self._get_pseudo_folder()
+                parent_folder.computer.uuid, os.path.join(parent_folder.get_remote_path(),
+                                                          self._get_pseudo_folder()), self._get_pseudo_folder()
             ))
 
         if restart_flag:  # in this case, copy in addition also the dynamical matrices
             if symlink:
                 remote_symlink_list.append((
                     parent_folder.computer.uuid,
-                    os.path.join(parent_folder.get_remote_path(), self._FOLDER_DYNAMICAL_MATRIX),
-                    self._FOLDER_DYNAMICAL_MATRIX
+                    os.path.join(parent_folder.get_remote_path(),
+                                 self._FOLDER_DYNAMICAL_MATRIX), self._FOLDER_DYNAMICAL_MATRIX
                 ))
 
             else:
@@ -291,8 +289,7 @@ class PhCalculation(CalcJob):
                 # no need to copy the _ph0, since I copied already the whole ./out folder
                 remote_copy_list.append((
                     parent_folder.computer.uuid,
-                    os.path.join(parent_folder.get_remote_path(), self._FOLDER_DYNAMICAL_MATRIX),
-                    '.'
+                    os.path.join(parent_folder.get_remote_path(), self._FOLDER_DYNAMICAL_MATRIX), '.'
                 ))
 
         # Create an `.EXIT` file if `only_initialization` flag in `settings` is set to `True`
@@ -302,8 +299,7 @@ class PhCalculation(CalcJob):
 
                 remote_copy_list.append((
                     parent_folder.computer.uuid,
-                    os.path.join(parent_folder.get_remote_path(), self._FOLDER_DYNAMICAL_MATRIX),
-                    '.'
+                    os.path.join(parent_folder.get_remote_path(), self._FOLDER_DYNAMICAL_MATRIX), '.'
                 ))
 
         codeinfo = datastructures.CodeInfo()
@@ -331,7 +327,6 @@ class PhCalculation(CalcJob):
             raise exceptions.InputValidationError(f'`settings` contained unexpected keys: {unknown_keys}')
 
         return calcinfo
-
 
     @staticmethod
     def _get_pseudo_folder():

--- a/aiida_quantumespresso/calculations/pp.py
+++ b/aiida_quantumespresso/calculations/pp.py
@@ -114,6 +114,7 @@ class PpCalculation(CalcJob):
             message='The data file format is not supported by the parser')
         spec.exit_code(333, 'ERROR_OUTPUT_DATAFILE_PARSE',
             message='The formatted data output file `{filename}` could not be parsed')
+        # yapf: enable
 
     def prepare_for_submission(self, folder):  # pylint: disable=too-many-branches,too-many-statements
         """Prepare the calculation job for submission by transforming input nodes into input files.
@@ -146,7 +147,8 @@ class PpCalculation(CalcJob):
                 if key in parameters[namelist]:
                     raise exceptions.InputValidationError(
                         "You cannot specify explicitly the '{}' key in the '{}' "
-                        'namelist.'.format(key, namelist))
+                        'namelist.'.format(key, namelist)
+                    )
             else:
                 parameters[namelist] = {}
             parameters[namelist][key] = value
@@ -178,7 +180,8 @@ class PpCalculation(CalcJob):
             raise exceptions.InputValidationError(
                 'The following namelists are specified in parameters, but are '
                 'not valid namelists for the current type of calculation: '
-                '{}'.format(','.join(list(parameters.keys()))))
+                '{}'.format(','.join(list(parameters.keys())))
+            )
 
         remote_copy_list = []
         local_copy_list = []
@@ -188,26 +191,20 @@ class PpCalculation(CalcJob):
         if isinstance(parent_calc_folder, orm.RemoteData):
             remote_copy_list.append((
                 parent_calc_folder.computer.uuid,
-                os.path.join(parent_calc_folder.get_remote_path(), self._INPUT_SUBFOLDER),
-                self._OUTPUT_SUBFOLDER
+                os.path.join(parent_calc_folder.get_remote_path(), self._INPUT_SUBFOLDER), self._OUTPUT_SUBFOLDER
             ))
             remote_copy_list.append((
                 parent_calc_folder.computer.uuid,
-                os.path.join(parent_calc_folder.get_remote_path(), self._PSEUDO_SUBFOLDER),
-                self._PSEUDO_SUBFOLDER
+                os.path.join(parent_calc_folder.get_remote_path(), self._PSEUDO_SUBFOLDER), self._PSEUDO_SUBFOLDER
             ))
         elif isinstance(parent_calc_folder, orm.FolderData):
             for filename in parent_calc_folder.list_object_names():
-                local_copy_list.append((
-                    parent_calc_folder.uuid,
-                    filename,
-                    os.path.join(self._OUTPUT_SUBFOLDER, filename)
-                ))
-                local_copy_list.append((
-                    parent_calc_folder.uuid,
-                    filename,
-                    os.path.join(self._PSEUDO_SUBFOLDER, filename)
-                ))
+                local_copy_list.append(
+                    (parent_calc_folder.uuid, filename, os.path.join(self._OUTPUT_SUBFOLDER, filename))
+                )
+                local_copy_list.append(
+                    (parent_calc_folder.uuid, filename, os.path.join(self._PSEUDO_SUBFOLDER, filename))
+                )
 
         codeinfo = datastructures.CodeInfo()
         codeinfo.cmdline_params = settings.pop('CMDLINE', [])
@@ -228,10 +225,7 @@ class PpCalculation(CalcJob):
         # files may be written. In that case, the data files will have `filplot` as a prefix with some suffix to
         # distinguish them from one another. The `fileout` filename will be the full data filename with the `fileout`
         # value as a suffix.
-        retrieve_tuples = [
-            self._FILEOUT,
-            (f'{self._FILPLOT}_*{self._FILEOUT}', '.', 0)
-        ]
+        retrieve_tuples = [self._FILEOUT, (f'{self._FILPLOT}_*{self._FILEOUT}', '.', 0)]
 
         if self.inputs.metadata.options.keep_plot_file:
             calcinfo.retrieve_list.extend(retrieve_tuples)

--- a/aiida_quantumespresso/calculations/projwfc.py
+++ b/aiida_quantumespresso/calculations/projwfc.py
@@ -53,3 +53,4 @@ class ProjwfcCalculation(NamelistsCalculation):
             message='The pdos_tot file could not be read from the retrieved folder.')
         spec.exit_code(340, 'ERROR_PARSING_PROJECTIONS',
             message='An exception was raised parsing bands and projections.')
+        # yapf: enable

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -145,6 +145,7 @@ class PwCalculation(BasePwCpInputGenerator):
             message='The electronic minimization cycle did not reach self-consistency.')
         spec.exit_code(541, 'ERROR_SYMMETRY_NON_ORTHOGONAL_OPERATION',
             message='The variable cell optimization broke the symmetry of the k-points.')
+        # yapf: enable
 
     @classproperty
     def filename_input_hubbard_parameters(cls):

--- a/aiida_quantumespresso/calculations/pw2gw.py
+++ b/aiida_quantumespresso/calculations/pw2gw.py
@@ -53,6 +53,7 @@ class Pw2gwCalculation(NamelistsCalculation):
             message='The eps*.dat output files contains different values of energies.')
         spec.exit_code(350, 'ERROR_UNEXPECTED_PARSER_EXCEPTION',
             message='The parser raised an unexpected exception.')
+        # yapf: enable
 
     def prepare_for_submission(self, folder):
         """Prepare the calculation job for submission by transforming input nodes into input files.
@@ -71,8 +72,7 @@ class Pw2gwCalculation(NamelistsCalculation):
         parent_calc_folder = self.inputs.parent_folder
         calcinfo.remote_copy_list.append((
             parent_calc_folder.computer.uuid,
-            os.path.join(parent_calc_folder.get_remote_path(), self._INPUT_PSEUDOFOLDER),
-            self._INPUT_PSEUDOFOLDER
+            os.path.join(parent_calc_folder.get_remote_path(), self._INPUT_PSEUDOFOLDER), self._INPUT_PSEUDOFOLDER
         ))
 
         return calcinfo

--- a/aiida_quantumespresso/calculations/pw2wannier90.py
+++ b/aiida_quantumespresso/calculations/pw2wannier90.py
@@ -39,6 +39,7 @@ class Pw2wannier90Calculation(NamelistsCalculation):
             message='Encountered a generic error message')
         spec.exit_code(350, 'ERROR_UNEXPECTED_PARSER_EXCEPTION',
             message='An error happened while parsing the output file')
+        # yapf: enable
 
     def prepare_for_submission(self, folder):
         """Prepare the calculation job for submission by transforming input nodes into input files.
@@ -54,8 +55,6 @@ class Pw2wannier90Calculation(NamelistsCalculation):
 
         # Put the nnkp in the folder, with the correct filename
         nnkp_file = self.inputs.nnkp_file
-        calcinfo.local_copy_list.append(
-            (nnkp_file.uuid, nnkp_file.filename, f'{self._SEEDNAME}.nnkp')
-        )
+        calcinfo.local_copy_list.append((nnkp_file.uuid, nnkp_file.filename, f'{self._SEEDNAME}.nnkp'))
 
         return calcinfo

--- a/aiida_quantumespresso/calculations/q2r.py
+++ b/aiida_quantumespresso/calculations/q2r.py
@@ -37,3 +37,4 @@ class Q2rCalculation(NamelistsCalculation):
             message='The stdout output file was incomplete probably because the calculation got interrupted.')
         spec.exit_code(330, 'ERROR_READING_FORCE_CONSTANTS_FILE',
             message='The force constants file could not be read.')
+        # yapf: enable

--- a/aiida_quantumespresso/workflows/matdyn/base.py
+++ b/aiida_quantumespresso/workflows/matdyn/base.py
@@ -29,6 +29,7 @@ class MatdynBaseWorkChain(BaseRestartWorkChain):
         )
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
             message='The calculation failed with an unrecoverable error.')
+        # yapf: enable
 
     def setup(self):
         """Call the `setup` of the `BaseRestartWorkChain` and then create the inputs dictionary in `self.ctx.inputs`.

--- a/aiida_quantumespresso/workflows/ph/base.py
+++ b/aiida_quantumespresso/workflows/ph/base.py
@@ -43,6 +43,7 @@ class PhBaseWorkChain(BaseRestartWorkChain):
             message='The `metadata.options` did not specify both `resources.num_machines` and `max_wallclock_seconds`.')
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
             message='The calculation failed with an unrecoverable error.')
+        # yapf: enable
 
     def setup(self):
         """Call the `setup` of the `BaseRestartWorkChain` and then create the inputs dictionary in `self.ctx.inputs`.

--- a/aiida_quantumespresso/workflows/pw/band_structure.py
+++ b/aiida_quantumespresso/workflows/pw/band_structure.py
@@ -56,6 +56,7 @@ class PwBandStructureWorkChain(WorkChain):
         spec.output('scf_parameters', valid_type=orm.Dict)
         spec.output('band_parameters', valid_type=orm.Dict)
         spec.output('band_structure', valid_type=orm.BandsData)
+        # yapf: enable
 
     def _get_protocol(self):
         """Return a `ProtocolManager` instance and a dictionary of modifiers."""
@@ -92,32 +93,36 @@ class PwBandStructureWorkChain(WorkChain):
                 self.report(f'failed to retrieve the cutoff or dual factor for {kind}')
                 return self.exit_codes.ERROR_INVALID_INPUT_UNRECOGNIZED_KIND
 
-        self.ctx.parameters = orm.Dict(dict={
-            'CONTROL': {
-                'restart_mode': 'from_scratch',
-                'tstress': self.ctx.protocol['tstress'],
-                'tprnfor': self.ctx.protocol['tprnfor'],
-            },
-            'SYSTEM': {
-                'ecutwfc': max(ecutwfc),
-                'ecutrho': max(ecutrho),
-                'smearing': self.ctx.protocol['smearing'],
-                'degauss': self.ctx.protocol['degauss'],
-                'occupations': self.ctx.protocol['occupations'],
-            },
-            'ELECTRONS': {
-                'conv_thr': self.ctx.protocol['convergence_threshold_per_atom'] * len(self.inputs.structure.sites),
+        self.ctx.parameters = orm.Dict(
+            dict={
+                'CONTROL': {
+                    'restart_mode': 'from_scratch',
+                    'tstress': self.ctx.protocol['tstress'],
+                    'tprnfor': self.ctx.protocol['tprnfor'],
+                },
+                'SYSTEM': {
+                    'ecutwfc': max(ecutwfc),
+                    'ecutrho': max(ecutrho),
+                    'smearing': self.ctx.protocol['smearing'],
+                    'degauss': self.ctx.protocol['degauss'],
+                    'occupations': self.ctx.protocol['occupations'],
+                },
+                'ELECTRONS': {
+                    'conv_thr': self.ctx.protocol['convergence_threshold_per_atom'] * len(self.inputs.structure.sites),
+                }
             }
-        })
+        )
 
     def run_bands(self):
         """Run the `PwBandsWorkChain` to compute the band structure."""
+
         def get_common_inputs():
             """Return the dictionary of inputs to be used as the basis for each `PwBaseWorkChain`."""
             protocol, protocol_modifiers = self._get_protocol()
             checked_pseudos = protocol.check_pseudos(
                 modifier_name=protocol_modifiers.get('pseudo', None),
-                pseudo_data=protocol_modifiers.get('pseudo_data', None))
+                pseudo_data=protocol_modifiers.get('pseudo_data', None)
+            )
             known_pseudos = checked_pseudos['found']
 
             inputs = AttributeDict({
@@ -172,11 +177,7 @@ class PwBandStructureWorkChain(WorkChain):
 
         self.report('workchain successfully completed')
         link_labels = [
-            'primitive_structure',
-            'seekpath_parameters',
-            'scf_parameters',
-            'band_parameters',
-            'band_structure'
+            'primitive_structure', 'seekpath_parameters', 'scf_parameters', 'band_parameters', 'band_structure'
         ]
 
         for link_triple in workchain.get_outgoing().all():

--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -108,6 +108,7 @@ class PwBandsWorkChain(WorkChain):
             help='The output parameters of the BANDS `PwBaseWorkChain`.')
         spec.output('band_structure', valid_type=orm.BandsData,
             help='The computed band structure.')
+        # yapf: enable
 
     def setup(self):
         """Define the current structure in the context to be the input structure."""
@@ -153,7 +154,9 @@ class PwBandsWorkChain(WorkChain):
         """
         inputs = {
             'reference_distance': self.inputs.get('bands_kpoints_distance', None),
-            'metadata': {'call_link_label': 'seekpath'}
+            'metadata': {
+                'call_link_label': 'seekpath'
+            }
         }
         result = seekpath_structure_analysis(self.ctx.current_structure, **inputs)
         self.ctx.current_structure = result['primitive_structure']
@@ -225,8 +228,8 @@ class PwBandsWorkChain(WorkChain):
             nelectron = int(parameters['number_of_electrons'])
             nbnd = max(
                 int(0.5 * nelectron * nspin_factor * factor),
-                int(0.5 * nelectron * nspin_factor) + 4 * nspin_factor,
-                nbands)
+                int(0.5 * nelectron * nspin_factor) + 4 * nspin_factor, nbands
+            )
             inputs.pw.parameters['SYSTEM']['nbnd'] = nbnd
 
         # Otherwise set the current number of bands, unless explicitly set in the inputs

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -107,6 +107,7 @@ class PwBaseWorkChain(BaseRestartWorkChain):
             message='The initialization calculation failed.')
         spec.exit_code(501, 'ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF',
             message='Then ionic minimization cycle converged but the thresholds are exceeded in the final SCF.')
+        # yapf: enable
 
     def setup(self):
         """Call the `setup` of the `BaseRestartWorkChain` and then create the inputs dictionary in `self.ctx.inputs`.
@@ -150,7 +151,9 @@ class PwBaseWorkChain(BaseRestartWorkChain):
                 'structure': self.inputs.pw.structure,
                 'distance': self.inputs.kpoints_distance,
                 'force_parity': self.inputs.get('kpoints_force_parity', orm.Bool(False)),
-                'metadata': {'call_link_label': 'create_kpoints_from_distance'}
+                'metadata': {
+                    'call_link_label': 'create_kpoints_from_distance'
+                }
             }
             kpoints = create_kpoints_from_distance(**inputs)  # pylint: disable=unexpected-keyword-arg
 
@@ -231,8 +234,9 @@ class PwBaseWorkChain(BaseRestartWorkChain):
             return self.exit_codes.ERROR_INVALID_INPUT_AUTOMATIC_PARALLELIZATION_MISSING_KEY
 
         if remaining_keys:
-            self.report('detected unrecognized keys in the automatic_parallelization input: {}'.format(
-                ' '.join(remaining_keys)))
+            self.report(
+                f"detected unrecognized keys in the automatic_parallelization input: {' '.join(remaining_keys)}"
+            )
             return self.exit_codes.ERROR_INVALID_INPUT_AUTOMATIC_PARALLELIZATION_UNRECOGNIZED_KEY
 
         # Add the calculation mode to the automatic parallelization dictionary
@@ -385,7 +389,7 @@ class PwBaseWorkChain(BaseRestartWorkChain):
 
     @process_handler(priority=580, exit_codes=[
         PwCalculation.exit_codes.ERROR_OUT_OF_WALLTIME,
-        ])
+    ])
     def handle_out_of_walltime(self, calculation):
         """Handle `ERROR_OUT_OF_WALLTIME` exit code: calculation shut down neatly and we can simply restart."""
         try:
@@ -399,9 +403,11 @@ class PwBaseWorkChain(BaseRestartWorkChain):
 
         return ProcessHandlerReport(True)
 
-    @process_handler(priority=570, exit_codes=[
-        PwCalculation.exit_codes.ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF,
-        ])
+    @process_handler(
+        priority=570, exit_codes=[
+            PwCalculation.exit_codes.ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF,
+        ]
+    )
     def handle_vcrelax_converged_except_final_scf(self, calculation):
         """Handle `ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF` exit code.
 
@@ -414,12 +420,15 @@ class PwBaseWorkChain(BaseRestartWorkChain):
         self.results()  # Call the results method to attach the output nodes
         return ProcessHandlerReport(True, self.exit_codes.ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF)
 
-    @process_handler(priority=560, exit_codes=[
-        PwCalculation.exit_codes.ERROR_IONIC_CONVERGENCE_NOT_REACHED,
-        PwCalculation.exit_codes.ERROR_IONIC_CYCLE_EXCEEDED_NSTEP,
-        PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_FAILURE,
-        PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_AND_FINAL_SCF_FAILURE,
-        ])
+    @process_handler(
+        priority=560,
+        exit_codes=[
+            PwCalculation.exit_codes.ERROR_IONIC_CONVERGENCE_NOT_REACHED,
+            PwCalculation.exit_codes.ERROR_IONIC_CYCLE_EXCEEDED_NSTEP,
+            PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_FAILURE,
+            PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_AND_FINAL_SCF_FAILURE,
+        ]
+    )
     def handle_relax_recoverable_ionic_convergence_error(self, calculation):
         """Handle various exit codes for recoverable `relax` calculations with failed ionic convergence.
 
@@ -432,10 +441,13 @@ class PwBaseWorkChain(BaseRestartWorkChain):
         self.report_error_handled(calculation, action)
         return ProcessHandlerReport(True)
 
-    @process_handler(priority=550, exit_codes=[
-        PwCalculation.exit_codes.ERROR_IONIC_CYCLE_ELECTRONIC_CONVERGENCE_NOT_REACHED,
-        PwCalculation.exit_codes.ERROR_IONIC_CONVERGENCE_REACHED_FINAL_SCF_FAILED,
-        ])
+    @process_handler(
+        priority=550,
+        exit_codes=[
+            PwCalculation.exit_codes.ERROR_IONIC_CYCLE_ELECTRONIC_CONVERGENCE_NOT_REACHED,
+            PwCalculation.exit_codes.ERROR_IONIC_CONVERGENCE_REACHED_FINAL_SCF_FAILED,
+        ]
+    )
     def handle_relax_recoverable_electronic_convergence_error(self, calculation):
         """Handle various exit codes for recoverable `relax` calculations with failed electronic convergence.
 
@@ -455,7 +467,8 @@ class PwBaseWorkChain(BaseRestartWorkChain):
         return ProcessHandlerReport(True)
 
     @process_handler(priority=410, exit_codes=[
-        PwCalculation.exit_codes.ERROR_ELECTRONIC_CONVERGENCE_NOT_REACHED,])
+        PwCalculation.exit_codes.ERROR_ELECTRONIC_CONVERGENCE_NOT_REACHED,
+    ])
     def handle_electronic_convergence_not_achieved(self, calculation):
         """Handle `ERROR_ELECTRONIC_CONVERGENCE_NOT_REACHED`: decrease the mixing beta and restart from scratch."""
         factor = self.defaults.delta_factor_mixing_beta

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -94,6 +94,7 @@ class PwRelaxWorkChain(WorkChain):
         spec.expose_outputs(PwBaseWorkChain, exclude=('output_structure',))
         spec.output('output_structure', valid_type=orm.StructureData, required=False,
             help='The successfully relaxed structure, unless `relax_type is RelaxType.NONE`.')
+        # yapf: enable
 
     def setup(self):
         """Input validation and context setup."""
@@ -188,9 +189,7 @@ class PwRelaxWorkChain(WorkChain):
         """
         workchain = self.ctx.workchains[-1]
 
-        acceptable_statuses = [
-            'ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF'
-        ]
+        acceptable_statuses = ['ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF']
 
         if workchain.is_excepted or workchain.is_killed:
             self.report('relax PwBaseWorkChain was excepted or killed')
@@ -229,11 +228,17 @@ class PwRelaxWorkChain(WorkChain):
 
         if volume_difference < volume_threshold:
             self.ctx.is_converged = True
-            self.report('relative cell volume difference {} smaller than convergence threshold {}'
-                .format(volume_difference, volume_threshold))
+            self.report(
+                'relative cell volume difference {} smaller than convergence threshold {}'.format(
+                    volume_difference, volume_threshold
+                )
+            )
         else:
-            self.report('current relative cell volume difference {} larger than convergence threshold {}'
-                .format(volume_difference, volume_threshold))
+            self.report(
+                'current relative cell volume difference {} larger than convergence threshold {}'.format(
+                    volume_difference, volume_threshold
+                )
+            )
 
         self.ctx.current_cell_volume = curr_cell_volume
 

--- a/aiida_quantumespresso/workflows/q2r/base.py
+++ b/aiida_quantumespresso/workflows/q2r/base.py
@@ -29,6 +29,7 @@ class Q2rBaseWorkChain(BaseRestartWorkChain):
         )
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
             message='The calculation failed with an unrecoverable error.')
+        # yapf: enable
 
     def setup(self):
         """Call the `setup` of the `BaseRestartWorkChain` and then create the inputs dictionary in `self.ctx.inputs`.


### PR DESCRIPTION
The `calculations/__init__.py` contained a `# yapf: disable` statement, but no `# yapf: enable`. My understanding is that single `# yapf: disable` are "allowed" only at  the end of a specific line that shouldn't be formatted, otherwise it will apply for the entire rest of the file (see [the examples in their README](https://github.com/google/yapf#why-does-yapf-destroy-my-awesome-formatting)).

Here we add a `# yapf: enable` statement after the things that shouldn't be formatted, and apply the resulting formatting changes.

**EDIT:** Turns out `calculations/__init__.py` isn't the only affected file, updated the PR to add matching `# yapf: enable` everywhere.
