### PR TITLE
`PwBaseWorkChain`: Add report on disabling bands sanity check

### DIFF
--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -342,8 +342,16 @@ class PwBaseWorkChain(BaseRestartWorkChain):
         """
         from aiida_quantumespresso.utils.bands import get_highest_occupied_band
 
+        occupations = calculation.inputs.parameters.get_attribute('SYSTEM', {}).get('occupations', None)
+
+        if occupations is None:
+            self.report(
+                '`SYSTEM.occupations` parameter is not defined: performing band occupation check. '
+                'If you want to disable this, explicitly set `SYSTEM.occupations` to `fixed`.'
+            )
+
         # Only skip the check on the highest band occupation if `occupations` was explicitly set to `fixed`.
-        if calculation.inputs.parameters.get_attribute('SYSTEM', {}).get('occupations', None) == 'fixed':
+        if occupations == 'fixed':
             return
 
         try:


### PR DESCRIPTION
Fixes #628

When the `PwCalculation` finishes with exit code `0`, the `PwBaseWorkChain` still executes a sanity check to make sure the highest energy band is not occupied, which is an indication that the calculation was run with insufficient bands in case the input structure is metallic. If the user is running an insulator, however, the check is still performed unless the `occupations` input of the `SYSTEM` namelist is specifically set to `'fixed'`. Since this is also the default value of `pw.x`, it might be confusing to users that the number of bands is increased.

Here we add a message to the report logs to explain this to the user in case the `SYSTEM.occupations` input is not specified, along with a recommendation that the check can be disabled when the input is specifically set to `'fixed'`.

