### PR TITLE
`Devops`: Fix nightly build vs aiida-core develop

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.6, 3.7, 3.8]
+                python-version: [3.7, 3.8]
 
         services:
             postgres:
@@ -57,8 +57,8 @@ jobs:
             id: install
             run: |
                 pip install --upgrade setuptools
+                pip install git+https://github.com/aiidateam/aiida-core@develop#egg=aiida-core[atomic_tools]
                 pip install -e .[tests]
-                pip install git+https://github.com/aiidateam/aiida-core@develop
                 reentry scan
 
         -   name: Run pytest


### PR DESCRIPTION
Fixes #627 

The nightly build versus the `aiida-core` develop branch has been
failing. Here we make two adjustments:

* Remove the tests for Python 3.6 since `aiida-core` has dropped support
for this version.
* First install the develop branch of `aiida-core`, then
`aiida-quantumespresso. This way there are no dependency conflicts (e.g.
at this moment due to the switch from `tornado` to `asyncio`.