### PR TITLE
Read PHONON version number from stdout

### DIFF
--- a/aiida_quantumespresso/parsers/parse_raw/ph.py
+++ b/aiida_quantumespresso/parsers/parse_raw/ph.py
@@ -195,7 +195,10 @@ def parse_ph_text_output(lines, logs):
 
         detect_important_message(logs, line)
 
-        if 'q-points for this run' in line:
+        if 'PHONON' in line and 'starts on' in line:
+            parsed_data['code_version'] = line.split('PHONON')[1].split('starts on')[0].strip()
+
+        elif 'q-points for this run' in line:
             try:
                 num_qpoints = int(line.split('/')[1].split('q-points')[0])
                 if (


### PR DESCRIPTION
PR #633 is critical. To merge PR #633, @sphuber suggested to check version number, but PHONON parameter output doesn't contain the version information.

This PR is made to read the version of PHONON. The code is taken from `parse_output_base` method. Here I follow `parse_output_base`'s naming of the key `'code_version'`, but this may be inconsistent with `'creator_version'` in PW, though I don't know what exactly means 'creator'.