### PR TITLE
`PwRelaxWorkChain`: Move `RelaxType` input to `get_builder_from_protocol`

### DIFF
--- a/aiida_quantumespresso/cli/workflows/pw/bands.py
+++ b/aiida_quantumespresso/cli/workflows/pw/bands.py
@@ -49,6 +49,9 @@ def launch_workflow(
     cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)
 
     parameters = {
+        'CONTROL': {
+            'calculation': 'relax',
+        },
         'SYSTEM': {
             'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
             'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,

--- a/aiida_quantumespresso/cli/workflows/pw/relax.py
+++ b/aiida_quantumespresso/cli/workflows/pw/relax.py
@@ -56,6 +56,9 @@ def launch_workflow(
     cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)
 
     parameters = {
+        'CONTROL': {
+            'calculation': 'relax',
+        },
         'SYSTEM': {
             'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
             'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,

--- a/aiida_quantumespresso/cli/workflows/pw/relax.py
+++ b/aiida_quantumespresso/cli/workflows/pw/relax.py
@@ -49,7 +49,6 @@ def launch_workflow(
     from aiida.plugins import WorkflowFactory
     from qe_tools import CONSTANTS
 
-    from aiida_quantumespresso.common.types import RelaxType
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     builder = WorkflowFactory('quantumespresso.pw.relax').get_builder()
@@ -81,7 +80,6 @@ def launch_workflow(
         raise click.BadParameter(str(exception))
 
     builder.structure = structure
-    builder.relax_type = Str(RelaxType.ATOMS.value)
     builder.base.kpoints_distance = Float(kpoints_distance)
     builder.base.pw.code = code
     builder.base.pw.pseudos = pseudo_family.get_pseudos(structure=structure)

--- a/aiida_quantumespresso/workflows/protocols/pw/relax.yaml
+++ b/aiida_quantumespresso/workflows/protocols/pw/relax.yaml
@@ -2,7 +2,6 @@ default_inputs:
     clean_workdir: True
     max_meta_convergence_iterations: 5
     meta_convergence: True
-    relax_type: atoms_cell
     volume_convergence: 0.02
     base:
         pw:

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -2,6 +2,7 @@
 """Workchain to relax a structure using Quantum ESPRESSO pw.x."""
 from aiida import orm
 from aiida.common import AttributeDict, exceptions
+from aiida.common.lang import type_check
 from aiida.engine import WorkChain, ToContext, if_, while_, append_
 from aiida.plugins import CalculationFactory, WorkflowFactory
 
@@ -31,19 +32,9 @@ def validate_relaxation_scheme(value, _):
         import warnings
         from aiida.common.warnings import AiidaDeprecationWarning
         warnings.warn(
-            'the `relaxation_scheme` input is deprecated and will be removed. Use the ``relax_type`` input instead. '
-            'Accepted values are values of the ``aiida_quantumespresso.common.types.RelaxType`` enum',
-            AiidaDeprecationWarning
+            'the `relaxation_scheme` input is deprecated and will be removed. Use the `get_builder_from_protocol` '
+            'instead to obtain a prepopulated builder using the `RelaxType` enum.', AiidaDeprecationWarning
         )
-
-
-def validate_relax_type(value, _):
-    """Validate the relax type input."""
-    if value:
-        try:
-            RelaxType(value.value)
-        except ValueError:
-            return f'`{value.value}` is not a valid value of `RelaxType`.'
 
 
 class PwRelaxWorkChain(ProtocolMixin, WorkChain):
@@ -66,9 +57,6 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
             help='If `True`, a final SCF calculation will be performed on the successfully relaxed structure.')
         spec.input('relaxation_scheme', valid_type=orm.Str, required=False, validator=validate_relaxation_scheme,
             help='The relaxation scheme to use: choose either `relax` or `vc-relax` for variable cell relax.')
-        spec.input('relax_type', valid_type=orm.Str, default=lambda: orm.Str(RelaxType.ATOMS_CELL.value),
-            validator=validate_relax_type,
-            help='The relax type to use: should be a value of the enum ``common.types.RelaxType``.')
         spec.input('meta_convergence', valid_type=orm.Bool, default=lambda: orm.Bool(True),
             help='If `True` the workchain will perform a meta-convergence on the cell volume.')
         spec.input('max_meta_convergence_iterations', valid_type=orm.Int, default=lambda: orm.Int(5),
@@ -95,21 +83,26 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
             message='the final scf PwBaseWorkChain sub process failed')
         spec.expose_outputs(PwBaseWorkChain, exclude=('output_structure',))
         spec.output('output_structure', valid_type=orm.StructureData, required=False,
-            help='The successfully relaxed structure, unless `relax_type is RelaxType.NONE`.')
+            help='The successfully relaxed structure.')
         # yapf: enable
 
     @classmethod
-    def get_builder_from_protocol(cls, code, structure, protocol=None, overrides=None, **kwargs):
+    def get_builder_from_protocol(
+        cls, code, structure, protocol=None, overrides=None, relax_type=RelaxType.ATOMS_CELL, **kwargs
+    ):
         """Return a builder prepopulated with inputs selected according to the chosen protocol.
 
         :param code: the ``Code`` instance configured for the ``quantumespresso.pw`` plugin.
         :param structure: the ``StructureData`` instance to use.
         :param protocol: protocol to use, if not specified, the default will be used.
         :param overrides: optional dictionary of inputs to override the defaults of the protocol.
+        :param relax_type: the relax type to use: should be a value of the enum ``common.types.RelaxType``.
         :param kwargs: additional keyword arguments that will be passed to the ``get_builder_from_protocol`` of all the
             sub processes that are called by this workchain.
         :return: a process builder instance with all inputs defined ready for launch.
         """
+        type_check(relax_type, RelaxType)
+
         args = (code, structure, protocol)
         inputs = cls.get_protocol_inputs(protocol, overrides)
         builder = cls.get_builder()
@@ -124,13 +117,34 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         base_final_scf['pw'].pop('structure', None)
         base_final_scf.pop('clean_workdir', None)
 
+        if relax_type in [RelaxType.VOLUME, RelaxType.SHAPE, RelaxType.CELL]:
+            base.pw.settings = orm.Dict(dict=PwRelaxWorkChain._fix_atomic_positions(structure, base.pw.settings))
+
+        if relax_type is RelaxType.NONE:
+            base.pw.parameters['CONTROL']['calculation'] = 'scf'
+            base.pw.parameters.delete_attribute('CELL')
+
+        elif relax_type is RelaxType.ATOMS:
+            base.pw.parameters['CONTROL']['calculation'] = 'relax'
+            base.pw.parameters.delete_attribute('CELL')
+        else:
+            base.pw.parameters['CONTROL']['calculation'] = 'vc-relax'
+
+        if relax_type in [RelaxType.VOLUME, RelaxType.ATOMS_VOLUME]:
+            base.pw.parameters['CELL']['cell_dofree'] = 'volume'
+
+        if relax_type in [RelaxType.SHAPE, RelaxType.ATOMS_SHAPE]:
+            base.pw.parameters['CELL']['cell_dofree'] = 'shape'
+
+        if relax_type in [RelaxType.CELL, RelaxType.ATOMS_CELL]:
+            base.pw.parameters['CELL']['cell_dofree'] = 'all'
+
         builder.base = base
         builder.base_final_scf = base_final_scf
         builder.structure = structure
         builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
         builder.max_meta_convergence_iterations = orm.Int(inputs['max_meta_convergence_iterations'])
         builder.meta_convergence = orm.Bool(inputs['meta_convergence'])
-        builder.relax_type = orm.Str(inputs['relax_type'])
         builder.volume_convergence = orm.Float(inputs['volume_convergence'])
 
         return builder
@@ -143,22 +157,25 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         self.ctx.is_converged = False
         self.ctx.iteration = 0
 
-        # Determine the correct `RelaxType` and add it to the context
+        self.ctx.relax_inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, namespace='base'))
+        self.ctx.relax_inputs.pw.parameters = self.ctx.relax_inputs.pw.parameters.get_dict()
+
+        # Adjust the inputs for the chosen relaxation scheme
         if 'relaxation_scheme' in self.inputs:
-            if self.inputs.relaxation_scheme.value == 'relax':
-                self.ctx.relax_type = RelaxType.ATOMS
-            elif self.inputs.relaxation_scheme.value == 'vc-relax':
-                self.ctx.relax_type = RelaxType.ATOMS_CELL
+            if self.inputs.relaxation_scheme.value in ('relax', 'vc-relax'):
+                self.ctx.relax_inputs.pw.parameters['CONTROL']['calculation'] = self.inputs.relaxation_scheme.value
             else:
                 raise ValueError('unsupported value for the `relaxation_scheme` input.')
-        else:
-            self.ctx.relax_type = RelaxType(self.inputs.relax_type)
 
         # Set the meta_convergence and add it to the context
         self.ctx.meta_convergence = self.inputs.meta_convergence.value
-        if self.inputs.meta_convergence and self.ctx.relax_type in [RelaxType.NONE, RelaxType.ATOMS, RelaxType.SHAPE]:
+        volume_cannot_change = (
+            self.ctx.relax_inputs.pw.parameters['CONTROL']['calculation'] in ('scf', 'relax') or
+            self.ctx.relax_inputs.pw.parameters['CELL']['cell_dofree'] == 'shape'
+        )
+        if self.ctx.meta_convergence and volume_cannot_change:
             self.report(
-                f'Since there is no change in volume for `{self.ctx.relax_type}`, meta convergence is turned off.'
+                'No change in volume possible for the provided base input parameters. Meta convergence is turned off.'
             )
             self.ctx.meta_convergence = False
 
@@ -170,8 +187,11 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         elif 'base_final_scf' in self.inputs:
             self.ctx.final_scf_inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, namespace='base_final_scf'))
 
