### PR TITLE
Protocols: Add support for `CutoffsPseudoPotentialFamily`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -92,7 +92,7 @@
     },
     "install_requires": [
         "aiida_core[atomic_tools]~=1.4,>=1.4.4",
-        "aiida-pseudo~=0.6,>=0.6.1",
+        "aiida-pseudo~=0.6.1",
         "jsonschema",
         "packaging",
         "qe-tools~=2.0rc1",

--- a/setup.json
+++ b/setup.json
@@ -92,7 +92,7 @@
     },
     "install_requires": [
         "aiida_core[atomic_tools]~=1.4,>=1.4.4",
-        "aiida-pseudo~=0.6.0",
+        "aiida-pseudo~=0.6,>=0.6.1",
         "jsonschema",
         "packaging",
         "qe-tools~=2.0rc1",


### PR DESCRIPTION
Fixes #684 

In the `aiida-pseudo` release v1.6.1, a generic pseudo family class was added
which has the features of the `RecommendedCutoffsMixin` class. This
allows the user to install pseudo families other than the supported SSSP
and pseudo-dojo configurations and set recommended cutoffs for specified
stringencies.

Here we add support for the `CutoffsPseudoPotentialFamily` class to the
`get_builder_from_protocol` method of the `PwBaseWorkChain`. Since these
pseudo families aren't configured with recommended cutoffs by default,
we catch any ValueErrors raised by the `get_recommended_cutoffs` method
and add reraise them with a message that clearly indicates that
the failure is related to obtaining the recommended cutoffs.