### PR TITLE
`ProtocolMixin`: increase flexibility and usability for other packages

### DIFF
--- a/aiida_quantumespresso/workflows/pdos.py
+++ b/aiida_quantumespresso/workflows/pdos.py
@@ -308,6 +308,13 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         spec.expose_outputs(ProjwfcCalculation, namespace='projwfc')
 
     @classmethod
+    def get_protocol_filepath(cls):
+        """Return ``pathlib.Path`` to the ``.yaml`` file that defines the protocols."""
+        from importlib_resources import files
+        from . import protocols
+        return files(protocols) / 'pdos.yaml'
+
+    @classmethod
     def get_builder_from_protocol(
         cls, pw_code, dos_code, projwfc_code, structure, protocol=None, overrides=None, **kwargs
     ):
@@ -324,11 +331,10 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         :return: a process builder instance with all inputs defined ready for launch.
         """
 
-        args = (pw_code, structure, protocol)
 
         inputs = cls.get_protocol_inputs(protocol, overrides)
-        builder = cls.get_builder()
 
+        args = (pw_code, structure, protocol)
         scf = PwBaseWorkChain.get_builder_from_protocol(*args, overrides=inputs.get('scf', None), **kwargs)
         scf['pw'].pop('structure', None)
         scf.pop('clean_workdir', None)
@@ -338,6 +344,7 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         nscf['pw']['parameters']['SYSTEM'].pop('degauss', None)
         nscf.pop('clean_workdir', None)
 
+        builder = cls.get_builder()
         builder.structure = structure
         builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
         builder.scf = scf

--- a/aiida_quantumespresso/workflows/pw/bands.py
+++ b/aiida_quantumespresso/workflows/pw/bands.py
@@ -113,6 +113,13 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
         # yapf: enable
 
     @classmethod
+    def get_protocol_filepath(cls):
+        """Return ``pathlib.Path`` to the ``.yaml`` file that defines the protocols."""
+        from importlib_resources import files
+        from ..protocols import pw as pw_protocols
+        return files(pw_protocols) / 'bands.yaml'
+
+    @classmethod
     def get_builder_from_protocol(cls, code, structure, protocol=None, overrides=None, **kwargs):
         """Return a builder prepopulated with inputs selected according to the chosen protocol.
 
@@ -124,10 +131,9 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
             sub processes that are called by this workchain.
         :return: a process builder instance with all inputs defined ready for launch.
         """
-        args = (code, structure, protocol)
         inputs = cls.get_protocol_inputs(protocol, overrides)
-        builder = cls.get_builder()
 
+        args = (code, structure, protocol)
         relax = PwRelaxWorkChain.get_builder_from_protocol(*args, overrides=inputs.get('relax', None), **kwargs)
         scf = PwBaseWorkChain.get_builder_from_protocol(*args, overrides=inputs.get('scf', None), **kwargs)
         bands = PwBaseWorkChain.get_builder_from_protocol(*args, overrides=inputs.get('bands', None), **kwargs)
@@ -142,6 +148,7 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
         bands.pop('kpoints_distance', None)
         bands.pop('kpoints_force_parity', None)
 
+        builder = cls.get_builder()
         builder.structure = structure
         builder.relax = relax
         builder.scf = scf

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -118,6 +118,13 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         # yapf: enable
 
     @classmethod
+    def get_protocol_filepath(cls):
+        """Return ``pathlib.Path`` to the ``.yaml`` file that defines the protocols."""
+        from importlib_resources import files
+        from ..protocols import pw as pw_protocols
+        return files(pw_protocols) / 'base.yaml'
+
+    @classmethod
     def get_builder_from_protocol(
         cls,
         code,
@@ -160,7 +167,6 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         if initial_magnetic_moments is not None and spin_type is not SpinType.COLLINEAR:
             raise ValueError(f'`initial_magnetic_moments` is specified but spin type `{spin_type}` is incompatible.')
 
-        builder = cls.get_builder()
         inputs = cls.get_protocol_inputs(protocol, overrides)
 
         meta_parameters = inputs.pop('meta_parameters')
@@ -202,6 +208,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             parameters['SYSTEM']['starting_magnetization'] = starting_magnetization
 
         # pylint: disable=no-member
+        builder = cls.get_builder()
         builder.pw['code'] = code
         builder.pw['pseudos'] = pseudo_family.get_pseudos(structure=structure)
         builder.pw['structure'] = structure

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -96,6 +96,13 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         # yapf: enable
 
     @classmethod
+    def get_protocol_filepath(cls):
+        """Return ``pathlib.Path`` to the ``.yaml`` file that defines the protocols."""
+        from importlib_resources import files
+        from ..protocols import pw as pw_protocols
+        return files(pw_protocols) / 'relax.yaml'
+
+    @classmethod
     def get_builder_from_protocol(
         cls, code, structure, protocol=None, overrides=None, relax_type=RelaxType.POSITIONS_CELL, **kwargs
     ):
@@ -112,10 +119,9 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         """
         type_check(relax_type, RelaxType)
 
-        args = (code, structure, protocol)
         inputs = cls.get_protocol_inputs(protocol, overrides)
-        builder = cls.get_builder()
 
+        args = (code, structure, protocol)
         base = PwBaseWorkChain.get_builder_from_protocol(*args, overrides=inputs.get('base', None), **kwargs)
         base_final_scf = PwBaseWorkChain.get_builder_from_protocol(
             *args, overrides=inputs.get('base_final_scf', None), **kwargs
@@ -153,6 +159,7 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         if relax_type in (RelaxType.CELL, RelaxType.POSITIONS_CELL):
             base.pw.parameters['CELL']['cell_dofree'] = 'all'
 
+        builder = cls.get_builder()
         builder.base = base
         builder.base_final_scf = base_final_scf
         builder.structure = structure

--- a/setup.json
+++ b/setup.json
@@ -97,7 +97,8 @@
         "packaging",
         "qe-tools~=2.0rc1",
         "xmlschema~=1.2,>=1.2.5",
-        "numpy"
+        "numpy",
+        "importlib_resources"
     ],
     "license": "MIT License",
     "name": "aiida_quantumespresso",


### PR DESCRIPTION
Fixes #677 

The load_protocol_file method in the protocol utils.py
module uses the path of the module file to obtain the path to the .yaml
file that described the protocols. However, this fails in case the
`ProtocolMixin` class is used by other packages, since the protocol files
of the package's work chains will be stored in that package.

Moreover, the user can only adapt the protocol by specifying
`overrides` as a dictionary, or adapting the builder afterwards.

Here we adapt the `ProtocolMixin` class as follows:

* Add a `get_protocol_filepath()` class method that needs to be
implemented by the work chain classes that use the `ProtocolMixin`.
* Move the `load_protocol_file` method into the `ProtocolMixin` class as
a hidden method that relies on the `get_protocol_filepath` method.
* The `get_protocol_inputs` method is made more flexible by accepting
a `pathlib.Path` for the `overrides` input. This allows the user to
define protocol overrides in a `.yaml` file.

The `Path` to the hardcoded protocols that ship with the package are now
also obtained using `importlib_resources`.