### PR TITLE
`PwBaseWorkChain`: handle diagonalization issues

### DIFF
--- a/aiida_quantumespresso/calculations/pw.py
+++ b/aiida_quantumespresso/calculations/pw.py
@@ -122,6 +122,8 @@ class PwCalculation(BasePwCpInputGenerator):
             message='The code failed with negative dexx in the exchange calculation.')
         spec.exit_code(462, 'ERROR_COMPUTING_CHOLESKY',
             message='The code failed during the cholesky factorization.')
+        spec.exit_code(463, 'ERROR_DIAGONALIZATION_TOO_MANY_BANDS_NOT_CONVERGED',
+            message='Too many bands failed to converge during the diagonalization.')
 
         spec.exit_code(481, 'ERROR_NPOOLS_TOO_HIGH',
             message='The k-point parallelization "npools" is too high, some nodes have no k-points.')

--- a/aiida_quantumespresso/parsers/parse_raw/pw.py
+++ b/aiida_quantumespresso/parsers/parse_raw/pw.py
@@ -246,6 +246,7 @@ def detect_important_message(logs, line):
             'problems computing cholesky': 'ERROR_COMPUTING_CHOLESKY',
             'dexx is negative': 'ERROR_DEXX_IS_NEGATIVE',
             'some nodes have no k-points': 'ERROR_NPOOLS_TOO_HIGH',
+            'too many bands are not converged': 'ERROR_DIAGONALIZATION_TOO_MANY_BANDS_NOT_CONVERGED',
         },
         'warning': {
             'Warning:': None,

--- a/aiida_quantumespresso/parsers/pw.py
+++ b/aiida_quantumespresso/parsers/pw.py
@@ -140,6 +140,7 @@ class PwParser(Parser):
             'ERROR_DEXX_IS_NEGATIVE',
             'ERROR_COMPUTING_CHOLESKY',
             'ERROR_NPOOLS_TOO_HIGH',
+            'ERROR_DIAGONALIZATION_TOO_MANY_BANDS_NOT_CONVERGED',
         ]:
             if error_label in logs['error']:
                 return self.exit_codes.get(error_label)

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -529,7 +529,6 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         density. In case the run already used conjugate gradient diagonalization, abort.
         """
         if self.ctx.inputs.parameters['ELECTRONS'].get('diagonalization', None) == 'cg':
-            print('ELLO')
             action = 'found diagonalization issues but already running with conjugate gradient algorithm, aborting...'
             self.report_error_handled(calculation, action)
             return ProcessHandlerReport(True, self.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE)
@@ -537,7 +536,6 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         self.ctx.inputs.parameters['ELECTRONS']['diagonalization'] = 'cg'
         action = 'found diagonalization issues, switching to conjugate gradient diagonalization.'
         self.report_error_handled(calculation, action)
-        print('WAVE')
         return ProcessHandlerReport(True)
 
     @process_handler(priority=580, exit_codes=[

--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -529,6 +529,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         density. In case the run already used conjugate gradient diagonalization, abort.
         """
         if self.ctx.inputs.parameters['ELECTRONS'].get('diagonalization', None) == 'cg':
+            print('ELLO')
             action = 'found diagonalization issues but already running with conjugate gradient algorithm, aborting...'
             self.report_error_handled(calculation, action)
             return ProcessHandlerReport(True, self.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE)
@@ -536,6 +537,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         self.ctx.inputs.parameters['ELECTRONS']['diagonalization'] = 'cg'
         action = 'found diagonalization issues, switching to conjugate gradient diagonalization.'
         self.report_error_handled(calculation, action)
