### PR TITLE
`PdosWorkChain`: Fix initialization and protocol usage of `ElectronicType`

### DIFF
--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -160,17 +160,14 @@ class PwCalculation(BasePwCpInputGenerator):
         """Validate the top level namespace.
 
         1. Check that the restart input parameters are set correctly. In case of 'nscf' and 'bands' calculations, this
-        means that ``parent_folder`` is provided, ``startingpot`` is set to 'file' and ``restart_mode`` is
-        'from_scratch'. For other calculations, if the ``parent_folder`` is provided, the restart settings must be set
-        to use some of the outputs.
+        means that ``startingpot`` is set to 'file' and ``restart_mode`` is 'from_scratch'. For other calculations, if
+        the ``parent_folder`` is provided, the restart settings must be set to use some of the outputs.
         """
         parameters = value['parameters'].get_dict()
         calculation_type = parameters.get('CONTROL', {}).get('calculation', 'scf')
 
         # Check that the restart input parameters are set correctly
         if calculation_type in ('nscf', 'bands'):
-            if 'parent_folder' not in value:
-                return f'`parent_folder` not provided for `{calculation_type}` calculation.'
             if parameters.get('ELECTRONS', {}).get('startingpot', 'file') != 'file':
                 return f'`startingpot` should be set to `file` for a `{calculation_type}` calculation.'
             if parameters.get('CONTROL', {}).get('restart_mode', 'from_scratch') != 'from_scratch':

--- a/aiida_quantumespresso/workflows/pdos.py
+++ b/aiida_quantumespresso/workflows/pdos.py
@@ -340,6 +340,7 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         scf.pop('clean_workdir', None)
         nscf = PwBaseWorkChain.get_builder_from_protocol(*args, overrides=inputs.get('nscf', None), **kwargs)
         nscf['pw'].pop('structure', None)
+        nscf['pw']['parameters']['SYSTEM']['occupations'] = 'tetrahedra'
         nscf['pw']['parameters']['SYSTEM'].pop('smearing', None)
         nscf['pw']['parameters']['SYSTEM'].pop('degauss', None)
         nscf.pop('clean_workdir', None)

