### PR TITLE
Protocols: Fix ionic convergence thresholds for fast protocol

### DIFF
--- a/aiida_quantumespresso/workflows/protocols/pw/base.yaml
+++ b/aiida_quantumespresso/workflows/protocols/pw/base.yaml
@@ -47,8 +47,8 @@ protocols:
         kpoints_distance: 0.50
         meta_parameters:
             conv_thr_per_atom: 0.4e-9
-            etot_conv_thr_per_atom: 1.e-6
+            etot_conv_thr_per_atom: 1.e-4
         pw:
             parameters:
                 CONTROL:
-                    forc_conv_thr: 1.e-5
+                    forc_conv_thr: 1.e-3


### PR DESCRIPTION
The ionic convergence thresholds for the `fast` protocol were more
strict than the `moderate` and `precise` protocols. Here we loosen the
ionic convergence thresholds for the `fast` protocols to something more
suitable for test calculations.