### PR TITLE
Protocols: Fix mutation of overrides

### DIFF
--- a/aiida_quantumespresso/workflows/protocols/utils.py
+++ b/aiida_quantumespresso/workflows/protocols/utils.py
@@ -70,6 +70,7 @@ def recursive_merge(left, right):
     """
     import collections
 
+    # Note that a deepcopy is not necessary, since this function is called recusively.
     right = right.copy()
 
     for key, value in left.items():

--- a/aiida_quantumespresso/workflows/protocols/utils.py
+++ b/aiida_quantumespresso/workflows/protocols/utils.py
@@ -70,6 +70,8 @@ def recursive_merge(left, right):
     """
     import collections
 
+    right = right.copy()
+
     for key, value in left.items():
         if key in right:
             if isinstance(value, collections.abc.Mapping) and isinstance(right[key], collections.abc.Mapping):

--- a/tests/workflows/protocols/test_utils.py
+++ b/tests/workflows/protocols/test_utils.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Tests for the utility functions for the protocols."""
+
+def test_recursive_merge():
+    """Test the recursive merge function."""
+    from aiida_quantumespresso.workflows.protocols.utils import recursive_merge
+
+    left_dict = {
+        'a': {
+            'b': 1,
+            'c': {
+                'd': 2
+            }
+        },
+        'g': 3
+    }
+    right_dict = {
+        'a': {
+            'c': {
+                'd': 'D'
+            }
+        },
+        'e': {
+            'f': 'F'
+        }
+    }
+    merged = recursive_merge(left_dict, right_dict)
+
+    assert right_dict == {
+        'a': {
+            'c': {
+                'd': 'D'
+            }
+        },
+        'e': {
+            'f': 'F'
+        }
+    }
+
+    assert merged == {
+        'a': {
+            'b': 1,
+            'c': {
+                'd': 'D'
+            }
+        },
+        'e': {
+            'f': 'F'
+        },
+        'g': 3
+    }

--- a/tests/workflows/protocols/test_utils.py
+++ b/tests/workflows/protocols/test_utils.py
@@ -1,51 +1,15 @@
 # -*- coding: utf-8 -*-
 """Tests for the utility functions for the protocols."""
 
+
 def test_recursive_merge():
     """Test the recursive merge function."""
     from aiida_quantumespresso.workflows.protocols.utils import recursive_merge
 
-    left_dict = {
-        'a': {
-            'b': 1,
-            'c': {
-                'd': 2
-            }
-        },
-        'g': 3
-    }
-    right_dict = {
-        'a': {
-            'c': {
-                'd': 'D'
-            }
-        },
-        'e': {
-            'f': 'F'
-        }
-    }
+    left_dict = {'a': {'b': 1, 'c': {'d': 2}}, 'g': 3}
+    right_dict = {'a': {'c': {'d': 'D'}}, 'e': {'f': 'F'}}
     merged = recursive_merge(left_dict, right_dict)
 
-    assert right_dict == {
-        'a': {
-            'c': {
-                'd': 'D'
-            }
-        },
-        'e': {
-            'f': 'F'
-        }
-    }
+    assert right_dict == {'a': {'c': {'d': 'D'}}, 'e': {'f': 'F'}}
 
-    assert merged == {
-        'a': {
-            'b': 1,
-            'c': {
-                'd': 'D'
-            }
-        },
-        'e': {
-            'f': 'F'
-        },
-        'g': 3
-    }
+    assert merged == {'a': {'b': 1, 'c': {'d': 'D'}}, 'e': {'f': 'F'}, 'g': 3}


### PR DESCRIPTION
Fixes #649 

Currently the `overrides` input dictionary provided to the
`get_builder_from_protocol` method can be mutated to also include the
defaults from the protocol. Here we make a copy of the `right`
dictionary in the `recursive_merge` function, to prevent the key/value
pairs of the `left` dictionary to be added to the `right` one. This
prevents the mutation of the `overrides` argument.