### PR TITLE
Fixtures: fix bug in the `generate_upf_data` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 # pylint: disable=redefined-outer-name,too-many-statements
 """Initialise a text database and profile for pytest."""
 import collections
+import io
 import os
 import shutil
 import tempfile
@@ -281,18 +282,15 @@ def generate_calc_job_node(fixture_localhost):
 
 
 @pytest.fixture(scope='session')
-def generate_upf_data(tmp_path_factory):
+def generate_upf_data():
     """Return a `UpfData` instance for the given element a file for which should exist in `tests/fixtures/pseudos`."""
 
     def _generate_upf_data(element):
         """Return `UpfData` node."""
         from aiida_pseudo.data.pseudo import UpfData
-
-        with open(tmp_path_factory.mktemp('pseudos') / f'{element}.upf', 'w+b') as handle:
-            content = f'<UPF version="2.0.1"><PP_HEADER\nelement="{element}"\nz_valence="4.0"\n/></UPF>\n'
-            handle.write(content.encode('utf-8'))
-            handle.flush()
-            return UpfData(file=handle)
+        content = f'<UPF version="2.0.1"><PP_HEADER\nelement="{element}"\nz_valence="4.0"\n/></UPF>\n'
+        stream = io.BytesIO(content.encode('utf-8'))
+        return UpfData(stream, filename=f'{element}.upf')
 
     return _generate_upf_data
 


### PR DESCRIPTION
The fixture is constructing a `UpfData` by writing the content of a
pseudo in UPF format to a temporary file but then passing the stream to
the constructor. However, the stream was just written to and so the
pointer will be at the stream which will cause the constructor of the
node to read an empty string of bytes.

Since we are using a stream in memory, we don't actually need a file on
disk at all, so the temporary file is replaced by a simple `io.BytesIO`
stream which solves the problem.