### PR TITLE
CI: use `postgres-12` since update to Ubuntu Focal 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         -   name: Install system dependencies
             run: |
                 sudo apt update
-                sudo apt install postgresql-10
+                sudo apt install postgresql-12
 
         -   name: Install python dependencies
             run: |

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -50,7 +50,7 @@ jobs:
         -   name: Install system dependencies
             run: |
                 sudo apt update
-                sudo apt install postgresql-10
+                sudo apt install postgresql-12
 
         -   name: Install python dependencies
             continue-on-error: true


### PR DESCRIPTION
The CI configuration uses `ubuntu-latest` which recently became Ubuntu
Focal Fossa (20.04) which no longer has `postgres-10` available, but
instead provides `postgres-12`.