### PR TITLE
Fix psycopg2 dependency problem (temporary)

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -93,6 +93,7 @@
         ]
     },
     "install_requires": [
+        "psycopg2-binary<2.9",
         "aiida_core[atomic_tools]~=1.4,>=1.4.4",
         "aiida-pseudo~=0.6.1",
         "jsonschema",


### PR DESCRIPTION
A recent patch release of `psycopg2 v2.8` has broken (at least) the continuous
integration tests suite. This was fixed in `aiida-core v1.6.x` but not (yet?)
backported to previous versions that are currently supported by this plugin.
This pin can be removed once a higher version of `aiida-core` is supported
or once `psycopg2` has released a fix for these problems.