### PR TITLE
`PwBaseWorkChain`: fix bug in `validate_resources` validator

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -591,15 +591,19 @@ def generate_inputs_cp(fixture_code, generate_structure, generate_upf_data):
 def generate_workchain_pw(generate_workchain, generate_inputs_pw, generate_calc_job_node):
     """Generate an instance of a `PwBaseWorkChain`."""
 
-    def _generate_workchain_pw(exit_code=None, inputs=None):
+    def _generate_workchain_pw(exit_code=None, inputs=None, return_inputs=False):
         from plumpy import ProcessState
         from aiida.orm import Dict
 
         entry_point = 'quantumespresso.pw.base'
+
         if inputs is None:
             pw_inputs = generate_inputs_pw()
             kpoints = pw_inputs.pop('kpoints')
             inputs = {'pw': pw_inputs, 'kpoints': kpoints}
+
+        if return_inputs:
+            return inputs
 
         process = generate_workchain(entry_point, inputs)
 
@@ -614,6 +618,36 @@ def generate_workchain_pw(generate_workchain, generate_inputs_pw, generate_calc_
         return process
 
     return _generate_workchain_pw
+
+
+@pytest.fixture
+def generate_workchain_ph(generate_workchain, generate_inputs_ph, generate_calc_job_node):
+    """Generate an instance of a `PhBaseWorkChain`."""
+
+    def _generate_workchain_ph(exit_code=None, inputs=None, return_inputs=False):
+        from plumpy import ProcessState
+
+        entry_point = 'quantumespresso.ph.base'
+
+        if inputs is None:
+            inputs = {'ph': generate_inputs_ph()}
+
+        if return_inputs:
+            return inputs
+
+        process = generate_workchain(entry_point, inputs)
+
+        if exit_code is not None:
+            node = generate_calc_job_node()
+            node.set_process_state(ProcessState.FINISHED)
+            node.set_exit_status(exit_code.status)
+
+            process.ctx.iteration = 1
+            process.ctx.children = [node]
+
+        return process
+
+    return _generate_workchain_ph
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #682 

The `validate_resources` outline step would check that the
`metadata.options` namespace included at least the input
`resources.num_machines` and `max_wallclock_seconds` as long as the
automatic parallelization feature was not enabled. This was added when
the workchain was first developed, because the scheduler resources were
not validated on the base `CalcJob` in `aiida-core`.

However, since `aiida-core==1.0.0` the scheduler resources are validated
on the `CalcJob` base class. This means that a `PwBaseWorkChain` will
now not even be instantiated if the resources for the `PwCalculation`
are insufficient, so it is better to leave the validation up to the base
class.

What is worse, the logic in `validate_resources` is actually incorrect
as it assumed that the resources always need to include `num_machines`.
However, this is not the case as it is actually `Scheduler`
implementation specific, and for example for the `SgeScheduler` this
field is even prohibited and will raise when specified. This made that
the `PwBaseWorkChain` was fundamentally incompatible with those
schedulers before this fix.

The `PhBaseWorkChain` suffered from the same bug and has also been
fixed.