### PR TITLE
Tests: fix immigrate tests after change in `aiida-core`

### DIFF
--- a/tests/tools/test_immigrate.py
+++ b/tests/tools/test_immigrate.py
@@ -35,6 +35,9 @@ def test_create_builder(fixture_sandbox, fixture_code, generate_upf_data, genera
 
     builder = create_builder_from_file(in_folderpath, 'test_pw_default.in', code, metadata, upf_folderpath)
 
+    # In certain versions of `aiida-core` the builder comes with the `stash` namespace by default.
+    builder['metadata']['options'].pop('stash', None)
+
     assert builder['code'] == code
     assert builder['metadata'] == metadata
     pseudo_hash = si_upf.get_hash()
@@ -86,6 +89,9 @@ def test_create_builder_nonzero_ibrav(fixture_sandbox, fixture_code, generate_up
     si_upf.store()
 
     builder = create_builder_from_file(in_folderpath, 'test_pw_ibrav.in', code, metadata, upf_folderpath)
+
+    # In certain versions of `aiida-core` the builder comes with the `stash` namespace by default.
+    builder['metadata']['options'].pop('stash', None)
 
     assert builder['code'] == code
     assert builder['metadata'] == metadata


### PR DESCRIPTION
The nightly build started failing because a recent change in
`aiida-core`. The `CalcJob` now has a new namespace in the metadata
options called `stash`. This means that the options of any process builder
will now include this namespace even if nothing is specified.

This change was causing the immigrate tests to fail since the inputs
options do not have this namespace and so the comparison was failing.