--- a/tests/calculations/test_pw.py
+++ b/tests/calculations/test_pw.py
@@ -299,11 +299,6 @@ def test_pw_validate_inputs_restart_nscf(
     parameters = inputs['parameters'].get_dict()
     parameters['CONTROL']['calculation'] = calculation
 
-    # No parent_folder -> raise
-    inputs['parameters'] = orm.Dict(dict=parameters)
-    with pytest.raises(ValueError, match='`parent_folder` not provided for `.*` calculation.'):
-        generate_calc_job(fixture_sandbox, entry_point_name, inputs)
-
     # Parent_folder + defaults -> works
     inputs['parent_folder'] = remote_data
     generate_calc_job(fixture_sandbox, entry_point_name, inputs)

--- a/tests/workflows/protocols/test_pdos.py
+++ b/tests/workflows/protocols/test_pdos.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""Tests for the ``PwBandsWorkChain.get_builder_from_protocol`` method."""
+import pytest
+
+from aiida.engine import ProcessBuilder
+from aiida.plugins import WorkflowFactory
+
+from aiida_quantumespresso.common.types import ElectronicType, SpinType
+
+PdosWorkChain = WorkflowFactory('quantumespresso.pdos')
+
+
+def test_get_available_protocols():
+    """Test ``PdosWorkChain.get_available_protocols``."""
+    protocols = PdosWorkChain.get_available_protocols()
+    assert sorted(protocols.keys()) == ['fast', 'moderate', 'precise']
+    all('description' in protocol for protocol in protocols)
+
+
+def test_get_default_protocol():
+    """Test ``PdosWorkChain.get_default_protocol``."""
+    assert PdosWorkChain.get_default_protocol() == 'moderate'
+
+
+def test_default(fixture_code, generate_structure, data_regression, serialize_builder):
+    """Test ``PdosWorkChain.get_builder_from_protocol`` for the default protocol."""
+    pw_code = fixture_code('quantumespresso.pw')
+    dos_code = fixture_code('quantumespresso.dos')
+    projwfc_code = fixture_code('quantumespresso.projwfc')
+    structure = generate_structure()
+    builder = PdosWorkChain.get_builder_from_protocol(
+        pw_code=pw_code, dos_code=dos_code, projwfc_code=projwfc_code, structure=structure
+    )
+
+    assert isinstance(builder, ProcessBuilder)
+    data_regression.check(serialize_builder(builder))
+
+
+def test_electronic_type(fixture_code, generate_structure):
+    """Test ``PdosWorkChain.get_builder_from_protocol`` with ``electronic_type`` keyword."""
+    pw_code = fixture_code('quantumespresso.pw')
+    dos_code = fixture_code('quantumespresso.dos')
+    projwfc_code = fixture_code('quantumespresso.projwfc')
+    structure = generate_structure()
+
+    with pytest.raises(NotImplementedError):
+        builder = PdosWorkChain.get_builder_from_protocol(
+            pw_code=pw_code,
+            dos_code=dos_code,
+            projwfc_code=projwfc_code,
+            structure=structure,
+            electronic_type=ElectronicType.AUTOMATIC
+        )
+
+    builder = PdosWorkChain.get_builder_from_protocol(
+        pw_code=pw_code,
+        dos_code=dos_code,
+        projwfc_code=projwfc_code,
+        structure=structure,
+        electronic_type=ElectronicType.INSULATOR
+    )
+    for namespace, occupations in zip((builder.scf, builder.nscf), ('fixed', 'tetrahedra')):
+        parameters = namespace['pw']['parameters'].get_dict()
+        assert parameters['SYSTEM']['occupations'] == occupations
+        assert 'degauss' not in parameters['SYSTEM']
+        assert 'smearing' not in parameters['SYSTEM']
+
+
+def test_spin_type(fixture_code, generate_structure):
+    """Test ``PdosWorkChain.get_builder_from_protocol`` with ``spin_type`` keyword."""
+    pw_code = fixture_code('quantumespresso.pw')
+    dos_code = fixture_code('quantumespresso.dos')
+    projwfc_code = fixture_code('quantumespresso.projwfc')
+    structure = generate_structure()
+
+    with pytest.raises(NotImplementedError):
+        for spin_type in [SpinType.NON_COLLINEAR, SpinType.SPIN_ORBIT]:
+            builder = PdosWorkChain.get_builder_from_protocol(
+                pw_code=pw_code, dos_code=dos_code, projwfc_code=projwfc_code, structure=structure, spin_type=spin_type
+            )
+    builder = PdosWorkChain.get_builder_from_protocol(
+        pw_code=pw_code,
+        dos_code=dos_code,
+        projwfc_code=projwfc_code,
+        structure=structure,
+        spin_type=SpinType.COLLINEAR
+    )
+    for namespace in [builder.scf, builder.nscf]:
+        parameters = namespace['pw']['parameters'].get_dict()
+        assert parameters['SYSTEM']['nspin'] == 2
+        assert parameters['SYSTEM']['starting_magnetization'] == {'Si': 0.1}

--- a/tests/workflows/protocols/test_pdos/test_default.yml
+++ b/tests/workflows/protocols/test_pdos/test_default.yml
@@ -1,0 +1,86 @@
+clean_workdir: true
+dos:
+  code: test.quantumespresso.dos@localhost-test
+  metadata:
+    options:
+      max_wallclock_seconds: 43200
+      resources:
+        num_machines: 1
+      withmpi: true
+  parameters:
+    DOS:
+      DeltaE: 0.02
+nscf:
+  kpoints_distance: 0.1
+  kpoints_force_parity: false
+  pw:
+    code: test.quantumespresso.pw@localhost-test
+    metadata:
+      options:
+        max_wallclock_seconds: 43200
+        resources:
+          num_machines: 1
+        withmpi: true
+    parameters:
+      CONTROL:
+        calculation: nscf
+        etot_conv_thr: 2.0e-05
+        forc_conv_thr: 0.0001
+        restart_mode: from_scratch
+        tprnfor: true
+        tstress: true
+      ELECTRONS:
+        conv_thr: 4.0e-10
+        electron_maxstep: 80
+        mixing_beta: 0.4
+      SYSTEM:
+        ecutrho: 240.0
+        ecutwfc: 30.0
+        nosym: true
+        occupations: tetrahedra
+    pseudos:
+      Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
+projwfc:
+  code: test.quantumespresso.projwfc@localhost-test
+  metadata:
+    options:
+      max_wallclock_seconds: 43200
+      resources:
+        num_machines: 1
+      withmpi: true
+  parameters:
+    PROJWFC:
+      DeltaE: 0.02
+scf:
+  kpoints_distance: 0.15
+  kpoints_force_parity: false
+  pw:
+    code: test.quantumespresso.pw@localhost-test
+    metadata:
+      options:
+        max_wallclock_seconds: 43200
+        resources:
+          num_machines: 1
+        withmpi: true
+    parameters:
+      CONTROL:
+        calculation: scf
+        etot_conv_thr: 2.0e-05
+        forc_conv_thr: 0.0001
+        restart_mode: from_scratch
+        tprnfor: true
+        tstress: true
+      ELECTRONS:
+        conv_thr: 4.0e-10
+        electron_maxstep: 80
+        mixing_beta: 0.4
+      SYSTEM:
+        degauss: 0.01
+        ecutrho: 240.0
+        ecutwfc: 30.0
+        nosym: false
+        occupations: smearing
+        smearing: cold
+    pseudos:
+      Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
+structure: Si2


### PR DESCRIPTION
Fixes #740 
Fixes #685

Fixes two issues when using the `PdosWorkChain`:

1. Remove the validation of the `parent_folder` input for `nscf`
`PwCalculation`s. This made it impossible to use the `PdosWorkChain`
with an initial `scf` run, since the `parent_folder` is only created
inside the logic of the work chain, and hence cannot be provided as an
input upon submission.
2. In the `PdosWorkChain.get_builder_from_protocol()` method, override
the `occupations` setting to make sure it is set to `tetrahedra`.
Although this setting is also passed to the overrides from the `yaml`
file that defines the protocol, if the user sets
`ElectronicType.INSULATOR`, the occupations is set to `fixed` in the
`PwBaseWorkChain.get_builder_from_protocol()` method.