### PR TITLE
`BasePwCpInputGenerator`: Improve parameters input validation

### DIFF
--- a/aiida_quantumespresso/calculations/__init__.py
+++ b/aiida_quantumespresso/calculations/__init__.py
@@ -115,7 +115,8 @@ class BasePwCpInputGenerator(CalcJob):
         spec.input('structure', valid_type=orm.StructureData,
             help='The input structure.')
         spec.input('parameters', valid_type=orm.Dict,
-            help='The input parameters that are to be used to construct the input file.')
+            help='The input parameters that are to be used to construct the input file.',
+            validator=cls.validate_parameters)
         spec.input('settings', valid_type=orm.Dict, required=False,
             help='Optional parameters to affect the way the calculation job and the parsing are performed.')
         spec.input('parent_folder', valid_type=orm.RemoteData, required=False,
@@ -151,6 +152,11 @@ class BasePwCpInputGenerator(CalcJob):
             invalid_values = [val for val in value_dict.values() if not isinstance(val, numbers.Integral)]
             if invalid_values:
                 return f'Parallelization values must be integers; got invalid values {invalid_values}.'
+
+    @staticmethod
+    def validate_parameters(cls, value, _):
+        """Validate the input parameters of the pw.x calculation."""
+        pass
 
     def prepare_for_submission(self, folder):
         """Create the input files from the input nodes passed to this instance of the `CalcJob`.
@@ -442,11 +448,8 @@ class BasePwCpInputGenerator(CalcJob):
             pseudo = pseudos[kind.name]
             if kind.is_alloy or kind.has_vacancies:
                 raise exceptions.InputValidationError(
-                    "Kind '{}' is an alloy or has "
-                    'vacancies. This is not allowed for pw.x input structures.'
-                    ''.format(kind.name)
+                    f'Kind `{kind.name}` is an alloy or has vacancies. This is not allowed for `pw.x` input structures.'
                 )
-
             try:
                 # If it is the same pseudopotential file, use the same filename
                 filename = pseudo_filenames[pseudo.pk]

--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 """`CalcJob` implementation for the pw.x code of Quantum ESPRESSO."""
 import os
+import yaml
+import jsonschema
 
+from pathlib import Path
 from aiida import orm
 from aiida.common.lang import classproperty
 from aiida.plugins import factories
+from ..workflows.protocols.utils import recursive_merge
 
 from aiida_quantumespresso.calculations import BasePwCpInputGenerator
 
@@ -146,6 +150,15 @@ class PwCalculation(BasePwCpInputGenerator):
         spec.exit_code(541, 'ERROR_SYMMETRY_NON_ORTHOGONAL_OPERATION',
             message='The variable cell optimization broke the symmetry of the k-points.')
         # yapf: enable
+
+    @classmethod
+    def validate_parameters(cls, value, _):
+        """Validate the input parameters of the pw.x calculation."""
+
+        with (Path(__file__).resolve().parent / 'schemas' / 'pw' / 'parameters.yaml').open() as handle:
+            parameters_schema = yaml.safe_load(handle)
+
+        jsonschema.validate(value.get_dict(), parameters_schema)
 
     @classproperty
     def filename_input_hubbard_parameters(cls):

--- a/aiida_quantumespresso/calculations/schemas/pw/parameters.yaml
+++ b/aiida_quantumespresso/calculations/schemas/pw/parameters.yaml
@@ -1,0 +1,546 @@
+$schema: http://json-schema.org/draft/2019-09/schema#
+additionalProperties: false
+properties:
+  CELL:
+    additionalProperties: false
+    properties:
+      cell_dofree:
+        enum:
+        - all
+        - ibrav
+        - x
+        - y
+        - z
+        - xy
+        - xz
+        - yz
+        - xyz
+        - shape
+        - volume
+        - 2Dxy
+        - 2Dshape
+        - epitaxial_ab
+        - epitaxial_ac
+        - epitaxial_bc
+        type: string
+      cell_dynamics:
+        enum:
+        - none
+        - sd
+        - damp-pr
+        - damp-w
+        - bfgs
+        - none
+        - pr
+        - w
+        type: string
+      cell_factor:
+        type: number
+      press:
+        type: number
+      press_conv_thr:
+        type: number
+      wmass:
+        type: number
+    type: object
+  CONTROL:
+    additionalProperties: false
+    properties:
+      calculation:
+        enum:
+        - scf
+        - nscf
+        - bands
+        - relax
+        - md
+        - vc-relax
+        - vc-md
+        type: string
+      dipfield:
+        type: boolean
+      disk_io:
+        enum:
+        - high
+        - medium
+        - low
+        - none
+        type: string
+      dt:
+        type: number
+      etot_conv_thr:
+        type: number
+      forc_conv_thr:
+        type: number
+      gate:
+        type: boolean
+      gdir:
+        type: integer
+      iprint:
+        type: integer
+      lberry:
+        type: boolean
+      lelfield:
+        type: boolean
+      lfcpopt:
+        type: boolean
+      lkpoint_dir:
+        type: boolean
+      lorbm:
+        type: boolean
+      max_seconds:
+        type: number
+      nberrycyc:
+        type: integer
+      nppstr:
+        type: integer
+      nstep:
+        type: integer
+      outdir:
+        type: string
+      prefix:
+        type: string
+      pseudo_dir:
+        type: string
+      restart_mode:
+        enum:
+        - from_scratch
+        - restart
+        type: string
+      tefield:
+        type: boolean
+      title:
+        type: string
+      tprnfor:
+        type: boolean
+      tstress:
+        type: boolean
+      verbosity:
+        enum:
+        - high
+        - low
+        type: string
+      wf_collect:
+        type: boolean
+      wfcdir:
+        type: string
+    type: object
+  ELECTRONS:
+    additionalProperties: false
+    properties:
+      adaptive_thr:
+        type: boolean
+      conv_thr:
+        type: number
+      conv_thr_init:
+        type: number
+      conv_thr_multi:
+        type: number
+      diago_cg_maxiter:
+        type: integer
+      diago_david_ndim:
+        type: integer
+      diago_full_acc:
+        type: boolean
+      diago_thr_init:
+        type: number
+      diagonalization:
+        enum:
+        - david
+        - cg
+        - cg-serial
+        - david-serial
+        type: string
+      efield:
+        type: number
+      efield_cart:
+        type: object
+      efield_phase:
+        enum:
+        - read
+        - write
+        - none
+        type: string
+      electron_maxstep:
+        type: integer
+      mixing_beta:
+        type: number
+      mixing_fixed_ns:
+        type: integer
+      mixing_mode:
+        enum:
+        - plain
+        - TF
+        - local-TF
+        type: string
+      mixing_ndim:
+        type: integer
+      ortho_para:
+        type: integer
+      real_space:
+        type: boolean
+      scf_must_converge:
+        type: boolean
+      startingpot:
+        enum:
+        - atomic
+        - file
+        type: string
+      startingwfc:
+        enum:
+        - atomic
+        - atomic+random
+        - random
+        - file
+        type: string
+      tqr:
+        type: boolean
+    type: object
+  IONS:
+    additionalProperties: false
+    properties:
+      bfgs_ndim:
+        type: integer
+      delta_t:
+        type: number
+      ion_dynamics:
+        enum:
+        - bfgs
+        - damp
+        - verlet
+        - langevin
+        - langevin-smc
+        - bfgs
+        - damp
+        - beeman
+        type: string
+      ion_positions:
+        enum:
+        - default
+        - from_input
+        type: string
+      ion_temperature:
+        enum:
+        - rescaling
+        - rescale-v
+        - rescale-T
+        - reduce-T
+        - berendsen
+        - andersen
+        - initial
+        - not_controlled
+        type: string
+      nraise:
+        type: integer
+      pot_extrapolation:
+        enum:
+        - none
+        - atomic
+        - first_order
+        - second_order
+        type: string
+      refold_pos:
+        type: boolean
+      remove_rigid_rot:
+        type: boolean
+      tempw:
+        type: number
+      tolp:
+        type: number
+      trust_radius_ini:
+        type: number
+      trust_radius_max:
+        type: number
+      trust_radius_min:
+        type: number
+      upscale:
+        type: number
+      w_1:
+        type: number
+      w_2:
+        type: number
+      wfc_extrapolation:
+        enum:
+        - none
+        - first_order
+        - second_order
+        type: string
+    type: object
+  SYSTEM:
+    additionalProperties: false
+    properties:
+      A:
+        type: number
+      B:
+        type: number
+      C:
+        type: number
+      Hubbard_J:
+        type: array
+      Hubbard_J0:
+        type: object
+      Hubbard_U:
+        type: object
+      Hubbard_alpha:
+        type: object
+      Hubbard_beta:
+        type: object
+      U_projection_type:
+        enum:
+        - atomic
+        - ortho-atomic
+        - norm-atomic
+        - file
+        - pseudo
+        type: string
+      angle1:
+        type: object
+      angle2:
+        type: object
+      assume_isolated:
+        enum:
+        - none
+        - makov-payne
+        - m-p
+        - mp
+        - martyna-tuckerman
+        - m-t
+        - mt
+        - esm
+        - 2D
+        type: string
+      block:
+        type: boolean
+      block_1:
+        type: number
+      block_2:
+        type: number
+      block_height:
+        type: number
+      celldm:
+        type: object
+      constrained_magnetization:
+        enum:
+        - none
+        - total
+        - atomic
+        - total direction
+        - atomic direction
+        type: string
+      cosAB:
+        type: number
+      cosAC:
+        type: number
+      cosBC:
+        type: number
+      degauss:
+        type: number
+      dftd3_threebody:
+        type: boolean
+      dftd3_version:
+        enum:
+        - dftd3_version = 2
+        - dftd3_version = 3
+        - dftd3_version = 4
+        - dftd3_version = 5
+        - dftd3_version = 6
+        type: integer
+      eamp:
+        type: number
+      ecfixed:
+        type: number
+      ecutfock:
+        type: number
+      ecutrho:
+        type: number
+      ecutvcut:
+        type: number
+      ecutwfc:
+        type: number
+      edir:
+        type: integer
+      emaxpos:
+        type: number
+      eopreg:
+        type: number
+      esm_bc:
+        enum:
+        - pbc
+        - bc1
+        - bc2
+        - bc3
+        type: string
+      esm_efield:
+        type: number
+      esm_nfit:
+        type: integer
+      esm_w:
+        type: number
+      exx_fraction:
+        type: number
+      exxdiv_treatment:
+        enum:
+        - gygi-baldereschi
+        - vcut_spherical
+        - vcut_ws
+        - none
+        type: string
+      fcp_mu:
+        type: number
+      fixed_magnetization:
+        type: object
+      force_symmorphic:
+        type: boolean
+      ibrav:
+        type: integer
+      input_dft:
+        type: string
+      lambda:
+        type: number
+      lda_plus_u:
+        type: boolean
+      lda_plus_u_kind:
+        type: integer
+      lforcet:
+        type: boolean
+      localization_thr:
+        type: number
+      london:
+        type: boolean
+      london_c6:
+        type: object
+      london_rcut:
+        type: number
+      london_rvdw:
+        type: object
+      london_s6:
+        type: number
+      lspinorb:
+        type: boolean
+      nat:
+        type: integer
+      nbnd:
+        type: integer
+      no_t_rev:
+        type: boolean
+      noinv:
+        type: boolean
+      noncolin:
+        type: boolean
+      nosym:
+        type: boolean
+      nosym_evc:
+        type: boolean
+      nqx1:
+        type: integer
+      nqx2:
+        type: integer
+      nqx3:
+        type: integer
+      nr1:
+        type: integer
+      nr1s:
+        type: integer
+      nr2:
+        type: integer
+      nr2s:
+        type: integer
+      nr3:
+        type: integer
+      nr3s:
+        type: integer
+      nspin:
+        type: integer
+      ntyp:
+        type: integer
+      occupations:
+        enum:
+        - smearing
+        - tetrahedra
+        - tetrahedra_lin
+        - tetrahedra_opt
+        - fixed
+        - from_input
+        type: string
+      one_atom_occupations:
+        type: boolean
+      origin_choice:
+        type: integer
+      q2sigma:
+        type: number
+      qcutz:
+        type: number
+      relaxz:
+        type: boolean
+      report:
+        type: integer
+      rhombohedral:
+        type: boolean
+      screening_parameter:
+        type: number
+      smearing:
+        enum:
+        - gaussian
+        - gauss
+        - methfessel-paxton
+        - m-p
+        - mp
+        - marzari-vanderbilt
+        - cold
+        - m-v
+        - mv
+        - fermi-dirac
+        - f-d
+        - fd
+        type: string
+      space_group:
+        type: integer
+      starting_charge:
+        type: object
+      starting_magnetization:
+        type: object
+      starting_ns_eigenvalue:
+        type: array
+      starting_spin_angle:
+        type: boolean
+      tot_charge:
+        type: number
+      tot_magnetization:
+        type: number
+      ts_vdw_econv_thr:
+        type: number
+      ts_vdw_isolated:
+        type: boolean
+      uniqueb:
+        type: boolean
+      use_all_frac:
+        type: boolean
+      vdw_corr:
+        enum:
+        - grimme-d2
+        - Grimme-D2
+        - DFT-D
+        - dft-d
+        - grimme-d3
+        - Grimme-D3
+        - DFT-D3
+        - dft-d3
+        - TS
+        - ts
+        - ts-vdw
+        - ts-vdW
+        - tkatchenko-scheffler
+        - XDM
+        - xdm
+        type: string
+      x_gamma_extrapolation:
+        type: boolean
+      xdm:
+        type: boolean
+      xdm_a1:
+        type: number
+      xdm_a2:
+        type: number
+      zgate:
+        type: number
+    type: object
+type: object

--- a/aiida_quantumespresso/calculations/schemas/utils.py
+++ b/aiida_quantumespresso/calculations/schemas/utils.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Utilities for providing JSON schemas for the validation of calculation inputs."""
+
+import itertools
+
+def convert_to_json_schema(input_xml, schema_version=None):
+    """Convert a Quantum ESPRESSO input XML file into a JSON schema."""
+    
+    def _convert_type(qe_type):
+        """Convert a QE type in the input XML file to a JSON schema type."""
+        type_mapping = {
+            'CHARACTER': 'string',
+            'LOGICAL': 'boolean',
+            'INTEGER': 'integer',
+            'REAL': 'number',
+        }
+        return type_mapping[qe_type.upper()]
+
+    schema_version = schema_version or 'http://json-schema.org/draft/2019-09/schema#'
+    
+    json_schema = {
+        '$schema': schema_version,
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {}
+    }
+    
+    for namelist in input_xml.getElementsByTagName('namelist'):
+
+        namelist_dict = {
+            'type': 'object',
+            'additionalProperties': False,
+            'properties': {}
+        }
+        for tagname in ('var', 'dimension', 'multidimension'):
+            
+            for var in namelist.getElementsByTagName(tagname):
+                
+                if tagname == 'dimension':
+                    var_type = 'object'  # These are provided as a dict in the plugin
+                elif tagname == 'multidimension':
+                    var_type = 'array'  # These are provided as a list in the plugin
+                else:
+                    try:
+                        var_type = _convert_type(var.getAttribute('type'))
+                    except KeyError:
+                        continue  # Skip variables without a type -> These are stored in vargoups
+                allowed_values = [
+                    opt.getAttribute('val').split(', ') for opt in var.getElementsByTagName('opt')
+                ]
+                allowed_values = [value.strip('\' ') for value in itertools.chain(*allowed_values)]
+                
+                var_dict = {
+                    'type': var_type,
+                }
+                if len(allowed_values) > 0:
+                    var_dict['enum'] = allowed_values
+                
+                namelist_dict['properties'][var.getAttribute('name')] = var_dict
+
+        for vargroup in namelist.getElementsByTagName('vargroup'):
+            
+            for var in vargroup.getElementsByTagName('var'):
+            
+                var_dict = {
+                    'type': _convert_type(vargroup.getAttribute('type'))
+                }
+                namelist_dict['properties'][var.getAttribute('name')] = var_dict
+            
+        json_schema['properties'][namelist.getAttribute('name')] = namelist_dict
+
+    return json_schema


### PR DESCRIPTION
Fixes #675 

First working example of how we can add validation of the input
parameters of the Quantum ESPRESSO calculation jobs by converting the
INPUT-{}.XML files that are generated for the QE documentation into JSON
schemas that are then used in the validator of the `parameters` input.

The `convert_to_json_schema()` function in the `calculations.schemas.utils.py`
module is used to generate the `calculations.schemas.pw.parameters.yaml`
file, based on the `calculations.helpers.INPUT_PW-6.4.xml` file. This
yaml file is then loaded in the validator for the `parameters` input and
used to check if the parameters adhere to the prescriptions of the JSON
schema.