-        if self.ctx.relax_type is RelaxType.NONE:
-            self.report('Work chain will not run final SCF for `RelaxType.NONE`.')
+        if 'final_scf_inputs' in self.ctx and self.ctx.relax_inputs.pw.parameters['CONTROL']['calculation'] == 'scf':
+            self.report(
+                'Work chain will not run final SCF when `calculation` is set to `scf` for the relaxation '
+                '`PwBaseWorkChain`.'
+            )
             self.ctx.pop('final_scf_inputs')
 
     def should_run_relax(self):
@@ -194,34 +214,15 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         """Run the `PwBaseWorkChain` to run a relax `PwCalculation`."""
         self.ctx.iteration += 1
 
-        inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, namespace='base'))
+        inputs = self.ctx.relax_inputs
         inputs.pw.structure = self.ctx.current_structure
-        inputs.pw.parameters = inputs.pw.parameters.get_dict()
 
-        inputs.pw.parameters.setdefault('CELL', {})
         inputs.pw.parameters.setdefault('CONTROL', {})
         inputs.pw.parameters['CONTROL']['restart_mode'] = 'from_scratch'
 
-        if self.ctx.relax_type in [RelaxType.VOLUME, RelaxType.SHAPE, RelaxType.CELL]:
-            inputs.pw.settings = self._fix_atomic_positions(inputs.pw.structure, inputs.pw.get('settings', None))
-
-        if self.ctx.relax_type is RelaxType.NONE:
-            inputs.pw.parameters['CONTROL']['calculation'] = 'scf'
-            inputs.pw.parameters.pop('CELL', None)
-        elif self.ctx.relax_type is RelaxType.ATOMS:
-            inputs.pw.parameters['CONTROL']['calculation'] = 'relax'
-            inputs.pw.parameters.pop('CELL', None)
-        else:
-            inputs.pw.parameters['CONTROL']['calculation'] = 'vc-relax'
-
-        if self.ctx.relax_type in [RelaxType.VOLUME, RelaxType.ATOMS_VOLUME]:
-            inputs.pw.parameters['CELL']['cell_dofree'] = 'volume'
-
-        if self.ctx.relax_type in [RelaxType.SHAPE, RelaxType.ATOMS_SHAPE]:
-            inputs.pw.parameters['CELL']['cell_dofree'] = 'shape'
-
-        if self.ctx.relax_type in [RelaxType.CELL, RelaxType.ATOMS_CELL]:
-            inputs.pw.parameters['CELL']['cell_dofree'] = 'all'
+        # If the relaxation uses 'vc-relax make sure there is a 'CELL' namelist
+        if inputs.pw.parameters['CONTROL']['calculation'] == 'vc-relax':
+            inputs.pw.parameters.setdefault('CELL', {})
 
         # If one of the nested `PwBaseWorkChains` changed the number of bands, apply it here
         if self.ctx.current_number_of_bands is not None:
