### PR TITLE
Dependencies: update to `aiida-pseudo==0.5.0`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -90,7 +90,7 @@
     },
     "install_requires": [
         "aiida_core[atomic_tools]~=1.4,>=1.4.4",
-        "aiida-pseudo~=0.4.0",
+        "aiida-pseudo~=0.5.0",
         "packaging",
         "qe-tools~=2.0rc1",
         "xmlschema~=1.2,>=1.2.5",


### PR DESCRIPTION
Update the requirements for `aiida-pseudo` to include the fixes
for the pseudo-dojo pseudos.