### PR TITLE
`RelaxType`: Rename `ATOMS` to `POSITIONS`

### DIFF
--- a/aiida_quantumespresso/common/types.py
+++ b/aiida_quantumespresso/common/types.py
@@ -15,13 +15,13 @@ class RelaxType(enum.Enum):
     """Enumeration of known relax types."""
 
     NONE = 'none'  # All degrees of freedom are fixed, essentially performs single point SCF calculation
-    ATOMS = 'atoms'  # Only the atomic positions are relaxed, cell is fixed
+    POSITIONS = 'positions'  # Only the atomic positions are relaxed, cell is fixed
     VOLUME = 'volume'  # Only the cell volume is optimized, cell shape and atoms are fixed
     SHAPE = 'shape'  # Only the cell shape is optimized at a fixed volume and fixed atomic positions
     CELL = 'cell'  # Only the cell is optimized, both shape and volume, while atomic positions are fixed
-    ATOMS_VOLUME = 'atoms_volume'  # Same as `VOLUME` but atomic positions are relaxed as well
-    ATOMS_SHAPE = 'atoms_shape'  # Same as `SHAPE`  but atomic positions are relaxed as well
-    ATOMS_CELL = 'atoms_cell'  # Same as `CELL`  but atomic positions are relaxed as well
+    POSITIONS_VOLUME = 'positions_volume'  # Same as `VOLUME` but atomic positions are relaxed as well
+    POSITIONS_SHAPE = 'positions_shape'  # Same as `SHAPE`  but atomic positions are relaxed as well
+    POSITIONS_CELL = 'positions_cell'  # Same as `CELL`  but atomic positions are relaxed as well
 
 
 class SpinType(enum.Enum):

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -97,7 +97,7 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
 
     @classmethod
     def get_builder_from_protocol(
-        cls, code, structure, protocol=None, overrides=None, relax_type=RelaxType.ATOMS_CELL, **kwargs
+        cls, code, structure, protocol=None, overrides=None, relax_type=RelaxType.POSITIONS_CELL, **kwargs
     ):
         """Return a builder prepopulated with inputs selected according to the chosen protocol.
 
@@ -133,19 +133,19 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
             base.pw.parameters['CONTROL']['calculation'] = 'scf'
             base.pw.parameters.delete_attribute('CELL')
 
-        elif relax_type is RelaxType.ATOMS:
+        elif relax_type is RelaxType.POSITIONS:
             base.pw.parameters['CONTROL']['calculation'] = 'relax'
             base.pw.parameters.delete_attribute('CELL')
         else:
             base.pw.parameters['CONTROL']['calculation'] = 'vc-relax'
 
-        if relax_type in [RelaxType.VOLUME, RelaxType.ATOMS_VOLUME]:
+        if relax_type in [RelaxType.VOLUME, RelaxType.POSITIONS_VOLUME]:
             base.pw.parameters['CELL']['cell_dofree'] = 'volume'
 
-        if relax_type in [RelaxType.SHAPE, RelaxType.ATOMS_SHAPE]:
+        if relax_type in [RelaxType.SHAPE, RelaxType.POSITIONS_SHAPE]:
             base.pw.parameters['CELL']['cell_dofree'] = 'shape'
 
-        if relax_type in [RelaxType.CELL, RelaxType.ATOMS_CELL]:
+        if relax_type in [RelaxType.CELL, RelaxType.POSITIONS_CELL]:
             base.pw.parameters['CELL']['cell_dofree'] = 'all'
 
         builder.base = base

--- a/tests/workflows/protocols/pw/test_relax.py
+++ b/tests/workflows/protocols/pw/test_relax.py
@@ -74,7 +74,7 @@ def test_relax_type(fixture_code, generate_structure):
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'scf'
     assert 'CELL' not in builder.base['pw']['parameters'].get_dict()
 
-    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS)
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.POSITIONS)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'relax'
     assert 'CELL' not in builder.base['pw']['parameters'].get_dict()
 
@@ -93,17 +93,17 @@ def test_relax_type(fixture_code, generate_structure):
     assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'all'
     assert builder.base['pw']['settings'].get_dict() == {'FIXED_COORDS': [[True, True, True], [True, True, True]]}
 
-    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS_VOLUME)
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.POSITIONS_VOLUME)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
     assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'volume'
     assert 'settings' not in builder.base['pw']
 
-    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS_SHAPE)
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.POSITIONS_SHAPE)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
     assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'shape'
     assert 'settings' not in builder.base['pw']
 
-    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.ATOMS_CELL)
+    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.POSITIONS_CELL)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
     assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'all'
     assert 'settings' not in builder.base['pw']


### PR DESCRIPTION
Renames the `RelaxType.ATOMS` to `RelaxType.POSITIONS`, since it is the
positions of the atoms that are being relaxed. Similarly,
`ATOMS_VOLUME`, `ATOMS_SHAPE` and `ATOMS_CELL` are renamed to
`POSITIONS_VOLUME`, `POSITIONS_SHAPE` and `POSITIONS_CELL`,
respectively.

This change is also necessary to accommodate a similar change in
`aiida-common-workflows`, see:

https://github.com/aiidateam/aiida-common-workflows/pull/146