### PR TITLE
Dependencies: update to `aiida-pseudo==0.4.0`

### DIFF
--- a/aiida_quantumespresso/cli/calculations/cp.py
+++ b/aiida_quantumespresso/cli/calculations/cp.py
@@ -23,6 +23,8 @@ def launch_calculation(code, structure, pseudo_family, max_num_machines, max_wal
     """Run a CpCalculation."""
     from aiida.orm import Dict
     from aiida.plugins import CalculationFactory
+    from qe_tools import CONSTANTS
+
     from aiida_quantumespresso.utils.resources import get_default_options
 
     cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)
@@ -38,8 +40,8 @@ def launch_calculation(code, structure, pseudo_family, max_num_machines, max_wal
             'nstep': 10,
         },
         'SYSTEM': {
-            'ecutwfc': cutoff_wfc,
-            'ecutrho': cutoff_rho,
+            'ecutwfc': cutoff_wfc / CONSTANTS.ry_to_ev,
+            'ecutrho': cutoff_rho / CONSTANTS.ry_to_ev,
             'nr1b': 24,
             'nr2b': 24,
             'nr3b': 24,

--- a/aiida_quantumespresso/cli/calculations/neb.py
+++ b/aiida_quantumespresso/cli/calculations/neb.py
@@ -59,6 +59,8 @@ def launch_calculation(
     """
     from aiida.orm import Dict
     from aiida.plugins import CalculationFactory
+    from qe_tools import CONSTANTS
+
     from aiida_quantumespresso.utils.resources import get_default_options
 
     cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structures[0])
@@ -68,8 +70,8 @@ def launch_calculation(
             'calculation': 'relax',
         },
         'SYSTEM': {
-            'ecutwfc': ecutwfc or cutoff_wfc,
-            'ecutrho': ecutrho or cutoff_rho,
+            'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
+            'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,
         }
     }
 

--- a/aiida_quantumespresso/cli/calculations/pw.py
+++ b/aiida_quantumespresso/cli/calculations/pw.py
@@ -58,6 +58,8 @@ def launch_calculation(
     """Run a PwCalculation."""
     from aiida.orm import Dict, KpointsData
     from aiida.plugins import CalculationFactory
+    from qe_tools import CONSTANTS
+
     from aiida_quantumespresso.utils.resources import get_default_options
 
     cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)
@@ -67,8 +69,8 @@ def launch_calculation(
             'calculation': mode,
         },
         'SYSTEM': {
-            'ecutwfc': ecutwfc or cutoff_wfc,
-            'ecutrho': ecutrho or cutoff_rho,
+            'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
+            'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,
         }
     }
 

--- a/aiida_quantumespresso/cli/workflows/pw/bands.py
+++ b/aiida_quantumespresso/cli/workflows/pw/bands.py
@@ -40,6 +40,8 @@ def launch_workflow(
     # pylint: disable=too-many-statements
     from aiida.orm import Bool, Float, Dict
     from aiida.plugins import WorkflowFactory
+    from qe_tools import CONSTANTS
+
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     builder = WorkflowFactory('quantumespresso.pw.bands').get_builder()
@@ -48,8 +50,8 @@ def launch_workflow(
 
     parameters = {
         'SYSTEM': {
-            'ecutwfc': ecutwfc or cutoff_wfc,
-            'ecutrho': ecutrho or cutoff_rho,
+            'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
+            'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,
         },
     }
 

--- a/aiida_quantumespresso/cli/workflows/pw/base.py
+++ b/aiida_quantumespresso/cli/workflows/pw/base.py
@@ -40,6 +40,8 @@ def launch_workflow(
     """Run a `PwBaseWorkChain`."""
     from aiida.orm import Bool, Float, Dict
     from aiida.plugins import WorkflowFactory
+    from qe_tools import CONSTANTS
+
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     builder = WorkflowFactory('quantumespresso.pw.base').get_builder()
@@ -48,8 +50,8 @@ def launch_workflow(
 
     parameters = {
         'SYSTEM': {
-            'ecutwfc': ecutwfc or cutoff_wfc,
-            'ecutrho': ecutrho or cutoff_rho,
+            'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
+            'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,
         },
     }
 

--- a/aiida_quantumespresso/cli/workflows/pw/relax.py
+++ b/aiida_quantumespresso/cli/workflows/pw/relax.py
@@ -47,6 +47,7 @@ def launch_workflow(
     """Run a `PwRelaxWorkChain`."""
     from aiida.orm import Bool, Float, Dict, Str
     from aiida.plugins import WorkflowFactory
+    from qe_tools import CONSTANTS
 
     from aiida_quantumespresso.common.types import RelaxType
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
@@ -57,8 +58,8 @@ def launch_workflow(
 
     parameters = {
         'SYSTEM': {
-            'ecutwfc': ecutwfc or cutoff_wfc,
-            'ecutrho': ecutrho or cutoff_rho,
+            'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
+            'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,
         },
     }
 

--- a/setup.json
+++ b/setup.json
@@ -89,8 +89,8 @@
         ]
     },
     "install_requires": [
-        "aiida_core[atomic_tools]~=1.4,>=1.4.2",
-        "aiida-pseudo~=0.3.0",
+        "aiida_core[atomic_tools]~=1.4,>=1.4.4",
+        "aiida-pseudo~=0.4.0",
         "packaging",
         "qe-tools~=2.0rc1",
         "xmlschema~=1.2,>=1.2.5",


### PR DESCRIPTION
This new minor version comes with some significant changes:

 * All format specific pseudopotential family subclasses have been
   removed, for example, `UpfFamily` no longer exists. The format of
   the pseudos in a family are now stored as an extra and can be
   retrieved through the `pseudo_type` property. The command line
   option param type `PseudoFamilyType` was updated to reflect these
   changes.

 * The recommended cutoffs for families are now always stored in
   electronvolt. They therefore have to be converted explicitly to
   Rydberg before they are passed to the calculations.