### PR TITLE
`Protocol`: Switch to initial_magnetic_moments argument

### DIFF
--- a/aiida_quantumespresso/workflows/protocols/utils.py
+++ b/aiida_quantumespresso/workflows/protocols/utils.py
@@ -109,13 +109,26 @@ def get_magnetization_parameters() -> dict:
         return yaml.safe_load(handle)
 
 
-def get_starting_magnetization(structure, pseudo_family):
+def get_starting_magnetization(structure, pseudo_family, initial_magnetic_moments=None):
     """Return the dictionary with starting magnetization for each kind in the structure.
 
     :param structure: the structure.
     :param pseudo_family: pseudopotential family.
+    :param initial_magnetic_moments: dictionary mapping each kind in the structure to its magnetic moment.
     :returns: dictionary of starting magnetizations.
     """
+    if initial_magnetic_moments is not None:
+
+        nkinds = len(structure.kinds)
+
+        if sorted(initial_magnetic_moments.keys()) != sorted(structure.get_kind_names()):
+            raise ValueError(f'`initial_magnetic_moments` needs one value for each of the {nkinds} kinds.')
+
+        return {
+            kind.name: initial_magnetic_moments[kind.name] / pseudo_family.get_pseudo(element=kind.symbol).z_valence
+            for kind in structure.kinds
+        }
+
     magnetic_parameters = get_magnetization_parameters()
     starting_magnetization = {}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,7 +289,7 @@ def generate_upf_data(tmp_path_factory):
         from aiida_pseudo.data.pseudo import UpfData
 
         with open(tmp_path_factory.mktemp('pseudos') / f'{element}.upf', 'w+b') as handle:
-            content = f'<UPF version="2.0.1"><PP_HEADER\nelement="{element}"\nz_valence="1.0"\n/></UPF>\n'
+            content = f'<UPF version="2.0.1"><PP_HEADER\nelement="{element}"\nz_valence="4.0"\n/></UPF>\n'
             handle.write(content.encode('utf-8'))
             handle.flush()
             return UpfData(file=handle)

--- a/tests/fixtures/pseudos/Si.upf
+++ b/tests/fixtures/pseudos/Si.upf
@@ -1,4 +1,4 @@
 <UPF version="2.0.1"><PP_HEADER
 element="Si"
-z_valence="1.0"
+z_valence="4.0"
 /></UPF>

--- a/tests/workflows/protocols/pw/test_bands/test_default.yml
+++ b/tests/workflows/protocols/pw/test_bands/test_default.yml
@@ -26,7 +26,7 @@ bands:
         occupations: smearing
         smearing: cold
     pseudos:
-      Si: Si<md5=b8624bea1910ebe720dc5977d5a73a7d>
+      Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
 bands_kpoints_distance: 0.025
 clean_workdir: true
 nbands_factor: 3.0
@@ -63,7 +63,7 @@ relax:
           occupations: smearing
           smearing: cold
       pseudos:
-        Si: Si<md5=b8624bea1910ebe720dc5977d5a73a7d>
+        Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
   max_meta_convergence_iterations: 5
   meta_convergence: true
   relax_type: atoms_cell
@@ -98,5 +98,5 @@ scf:
         occupations: smearing
         smearing: cold
     pseudos:
-      Si: Si<md5=b8624bea1910ebe720dc5977d5a73a7d>
+      Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
 structure: Si2

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -63,31 +63,33 @@ def test_spin_type(fixture_code, generate_structure):
     assert parameters['SYSTEM']['starting_magnetization'] == {'Si': 0.1}
 
 
-@pytest.mark.parametrize('starting_magnetization', ({}, {'Si1': 1.0, 'Si2': 2.0}))
-def test_starting_magnetization_invalid(fixture_code, generate_structure, starting_magnetization):
-    """Test ``PwBaseWorkChain.get_builder_from_protocol`` with invalid ``starting_magnetization`` keyword."""
+@pytest.mark.parametrize('initial_magnetic_moments', ({}, {'Si1': 1.0, 'Si2': 2.0}))
+def test_initial_magnetic_moments_invalid(fixture_code, generate_structure, initial_magnetic_moments):
+    """Test ``PwBaseWorkChain.get_builder_from_protocol`` with invalid ``initial_magnetic_moments`` keyword."""
     code = fixture_code('quantumespresso.pw')
     structure = generate_structure()
 
