### PR TITLE
Protocols: Allow for PseudoDojoFamily pseudos

### DIFF
--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -172,7 +172,8 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             pseudo_family = orm.QueryBuilder().append(pseudo_set, filters={'label': pseudo_family}).one()[0]
         except exceptions.NotExistent as exception:
             raise ValueError(
-                f'required pseudo family `{pseudo_family}` is not installed. Please run `aiida-pseudo install sssp`.'
+                f'required pseudo family `{pseudo_family}` is not installed. Please use `aiida-pseudo install` to'
+                'install it.'
             ) from exception
 
         cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -18,6 +18,7 @@ from ..protocols.utils import ProtocolMixin
 
 PwCalculation = CalculationFactory('quantumespresso.pw')
 SsspFamily = GroupFactory('pseudo.family.sssp')
+PseudoDojoFamily = GroupFactory('pseudo.family.pseudo_dojo')
 
 
 def validate_pseudo_family(value, _):
@@ -167,7 +168,8 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         natoms = len(structure.sites)
 
         try:
-            pseudo_family = orm.QueryBuilder().append(SsspFamily, filters={'label': pseudo_family}).one()[0]
+            pseudo_set = (PseudoDojoFamily, SsspFamily)
+            pseudo_family = orm.QueryBuilder().append(pseudo_set, filters={'label': pseudo_family}).one()[0]
         except exceptions.NotExistent as exception:
             raise ValueError(
                 f'required pseudo family `{pseudo_family}` is not installed. Please run `aiida-pseudo install sssp`.'


### PR DESCRIPTION
Currently the `get_builder_from_protocol()` method only queries for
pseudopotential families of type `SsspFamily`. Here we also include
the `PseudoDojoFamily` class in the query, so these pseudo families can
also be used for the protocols.