### PR TITLE
`PwBaseWorkChain`: Fix protocols

### DIFF
--- a/aiida_quantumespresso/workflows/protocols/pw/base.yaml
+++ b/aiida_quantumespresso/workflows/protocols/pw/base.yaml
@@ -34,9 +34,10 @@ protocols:
     precise:
         description: 'Protocol to perform the computation at high precision at higher computational cost.'
         kpoints_distance: 0.10
-        meta:
+        meta_parameters:
             conv_thr_per_atom: 0.1e-9
             etot_conv_thr_per_atom: 0.5e-5
+        pseudo_family: 'SSSP/1.1/PBE/precision'
         pw:
             parameters:
                 CONTROL:
@@ -44,7 +45,7 @@ protocols:
     fast:
         description: 'Protocol to perform the computation at low precision at minimal computational cost for testing purposes.'
         kpoints_distance: 0.50
-        meta:
+        meta_parameters:
             conv_thr_per_atom: 0.4e-9
             etot_conv_thr_per_atom: 1.e-6
         pw:


### PR DESCRIPTION
Fixes two issues with the `PwBaseWorkChain` protocol:

* Use `'SSSP/1.1/PBE/precision'` for protocol `precise`.
* Fix typo in `meta_parameters`.