### PR TITLE
Maintenance: address deprecation warnings

### DIFF
--- a/aiida_quantumespresso/parsers/matdyn.py
+++ b/aiida_quantumespresso/parsers/matdyn.py
@@ -97,7 +97,7 @@ def parse_raw_matdyn_phonon_file(phonon_frequencies):
             # case in which there are two frequencies attached like -1204.1234-1020.536
             if '-' in b:
                 c = re.split('(-)', b)
-                d = [i for i in c if i is not '']
+                d = [i for i in c if i != '']
                 for i in range(0, len(d), 2):  # d should have an even number of elements
                     corrected_data.append(float(d[i] + d[i + 1]))
             else:

--- a/setup.json
+++ b/setup.json
@@ -79,7 +79,7 @@
         "tests": [
             "pgtest~=1.3",
             "pytest~=6.0",
-            "pytest-regressions~=1.0"
+            "pytest-regressions~=2.3"
         ],
         "tcod": [
             "aiida-tcod"

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -18,6 +18,7 @@ def test_setup(generate_workchain_pw):
     assert isinstance(process.ctx.inputs, AttributeDict)
 
 
+@pytest.mark.filterwarnings('ignore::aiida.common.warnings.AiidaDeprecationWarning')
 def test_validate_pseudos(generate_workchain_pw):
     """Test `PwBaseWorkChain.validate_pseudos`."""
     process = generate_workchain_pw()


### PR DESCRIPTION
Note that there is one deprecation warning remaining that comes from the `pytest-regressions` dependency. They have [already addressed it](https://github.com/ESSS/pytest-regressions/commit/ffad2c7fd1d110f420f4e3ca3d39d90cae18a972) but we just need to wait for it to be released. When that happens I will update this PR and then it can be merged.