### PR TITLE
`PwBandStructureWorkChain`: Deprecate and fix

### DIFF
--- a/aiida_quantumespresso/utils/pseudopotential.py
+++ b/aiida_quantumespresso/utils/pseudopotential.py
@@ -29,6 +29,9 @@ def validate_and_prepare_pseudos_inputs(structure, pseudos=None, pseudo_family=N
     :raises: ValueError if neither pseudos or pseudo_family is specified or if no UpfData is found for
         every element in the structure
     :returns: a dictionary of UpfData nodes where the key is the kind name
+
+    .. deprecated:: 4.0.0
+        This functionality is now implemented in ``aiida-pseudo``.
     """
     from aiida.orm import Str
 
@@ -60,6 +63,9 @@ def get_pseudos_of_calc(calc):
 
     :param calc: a pw.x or cp.x calculation.
     :return: a dictionary where the key is the kind name and the value is the UpfData object.
+
+    .. deprecated:: 4.0.0
+        This functionality is now implemented in ``aiida-pseudo``.
     """
     from aiida.common.links import LinkType
 
@@ -95,6 +101,9 @@ def get_pseudos_from_dict(structure, pseudos_uuids):
     :param pseudos_uuids: a dictionary of UUIDs of UpfData for each chemical element, as specified above
     :raise MultipleObjectsError: if more than one UPF for the same element is found in the group.
     :raise NotExistent: if no UPF for an element in the group is found in the group.
+
+    .. deprecated:: 4.0.0
+        This functionality is now implemented in ``aiida-pseudo``.
     """
     from aiida.common import NotExistent
     from aiida.orm import load_node
@@ -116,7 +125,7 @@ def get_pseudos_from_dict(structure, pseudos_uuids):
                 'No node found associated to the UUID {} given for element {} '
                 'in the provided pseudos_uuids dictionary'.format(uuid, symbol)
             ) from exception
-        if not isinstance(upf, UpfData):
+        if not isinstance(upf, (LegacyUpfData, UpfData)):
             raise ValueError(f'Node with UUID {uuid} is not a UpfData')
         if upf.element != symbol:
             raise ValueError(f'Node<{uuid}> is associated to element {upf.element} and not to {symbol} as expected')

--- a/aiida_quantumespresso/workflows/pw/band_structure.py
+++ b/aiida_quantumespresso/workflows/pw/band_structure.py
@@ -25,7 +25,19 @@ def validate_protocol(protocol_dict, ctx=None):  # pylint: disable=unused-argume
 
 
 class PwBandStructureWorkChain(WorkChain):
-    """Workchain to automatically compute a band structure for a given structure using Quantum ESPRESSO pw.x."""
+    """Workchain to automatically compute a band structure for a given structure using Quantum ESPRESSO pw.x.
+
+    .. deprecated:: 4.0.0
+        This work chain has been replaced by the ``PwBandsWorkchain``.
+    """
+
+    import warnings
+    from aiida.common.warnings import AiidaDeprecationWarning
+
+    warnings.warn(
+        'The `PwBandStructureWorkChain` has been deprecated in favor of the `PwBandsWorkChain` and will be '
+        'removed in `v4.0.0`', AiidaDeprecationWarning
+    )
 
     @classmethod
     def define(cls, spec):

--- a/aiida_quantumespresso/workflows/pw/relax.py
+++ b/aiida_quantumespresso/workflows/pw/relax.py
@@ -280,7 +280,7 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
             structure = workchain.outputs.output_structure
         except exceptions.NotExistent:
             # If the calculation is set to 'scf', this is expected, so we are done
-            if self.inputs.base.pw.parameters['CONTROL']['calculation'] == 'scf':
+            if self.ctx.relax_inputs.pw.parameters['CONTROL']['calculation'] == 'scf':
                 self.ctx.is_converged = True
                 return
 
@@ -359,7 +359,7 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         # Get the latest relax workchain and pass the outputs
         final_relax_workchain = self.ctx.workchains[-1]
 
-        if self.inputs.base.pw.parameters['CONTROL']['calculation'] != 'scf':
+        if self.ctx.relax_inputs.pw.parameters['CONTROL']['calculation'] != 'scf':
             self.out('output_structure', final_relax_workchain.outputs.output_structure)
 
         try:


### PR DESCRIPTION
Fixes #687 

The `PwBandStructureWorkChain` is a legacy version of a band structure work
chain with a pre-defined protocol, mostly used for previous tutorials.
However, now that the `PwBandsWorkChain` has been equipped with a protocol
through the `get_builder_from_protocol()` method, it no longer serves a
purpose and should be deprecated.

However, there were still two issues with running the work chain that
needed to be fixed, since users were still running it and it is still
supported until v4.0.0:

* The `get_pseudos_from_dict()` method, used by the work chain, only
accepted `UpfData` from the `aiida-pseudo` package. Since the work chain
was often run with legacy `UpfData`, this raised errors for several
users. This is fixed by also accepting the legacy `UpfData` here.
* There was a small bug in the `PwRelaxWorkChain` when using the
`relaxation_scheme` input (which is also deprecated). Basically, at some
point in the work chain, the `base` input port was checked for the
`pw.parameters.CONTROL.calculation` value, but in case the user doesn't
specify this input (which passes validation when the `relaxation_scheme`
is provided), this would raise a `KeyError` when running the work chain.
This is fixed by obtaining the `calculation` value from the context
instead.