@@ -258,8 +259,8 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         try:
             structure = workchain.outputs.output_structure
         except exceptions.NotExistent:
-            # If relax_type is RelaxType.NONE, this is expected, so we are done
-            if self.ctx.relax_type is RelaxType.NONE:
+            # If the calculation is set to 'scf', this is expected, so we are done
+            if self.inputs.base.pw.parameters['CONTROL']['calculation'] == 'scf':
                 self.ctx.is_converged = True
                 return
 
@@ -345,7 +346,7 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         # Get the latest relax workchain and pass the outputs
         final_relax_workchain = self.ctx.workchains[-1]
 
-        if self.ctx.relax_type is not RelaxType.NONE:
+        if self.inputs.base.pw.parameters['CONTROL']['calculation'] != 'scf':
             self.out('output_structure', final_relax_workchain.outputs.output_structure)
 
         if 'final_scf_inputs' in self.ctx:

--- a/tests/workflows/protocols/pw/test_bands.py
+++ b/tests/workflows/protocols/pw/test_bands.py
@@ -72,5 +72,4 @@ def test_relax_type(fixture_code, generate_structure):
 
     builder = PwBandsWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.NONE)
     assert builder.relax['base']['pw']['parameters']['CONTROL']['calculation'] == 'scf'
-    with pytest.raises(KeyError):
-        builder.relax['base']['pw']['parameters']['CELL']  # pylint: disable=pointless-statement
+    assert 'CELL' not in builder.relax['base']['pw']['parameters'].get_dict()

