### PR TITLE
`PwRelaxWorkChain`: remove compatibility for volume optimization

### DIFF
--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -126,7 +126,12 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         base_final_scf['pw'].pop('structure', None)
         base_final_scf.pop('clean_workdir', None)
 
-        if relax_type in [RelaxType.VOLUME, RelaxType.SHAPE, RelaxType.CELL]:
+        # Quantum ESPRESSO currently only supports optimization of the volume for simple cubic systems. It requires
+        # to set `ibrav=1` or the code will except.
+        if relax_type in (RelaxType.VOLUME, RelaxType.POSITIONS_VOLUME):
+            raise ValueError(f'relax type `{relax_type} is not yet supported.')
+
+        if relax_type in (RelaxType.VOLUME, RelaxType.SHAPE, RelaxType.CELL):
             base.pw.settings = orm.Dict(dict=PwRelaxWorkChain._fix_atomic_positions(structure, base.pw.settings))
 
         if relax_type is RelaxType.NONE:
@@ -139,13 +144,13 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         else:
             base.pw.parameters['CONTROL']['calculation'] = 'vc-relax'
 
-        if relax_type in [RelaxType.VOLUME, RelaxType.POSITIONS_VOLUME]:
+        if relax_type in (RelaxType.VOLUME, RelaxType.POSITIONS_VOLUME):
             base.pw.parameters['CELL']['cell_dofree'] = 'volume'
 
-        if relax_type in [RelaxType.SHAPE, RelaxType.POSITIONS_SHAPE]:
+        if relax_type in (RelaxType.SHAPE, RelaxType.POSITIONS_SHAPE):
             base.pw.parameters['CELL']['cell_dofree'] = 'shape'
 
-        if relax_type in [RelaxType.CELL, RelaxType.POSITIONS_CELL]:
+        if relax_type in (RelaxType.CELL, RelaxType.POSITIONS_CELL):
             base.pw.parameters['CELL']['cell_dofree'] = 'all'
 
         builder.base = base

--- a/tests/workflows/protocols/pw/test_relax.py
+++ b/tests/workflows/protocols/pw/test_relax.py
@@ -78,10 +78,11 @@ def test_relax_type(fixture_code, generate_structure):
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'relax'
     assert 'CELL' not in builder.base['pw']['parameters'].get_dict()
 
-    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.VOLUME)
-    assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
-    assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'volume'
-    assert builder.base['pw']['settings'].get_dict() == {'FIXED_COORDS': [[True, True, True], [True, True, True]]}
+    with pytest.raises(ValueError):
+        builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.VOLUME)
+        # assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
+        # assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'volume'
+        # assert builder.base['pw']['settings'].get_dict() == {'FIXED_COORDS': [[True, True, True], [True, True, True]]}
 
     builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.SHAPE)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
@@ -93,10 +94,11 @@ def test_relax_type(fixture_code, generate_structure):
     assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'all'
     assert builder.base['pw']['settings'].get_dict() == {'FIXED_COORDS': [[True, True, True], [True, True, True]]}
 
-    builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.POSITIONS_VOLUME)
-    assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
-    assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'volume'
-    assert 'settings' not in builder.base['pw']
+    with pytest.raises(ValueError):
+        builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.POSITIONS_VOLUME)
+        # assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'
+        # assert builder.base['pw']['parameters']['CELL']['cell_dofree'] == 'volume'
+        # assert 'settings' not in builder.base['pw']
 
     builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure, relax_type=RelaxType.POSITIONS_SHAPE)
     assert builder.base['pw']['parameters']['CONTROL']['calculation'] == 'vc-relax'


### PR DESCRIPTION
Quantum ESPRESSO only supports optimizing the volume for simple cubic
systems. Since for now by default we accept any structure and set
`ibrav=0`, we simply do not support the relax types `POSITIONS_VOLUME`
and `VOLUME`. Once Quantum ESPRESSO supports volume optimization for any
symmetry or we add some validation to determine simple cubic structures,
we are simply going to remove support in the `get_builder_from_protocol`.