+        print('WAVE')
         return ProcessHandlerReport(True)
 
     @process_handler(priority=580, exit_codes=[

--- a/tests/parsers/fixtures/pw/failed_too_many_bands_not_converged/aiida.out
+++ b/tests/parsers/fixtures/pw/failed_too_many_bands_not_converged/aiida.out
@@ -1,0 +1,25 @@
+
+     Program PWSCF v.6.8 starts on 22Sep2021 at 20:34:38 
+
+     This program is part of the open-source Quantum ESPRESSO suite
+     for quantum simulation of materials; please cite
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 21 395502 (2009);
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 29 465901 (2017);
+         "P. Giannozzi et al., J. Chem. Phys. 152 154105 (2020);
+          URL http://www.quantum-espresso.org", 
+     in publications or presentations arising from this work. More details at
+     http://www.quantum-espresso.org/quote
+
+
+# NOTE: lines of output removed.
+
+     Davidson diagonalization with overlap
+
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     Error in routine c_bands (1):
+     too many bands are not converged
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+     stopping ...
+
+# NOTE: lines of output removed.

--- a/tests/parsers/test_pw.py
+++ b/tests/parsers/test_pw.py
@@ -258,6 +258,28 @@ def test_pw_failed_computing_cholesky(fixture_localhost, generate_calc_job_node,
     assert calcfunction.exit_status == node.process_class.exit_codes.ERROR_COMPUTING_CHOLESKY.status
 
 
+def test_failed_too_many_bands_not_converged(
+    fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs
+):
+    """Test the parsing of a calculation that failed during cholesky factorization.
+
+    In this test the stdout is incomplete, and the XML is missing completely. The stdout contains
+    the relevant error message.
+    """
+    name = 'failed_too_many_bands_not_converged'
+    entry_point_calc_job = 'quantumespresso.pw'
+    entry_point_parser = 'quantumespresso.pw'
+
+    node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, generate_inputs())
+    parser = generate_parser(entry_point_parser)
+    _, calcfunction = parser.parse_from_node(node, store_provenance=False)
+
+    assert calcfunction.is_finished, calcfunction.exception
+    assert calcfunction.is_failed, calcfunction.exit_status
+    desired_exit_status = node.process_class.exit_codes.ERROR_DIAGONALIZATION_TOO_MANY_BANDS_NOT_CONVERGED.status
+    assert calcfunction.exit_status == desired_exit_status
+
+
 def test_pw_failed_dexx_negative(fixture_localhost, generate_calc_job_node, generate_parser, generate_inputs):
     """Test the parsing of a calculation that failed due to negative dexx.
 

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -97,15 +97,41 @@ def test_handle_electronic_convergence_not_achieved(generate_workchain_pw, fixtu
     assert result.status == 0
 
 
-def test_handle_known_unrecoverable_failure(generate_workchain_pw):
-    """Test `PwBaseWorkChain.handle_known_unrecoverable_failure`."""
-    process = generate_workchain_pw(exit_code=PwCalculation.exit_codes.ERROR_COMPUTING_CHOLESKY)
+# This test should be reactivated once we have another known unrecoverable failure that is handled here
+# def test_handle_known_unrecoverable_failure(generate_workchain_pw):
+#     """Test `PwBaseWorkChain.handle_known_unrecoverable_failure`."""
+#     process = generate_workchain_pw(exit_code=PwCalculation.exit_codes.<INSERT EXIT CODE HERE>)
+#     process.setup()
+
+#     result = process.handle_known_unrecoverable_failure(process.ctx.children[-1])
+#     assert isinstance(result, ProcessHandlerReport)
+#     assert result.do_break
+#     assert result.exit_code == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
+
+#     result = process.inspect_process()
+#     assert result == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
+
+
+@pytest.mark.parametrize(
+    'exit_code', (
+        PwCalculation.exit_codes.ERROR_COMPUTING_CHOLESKY,
+        PwCalculation.exit_codes.ERROR_DIAGONALIZATION_TOO_MANY_BANDS_NOT_CONVERGED,
+    )
+)
+def test_handle_diagonalization_errors(generate_workchain_pw, exit_code):
+    """Test `PwBaseWorkChain.handle_diagonalization_errors`."""
+    process = generate_workchain_pw(exit_code=exit_code)
     process.setup()
 
-    result = process.handle_known_unrecoverable_failure(process.ctx.children[-1])
+    process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] = 'david'
+
+    result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'cg'
     assert result.do_break
-    assert result.exit_code == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
+
+    result = process.handle_diagonalization_errors(process.ctx.children[-1])
+    assert result.do_break
 
     result = process.inspect_process()
     assert result == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -97,19 +97,19 @@ def test_handle_electronic_convergence_not_achieved(generate_workchain_pw, fixtu
     assert result.status == 0
 
 
-# This test should be reactivated once we have another known unrecoverable failure that is handled here
-# def test_handle_known_unrecoverable_failure(generate_workchain_pw):
-#     """Test `PwBaseWorkChain.handle_known_unrecoverable_failure`."""
-#     process = generate_workchain_pw(exit_code=PwCalculation.exit_codes.<INSERT EXIT CODE HERE>)
-#     process.setup()
+@pytest.mark.skip('Reactivate once we have an unrecoverable failure once again.')
+def test_handle_known_unrecoverable_failure(generate_workchain_pw):
+    """Test `PwBaseWorkChain.handle_known_unrecoverable_failure`."""
+    process = generate_workchain_pw()
+    process.setup()
 
-#     result = process.handle_known_unrecoverable_failure(process.ctx.children[-1])
-#     assert isinstance(result, ProcessHandlerReport)
-#     assert result.do_break
-#     assert result.exit_code == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
+    result = process.handle_known_unrecoverable_failure(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert result.exit_code == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
 
-#     result = process.inspect_process()
-#     assert result == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
+    result = process.inspect_process()
+    assert result == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #742 

Add parsing for an error related to the diagonalization, and add a
corresponding exit code to the `PwCalculation`.

Add an error handler to deal with both this exit code as well as the
`ERROR_COMPUTING_CHOLESKY` exit code. In both cases, switching to using
conjugate gradient for the diagonalization seems to be a quite
successful approach for recovering from these failures. If the
calculation was already running conjugate gradient, the
`PwBaseWorkChain` fails with a known unrecoverable failure.