--- a/tests/workflows/protocols/pw/test_bands.py
+++ b/tests/workflows/protocols/pw/test_bands.py
@@ -66,10 +66,11 @@ def test_spin_type(fixture_code, generate_structure):
 
 
 def test_relax_type(fixture_code, generate_structure):
-    """Test ``PwBandsWorkChain.get_builder_from_protocol`` overriding the ``relax_type`` input."""
+    """Test ``PwBandsWorkChain.get_builder_from_protocol`` setting the ``relax_type`` input."""
     code = fixture_code('quantumespresso.pw')
     structure = generate_structure()
 
-    overrides = {'relax': {'relax_type': RelaxType.NONE.value}}
-    builder = PwBandsWorkChain.get_builder_from_protocol(code, structure, overrides=overrides)
-    assert builder.relax['relax_type'].value == RelaxType.NONE.value
+    builder = PwBandsWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.NONE)
+    assert builder.relax['base']['pw']['parameters']['CONTROL']['calculation'] == 'scf'
+    with pytest.raises(KeyError):
+        builder.relax['base']['pw']['parameters']['CELL']  # pylint: disable=pointless-statement

--- a/tests/workflows/protocols/pw/test_bands/test_default.yml
+++ b/tests/workflows/protocols/pw/test_bands/test_default.yml
@@ -44,9 +44,10 @@ relax:
           withmpi: true
       parameters:
         CELL:
+          cell_dofree: all
           press_conv_thr: 0.5
         CONTROL:
-          calculation: scf
+          calculation: vc-relax
           etot_conv_thr: 2.0e-05
           forc_conv_thr: 0.0001
           tprnfor: true
@@ -66,7 +67,6 @@ relax:
         Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
   max_meta_convergence_iterations: 5
   meta_convergence: true
-  relax_type: atoms_cell
   volume_convergence: 0.02
 scf:
   kpoints_distance: 0.15

--- a/tests/workflows/protocols/pw/test_relax.py
+++ b/tests/workflows/protocols/pw/test_relax.py
@@ -72,13 +72,11 @@ def test_relax_type(fixture_code, generate_structure):
 
     builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.NONE)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'scf'
-    with pytest.raises(KeyError):
-        builder.base['pw']['parameters']['CELL']  # pylint: disable=pointless-statement
+    assert 'CELL' not in builder.base['pw']['parameters'].get_dict()
 
     builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'relax'
-    with pytest.raises(KeyError):
-        builder.base['pw']['parameters']['CELL']  # pylint: disable=pointless-statement
+    assert 'CELL' not in builder.base['pw']['parameters'].get_dict()
 
     builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.VOLUME)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
@@ -98,17 +96,14 @@ def test_relax_type(fixture_code, generate_structure):
     builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS_VOLUME)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
     assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'volume'
-    with pytest.raises(KeyError):
-        builder.base['pw']['settings']  # pylint: disable=pointless-statement
+    assert 'settings' not in builder.base['pw']
 
     builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS_SHAPE)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
     assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'shape'
-    with pytest.raises(KeyError):
-        builder.base['pw']['settings']  # pylint: disable=pointless-statement
+    assert 'settings' not in builder.base['pw']
 
     builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS_CELL)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
     assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'all'
-    with pytest.raises(KeyError):
-        builder.base['pw']['settings']  # pylint: disable=pointless-statement
+    assert 'settings' not in builder.base['pw']

--- a/tests/workflows/protocols/pw/test_relax.py
+++ b/tests/workflows/protocols/pw/test_relax.py
@@ -65,10 +65,50 @@ def test_spin_type(fixture_code, generate_structure):
         assert parameters['SYSTEM']['starting_magnetization'] == {'Si': 0.1}
 
 