-    with pytest.raises(ValueError, match=r'`starting_magnetization` is specified but spin type `.*` is incompatible.'):
-        PwBaseWorkChain.get_builder_from_protocol(code, structure, starting_magnetization=starting_magnetization)
+    with pytest.raises(
+        ValueError, match=r'`initial_magnetic_moments` is specified but spin type `.*` is incompatible.'
+    ):
+        PwBaseWorkChain.get_builder_from_protocol(code, structure, initial_magnetic_moments=initial_magnetic_moments)
 
     with pytest.raises(ValueError):
         PwBaseWorkChain.get_builder_from_protocol(
-            code, structure, starting_magnetization=starting_magnetization, spin_type=SpinType.COLLINEAR
+            code, structure, initial_magnetic_moments=initial_magnetic_moments, spin_type=SpinType.COLLINEAR
         )
 
 
-def test_starting_magnetization(fixture_code, generate_structure):
-    """Test ``PwBaseWorkChain.get_builder_from_protocol`` with ``starting_magnetization`` keyword."""
+def test_initial_magnetic_moments(fixture_code, generate_structure):
+    """Test ``PwBaseWorkChain.get_builder_from_protocol`` with ``initial_magnetic_moments`` keyword."""
     code = fixture_code('quantumespresso.pw')
     structure = generate_structure()
 
-    starting_magnetization = {'Si': 1.0}
+    initial_magnetic_moments = {'Si': 1.0}
     builder = PwBaseWorkChain.get_builder_from_protocol(
-        code, structure, starting_magnetization=starting_magnetization, spin_type=SpinType.COLLINEAR
+        code, structure, initial_magnetic_moments=initial_magnetic_moments, spin_type=SpinType.COLLINEAR
     )
     parameters = builder.pw.parameters.get_dict()
 
     assert parameters['SYSTEM']['nspin'] == 2
-    assert parameters['SYSTEM']['starting_magnetization'] == starting_magnetization
+    assert parameters['SYSTEM']['starting_magnetization'] == {'Si': 0.25}

--- a/tests/workflows/protocols/pw/test_base/test_default.yml
+++ b/tests/workflows/protocols/pw/test_base/test_default.yml
@@ -28,5 +28,5 @@ pw:
       occupations: smearing
       smearing: cold
   pseudos:
-    Si: Si<md5=b8624bea1910ebe720dc5977d5a73a7d>
+    Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
   structure: Si2

--- a/tests/workflows/protocols/pw/test_relax/test_default.yml
+++ b/tests/workflows/protocols/pw/test_relax/test_default.yml
@@ -30,7 +30,7 @@ base:
         occupations: smearing
         smearing: cold
     pseudos:
-      Si: Si<md5=b8624bea1910ebe720dc5977d5a73a7d>
+      Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
 base_final_scf:
   kpoints_distance: 0.15
   kpoints_force_parity: false
@@ -63,7 +63,7 @@ base_final_scf:
         occupations: smearing
         smearing: cold
     pseudos:
-      Si: Si<md5=b8624bea1910ebe720dc5977d5a73a7d>
+      Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
 clean_workdir: true
 max_meta_convergence_iterations: 5
 meta_convergence: true


### PR DESCRIPTION
Replace the `starting_magnetization` input argument of the
`get_builder_from_protocol` method of the `PwBaseWorkChain` by
`initial_magmom`.

Allowing the user to define the initial magnetic moments in Bohr
magnetons instead of the `starting_magnetization` has several advantages:

* It's easier to think of an initial guess for the magnetic moment than
the `starting_magnetization` based on e.g. the oxidition state of the
element.
* The magnetization output of pw.x also is expressed in Bohr magnetons.
* Since deriving the `starting_magnetization` from the magnetic moments
requires the `z_valence`, it requires knowledge about which
pseudopotentials are being used for the calculation. This makes it a
more difficult quantity to work with than the magnetic moments when
using the `get_builder_from_protocol` method in other projects.