### PR TITLE
Fix/ph parser symmetry labels

### DIFF
--- a/aiida_quantumespresso/workflows/ph/base.py
+++ b/aiida_quantumespresso/workflows/ph/base.py
@@ -126,7 +126,7 @@ class PhBaseWorkChain(BaseRestartWorkChain):
         :param max_wallclock_seconds: the maximum wallclock time that will be set in the scheduler settings.
         """
         max_seconds_factor = self.defaults.delta_factor_max_seconds
-        max_seconds = min(max_wallclock_seconds - 60, max_wallclock_seconds * max_seconds_factor)
+        max_seconds = max_wallclock_seconds * max_seconds_factor
         self.ctx.inputs.parameters['INPUTPH']['max_seconds'] = max_seconds
 
     def prepare_process(self):


### PR DESCRIPTION
Adding symmetry label parsing from the std out of a ph.x run. The symmetry labels are printed after the mode frequencies for each computed q-point. 

A dictionary for each q-point (determined by the q-points listed in the header of the std out) has been added to the parsed 'output_parameters' as well as a key-value pair containing the number of q-points found and parsed in the std out, 'num_q_found'. As  PhCalculation can run out of wall time (thus not completing all the q-points) or be a restart (thus missing the data from the q-points calculated in a previous run), the dictionaries for each q_point is created with the key "q_point_i" containing the coordinated of the q_point from the header of std out. If the results of this q-point are in this std out they are parsed and added to 'q_point_i". 

For a PhBaseRestartWorkChain, which can call multiple iterations of PhCalculation, the results of the parsed q_points_i need to be merged. This is done by calcfunction added to PhBaseRestartWorkChain and is called after a check that all the instances of PhCalculation have the same number of q-points to calculate and that this is the number of q_points found and parsed across all the called instances of PhCalculation (i.e. the sum of num_q_found for all called  PhCalculation == number_of_qpoints". The merged results are output as "merged_output_parameters". As the data output to DYN_MAT is cumulative upon multiple restarts of a PhCalculation, the final merge is done by taking the output of the last called PhCalculation and adding in the q_points_i dictionaries from the other called instances of PhCalculation. The values for 'num_q_found', 'number_of_irr_representations_for_each_q', 'wall_time', 'wall_time_seconds' also need to be merged (the rest of the data can be simply copied from the last instance of PhCalculation). 

Possible extensions:
- 'number_of_irr_representations_for_each_q' could be added for each q-point to the respective q_point_i dict
- Add the parsed q_point_i data with the dynamical_matrix_i data. This should be done in the calcfunction  
- The 'merged_output_parameters' could replace the current 'output_parameters' which are just forwarded from the last call of PhCalculation by PhBaseRestartWorkChain

Issues with current implentation  - No error 'proper' handling. 