-@pytest.mark.parametrize('relax_type', RelaxType)
-def test_relax_type(fixture_code, generate_structure, relax_type):
-    """Docs."""
+def test_relax_type(fixture_code, generate_structure):
+    """Test ``PwRelaxWorkChain.get_builder_from_protocol`` with ``spin_type`` keyword."""
     code = fixture_code('quantumespresso.pw')
     structure = generate_structure()
-    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, overrides={'relax_type': relax_type.value})
-    assert builder.relax_type.value == relax_type.value
+
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.NONE)
+    assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'scf'
+    with pytest.raises(KeyError):
+        builder.base['pw']['parameters']['CELL']  # pylint: disable=pointless-statement
+
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS)
+    assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'relax'
+    with pytest.raises(KeyError):
+        builder.base['pw']['parameters']['CELL']  # pylint: disable=pointless-statement
+
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.VOLUME)
+    assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
+    assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'volume'
+    assert builder.base['pw']['settings'].get_dict() == {'FIXED_COORDS': [[True, True, True], [True, True, True]]}
+
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.SHAPE)
+    assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
+    assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'shape'
+    assert builder.base['pw']['settings'].get_dict() == {'FIXED_COORDS': [[True, True, True], [True, True, True]]}
+
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.CELL)
+    assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
+    assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'all'
+    assert builder.base['pw']['settings'].get_dict() == {'FIXED_COORDS': [[True, True, True], [True, True, True]]}
+
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS_VOLUME)
+    assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
+    assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'volume'
+    with pytest.raises(KeyError):
+        builder.base['pw']['settings']  # pylint: disable=pointless-statement
+
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS_SHAPE)
+    assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
+    assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'shape'
+    with pytest.raises(KeyError):
+        builder.base['pw']['settings']  # pylint: disable=pointless-statement
+
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS_CELL)
+    assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
+    assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'all'
+    with pytest.raises(KeyError):
+        builder.base['pw']['settings']  # pylint: disable=pointless-statement

--- a/tests/workflows/protocols/pw/test_relax/test_default.yml
+++ b/tests/workflows/protocols/pw/test_relax/test_default.yml
@@ -11,9 +11,10 @@ base:
         withmpi: true
     parameters:
       CELL:
+        cell_dofree: all
         press_conv_thr: 0.5
       CONTROL:
-        calculation: scf
+        calculation: vc-relax
         etot_conv_thr: 2.0e-05
         forc_conv_thr: 0.0001
         tprnfor: true
@@ -67,6 +68,5 @@ base_final_scf:
 clean_workdir: true
 max_meta_convergence_iterations: 5
 meta_convergence: true
-relax_type: atoms_cell
 structure: Si2
 volume_convergence: 0.02


### PR DESCRIPTION
Instead of having the Relaxtype as an input of the PwRelaxWorkChain, it
would be better to properly separate church and state by making it an
input of the `get_builder_from_protocol` method. Based on the chosen
`Relaxtype`, this will properly populate the builder of the
`PwRelaxWorkChain`.

Second, currently for `RelaxType.NONE`, the `PwRelaxWorkChain` fixes
the atoms using the `if_pos` inputs explained explained here:

https://www.quantum-espresso.org/Doc/INPUT_PW.html#idm1094

and then run a `'relax'` type calculation. This leads to issues with
all calculations raising `ERROR_IONIC_CONVERGENCE_NOT_REACHED` 
exit codes from the parser. 

Instead, here we set `parameters['CONTROL']['calculation'] = 'scf'` for
`RelaxType.NONE` in the `get_builder_from_protocol` method, since 
this "relaxation" type really corresponds to a static calculation.

Besides this, we also:

* Make sure the `PwRelaxWorkChain` only runs 1 `PwBaseWorkChain` for
  `RelaxType`'s `NONE`, `ATOMS` and `SHAPE`. I.e. meta convergence is
  turned off.
* Make sure we do not run a "final_scf" when `'calculation'` is set to `'scf'`
  for the `PwBaseWorkChain` that does the relaxation.
* Make sure we don't run into an error in the `results` step of the outline
  when running with `'calculation'` set to `'scf'`.

#### TODO

- [x] Ask @sphuber if we _really_ need to be able to disguise static calculations 
  as `PwRelaxWorkChain`s.
- [x] Give this work chain logic another hard look and see if it can't be simplified.
- [x] Add more tests for these `RelaxType`s and the work chain logic.
- [x] Test all of the `RelaxType`s and make sure we don't run into more errors.