### PR TITLE
Dependencies: update to `aiida-pseudo==0.6.0`

### DIFF
--- a/aiida_quantumespresso/cli/calculations/cp.py
+++ b/aiida_quantumespresso/cli/calculations/cp.py
@@ -23,11 +23,10 @@ def launch_calculation(code, structure, pseudo_family, max_num_machines, max_wal
     """Run a CpCalculation."""
     from aiida.orm import Dict
     from aiida.plugins import CalculationFactory
-    from qe_tools import CONSTANTS
 
     from aiida_quantumespresso.utils.resources import get_default_options
 
-    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)
+    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure, unit='Ry')
 
     parameters = {
         'CONTROL': {
@@ -40,8 +39,8 @@ def launch_calculation(code, structure, pseudo_family, max_num_machines, max_wal
             'nstep': 10,
         },
         'SYSTEM': {
-            'ecutwfc': cutoff_wfc / CONSTANTS.ry_to_ev,
-            'ecutrho': cutoff_rho / CONSTANTS.ry_to_ev,
+            'ecutwfc': cutoff_wfc,
+            'ecutrho': cutoff_rho,
             'nr1b': 24,
             'nr2b': 24,
             'nr3b': 24,

--- a/aiida_quantumespresso/cli/calculations/neb.py
+++ b/aiida_quantumespresso/cli/calculations/neb.py
@@ -59,19 +59,18 @@ def launch_calculation(
     """
     from aiida.orm import Dict
     from aiida.plugins import CalculationFactory
-    from qe_tools import CONSTANTS
 
     from aiida_quantumespresso.utils.resources import get_default_options
 
-    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structures[0])
+    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structures[0], unit='Ry')
 
     pw_parameters = {
         'CONTROL': {
             'calculation': 'relax',
         },
         'SYSTEM': {
-            'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
-            'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,
+            'ecutwfc': ecutwfc or cutoff_wfc,
+            'ecutrho': ecutrho or cutoff_rho
         }
     }
 

--- a/aiida_quantumespresso/cli/calculations/pw.py
+++ b/aiida_quantumespresso/cli/calculations/pw.py
@@ -58,19 +58,18 @@ def launch_calculation(
     """Run a PwCalculation."""
     from aiida.orm import Dict, KpointsData
     from aiida.plugins import CalculationFactory
-    from qe_tools import CONSTANTS
 
     from aiida_quantumespresso.utils.resources import get_default_options
 
-    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)
+    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure, unit='Ry')
 
     parameters = {
         'CONTROL': {
             'calculation': mode,
         },
         'SYSTEM': {
-            'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
-            'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,
+            'ecutwfc': ecutwfc or cutoff_wfc,
+            'ecutrho': ecutrho or cutoff_rho,
         }
     }
 

--- a/aiida_quantumespresso/cli/workflows/pw/bands.py
+++ b/aiida_quantumespresso/cli/workflows/pw/bands.py
@@ -40,21 +40,20 @@ def launch_workflow(
     # pylint: disable=too-many-statements
     from aiida.orm import Bool, Float, Dict
     from aiida.plugins import WorkflowFactory
-    from qe_tools import CONSTANTS
 
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     builder = WorkflowFactory('quantumespresso.pw.bands').get_builder()
 
-    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)
+    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure, unit='Ry')
 
     parameters = {
         'CONTROL': {
             'calculation': 'relax',
         },
         'SYSTEM': {
-            'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
-            'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,
+            'ecutwfc': ecutwfc or cutoff_wfc,
+            'ecutrho': ecutrho or cutoff_rho,
         },
     }
 

--- a/aiida_quantumespresso/cli/workflows/pw/base.py
+++ b/aiida_quantumespresso/cli/workflows/pw/base.py
@@ -40,18 +40,17 @@ def launch_workflow(
     """Run a `PwBaseWorkChain`."""
     from aiida.orm import Bool, Float, Dict
     from aiida.plugins import WorkflowFactory
-    from qe_tools import CONSTANTS
 
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     builder = WorkflowFactory('quantumespresso.pw.base').get_builder()
 
-    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)
+    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure, unit='Ry')
 
     parameters = {
         'SYSTEM': {
-            'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
-            'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,
+            'ecutwfc': ecutwfc or cutoff_wfc,
+            'ecutrho': ecutrho or cutoff_rho,
         },
     }
 

--- a/aiida_quantumespresso/cli/workflows/pw/relax.py
+++ b/aiida_quantumespresso/cli/workflows/pw/relax.py
@@ -47,21 +47,20 @@ def launch_workflow(
     """Run a `PwRelaxWorkChain`."""
     from aiida.orm import Bool, Float, Dict, Str
     from aiida.plugins import WorkflowFactory
-    from qe_tools import CONSTANTS
 
     from aiida_quantumespresso.utils.resources import get_default_options, get_automatic_parallelization_options
 
     builder = WorkflowFactory('quantumespresso.pw.relax').get_builder()
 
-    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)
+    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure, unit='Ry')
 
     parameters = {
         'CONTROL': {
             'calculation': 'relax',
         },
         'SYSTEM': {
-            'ecutwfc': ecutwfc or cutoff_wfc / CONSTANTS.ry_to_ev,
-            'ecutrho': ecutrho or cutoff_rho / CONSTANTS.ry_to_ev,
+            'ecutwfc': ecutwfc or cutoff_wfc,
+            'ecutrho': ecutrho or cutoff_rho,
         },
     }
 

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -32,7 +32,7 @@ def validate_pseudo_family(value, _):
 class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
     """Workchain to run a Quantum ESPRESSO pw.x calculation with automated error handling and restarts."""
 
-    # pylint: disable=too-many-public-methods
+    # pylint: disable=too-many-public-methods, too-many-statements
 
     _process_class = PwCalculation
 
@@ -140,7 +140,6 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             guess for the magnetic moment is automatically set in case this argument is not provided.
         :return: a process builder instance with all inputs defined ready for launch.
         """
-        from qe_tools import CONSTANTS
         from aiida_quantumespresso.workflows.protocols.utils import get_starting_magnetization
 
         if isinstance(code, str):
@@ -176,13 +175,13 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
                 'install it.'
             ) from exception
 
-        cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)
+        cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure, unit='Ry')
 
         parameters = inputs['pw']['parameters']
         parameters['CONTROL']['etot_conv_thr'] = natoms * meta_parameters['etot_conv_thr_per_atom']
         parameters['ELECTRONS']['conv_thr'] = natoms * meta_parameters['conv_thr_per_atom']
-        parameters['SYSTEM']['ecutwfc'] = cutoff_wfc / CONSTANTS.ry_to_ev
-        parameters['SYSTEM']['ecutrho'] = cutoff_rho / CONSTANTS.ry_to_ev
+        parameters['SYSTEM']['ecutwfc'] = cutoff_wfc
+        parameters['SYSTEM']['ecutrho'] = cutoff_rho
 
         if electronic_type is ElectronicType.INSULATOR:
             parameters['SYSTEM']['occupations'] = 'fixed'

--- a/setup.json
+++ b/setup.json
@@ -92,7 +92,7 @@
     },
     "install_requires": [
         "aiida_core[atomic_tools]~=1.4,>=1.4.4",
-        "aiida-pseudo~=0.5.0",
+        "aiida-pseudo~=0.6.0",
         "jsonschema",
         "packaging",
         "qe-tools~=2.0rc1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,6 @@ def serialize_builder():
 @pytest.fixture(scope='session', autouse=True)
 def sssp(aiida_profile, generate_upf_data):
     """Create an SSSP pseudo potential family from scratch."""
-    from qe_tools import CONSTANTS
     from aiida.common.constants import elements
     from aiida.plugins import GroupFactory
 
@@ -119,7 +118,8 @@ def sssp(aiida_profile, generate_upf_data):
 
     SsspFamily = GroupFactory('pseudo.family.sssp')
 
-    cutoffs = {'standard': {}}
+    cutoffs = {}
+    stringency = 'standard'
 
     with tempfile.TemporaryDirectory() as dirpath:
         for values in elements.values():
@@ -133,15 +133,15 @@ def sssp(aiida_profile, generate_upf_data):
                     handle.write(source.read())
                     handle.flush()
 
-            cutoffs['standard'][element] = {
-                'cutoff_wfc': 30. * CONSTANTS.ry_to_ev,
-                'cutoff_rho': 240. * CONSTANTS.ry_to_ev
+            cutoffs[element] = {
+                'cutoff_wfc': 30.0,
+                'cutoff_rho': 240.0,
             }
 
         label = 'SSSP/1.1/PBE/efficiency'
         family = SsspFamily.create_from_folder(dirpath, label)
 
-    family.set_cutoffs(cutoffs)
+    family.set_cutoffs(cutoffs, stringency, unit='Ry')
 
     return family
 


### PR DESCRIPTION
Fixes #670 

This new minor version introduces two important changes:

*  Add support for units for the recommended cutoffs. This means that we
can now request the recommended cutoffs in a specified unit. We add
support for this feature here.
* Changes the `set_cutoffs` method of the `RecommendedCutoffMixin` class
so it can set the recommended cutoffs for a single stringency instead
all at the same time. This only has influence on the `sssp` fixture for
the tests in `conftest.py`.