### PR TITLE
`Protocols`: Add settings from `overrides`

### DIFF
--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -217,6 +217,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         builder.pw['structure'] = structure
         builder.pw['parameters'] = orm.Dict(dict=parameters)
         builder.pw['metadata'] = inputs['pw']['metadata']
+        builder.pw['settings'] = orm.Dict(dict=inputs['pw']['settings'])
         if 'parallelization' in inputs['pw']:
             builder.pw['parallelization'] = orm.Dict(dict=inputs['pw']['parallelization'])
         builder.clean_workdir = orm.Bool(inputs['clean_workdir'])

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -217,7 +217,8 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         builder.pw['structure'] = structure
         builder.pw['parameters'] = orm.Dict(dict=parameters)
         builder.pw['metadata'] = inputs['pw']['metadata']
-        builder.pw['settings'] = orm.Dict(dict=inputs['pw']['settings'])
+        if 'settings' in inputs['pw']:
+            builder.pw['settings'] = orm.Dict(dict=inputs['pw']['settings'])
         if 'parallelization' in inputs['pw']:
             builder.pw['parallelization'] = orm.Dict(dict=inputs['pw']['parallelization'])
         builder.clean_workdir = orm.Bool(inputs['clean_workdir'])


### PR DESCRIPTION
Any settings passed to the `overrides` argument of the
`get_builder_from_protocol()` method are currently not passed to the
builder that is returned by the method. Here we fix this issue by adding
them from the inputs that are merged from the protocol inputs and the
overrides.