### PR TITLE
`parse_output_error`: fix parser for QE stdout errors

### DIFF
--- a/aiida_quantumespresso/parsers/parse_raw/base.py
+++ b/aiida_quantumespresso/parsers/parse_raw/base.py
@@ -74,29 +74,36 @@ def parse_output_error(lines, line_number_start, logs, message_map=None):
             if marker in line:
                 if message is None:
                     message = line
-                logs.error.append(message)
+                if message not in logs.error:
+                    logs.error.append(message)
 
         for marker, message in message_map['warning'].items():
             if marker in line:
                 if message is None:
                     message = line
-                logs.warning.append(message)
+                if message not in logs.warning:
+                    logs.warning.append(message)
 
     # First determine the line that closes the error block which is also marked by ``%%%%%%%`` in the line
-    for line_number, line in enumerate(lines[line_number_start + 1:]):
+    # Skip the starting line '%%%%%%%%%%%%'
+    line_number_start += 1
+    for line_number, line in enumerate(lines[line_number_start:]):
         if '%%%%%%%%%%%%' in line:
-            line_number_end = line_number
+            line_number_end = line_number_start + line_number
             break
     else:
         return
 
     # Get the set of unique lines between the error indicators and pass them through the message map, or if not provided
     # simply append the message to the `error` list of the logs container
-    for message in set(lines[line_number_start:line_number_end]):
+    for message in lines[line_number_start:line_number_end]:
+        if message.strip() == '':
+            continue
         if message_map is not None:
             map_message(message, message_map, logs)
         else:
-            logs.error(message)
+            if message not in logs.error:
+                logs.error.append(message)
 
     return
 

--- a/tests/parsers/fixtures/parse_raw/base/aiida.out
+++ b/tests/parsers/fixtures/parse_raw/base/aiida.out
@@ -1,0 +1,130 @@
+
+     Program OPEN_GRID v.6.8 starts on  7Oct2021 at  1:52:44 
+
+     This program is part of the open-source Quantum ESPRESSO suite
+     for quantum simulation of materials; please cite
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 21 395502 (2009);
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 29 465901 (2017);
+         "P. Giannozzi et al., J. Chem. Phys. 152 154105 (2020);
+          URL http://www.quantum-espresso.org", 
+     in publications or presentations arising from this work. More details at
+     http://www.quantum-espresso.org/quote
+
+     Parallel version (MPI & OpenMP), running on       8 processor cores
+     Number of MPI processes:                 8
+     Threads/MPI process:                     1
+
+     MPI processes distributed on     1 nodes
+     R & G space division:  proc/nbgrp/npool/nimage =       8
+     248208 MiB available memory on the printing compute node when the environment starts
+ 
+ 
+  Reading nscf_save data
+
+     Reading xml data from directory:
+
+     ./out/aiida.save/
+
+     IMPORTANT: XC functional enforced from input :
+     Exchange-correlation= PBE
+                           (   1   4   3   4   0   0   0)
+     Any further DFT definition will be discarded
+     Please, verify this is what you really want
+
+ 
+     Parallelization info
+     --------------------
+     sticks:   dense  smooth     PW     G-vecs:    dense   smooth      PW
+     Min         205     171     54                 5940     4534     829
+     Max         207     172     55                 5942     4536     831
+     Sum        1647    1373    439                47529    36275    6645
+ 
+     Using Slab Decomposition
+ 
+     Reading collected, re-writing distributed wavefunctions
+ 
+     EXX: q-point mesh:     8    8    8
+     EXX: setup a grid of 512 q-points centered on each k-point
+     (set verbosity='high' to see the list)
+
+     EXX grid:    36275 G-vectors     FFT dimensions: (  48,  48,  45)
+
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     Error in routine scale_sym_ops (12):
+     incompatible FFT grid
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+     stopping ...
+
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     Error in routine scale_sym_ops (12):
+     incompatible FFT grid
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+     stopping ...
+
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     Error in routine scale_sym_ops (12):
+     incompatible FFT grid
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+     stopping ...
+
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     Error in routine scale_sym_ops (12):
+     incompatible FFT grid
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+     stopping ...
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+     Message from routine scale_sym_ops:
+     found rotation not compatible with FFT grid
+
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     Error in routine scale_sym_ops (12):
+     incompatible FFT grid
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+     stopping ...
+
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     Error in routine scale_sym_ops (12):
+     incompatible FFT grid
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+     stopping ...
+
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     Error in routine scale_sym_ops (12):
+     incompatible FFT grid
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+     stopping ...
+
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     Error in routine scale_sym_ops (12):
+     incompatible FFT grid
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+     stopping ...

--- a/tests/parsers/parse_raw/test_base.py
+++ b/tests/parsers/parse_raw/test_base.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""Tests for the `parse_output_base`."""
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture
+def generate_output(filepath_tests):
+    """Return the absolute filepath to the directory containing the file `aiida.out`."""
+    fixtures_path = Path(filepath_tests) / 'parsers' / 'fixtures'
+    out_file = fixtures_path / 'parse_raw' / 'base' / 'aiida.out'
+
+    with open(out_file) as fout:
+        filecontent = fout.read()
+
+    return filecontent
+
+
+def test_parse_output_base_default(generate_output, data_regression):
+    """Test ``parse_output_base`` on the stdout of a ``open_grid.x`` calculation."""
+    from aiida_quantumespresso.parsers.parse_raw.base import parse_output_base
+
+    filecontent = generate_output
+    parsed_data, logs = parse_output_base(filecontent, codename='OPEN_GRID')
+
+    data_regression.check({'parsed_data': dict(parsed_data), 'logs': dict(logs)})

--- a/tests/parsers/parse_raw/test_base/test_parse_output_base_default.yml
+++ b/tests/parsers/parse_raw/test_base/test_parse_output_base_default.yml
@@ -1,0 +1,14 @@
+logs:
+  critical: []
+  debug: []
+  error:
+  - ERROR_OUTPUT_STDOUT_INCOMPLETE
+  - '     Error in routine scale_sym_ops (12):'
+  - '     incompatible FFT grid'
+  - '     stopping ...'
+  - '     Message from routine scale_sym_ops:'
+  - '     found rotation not compatible with FFT grid'
+  info: []
+  warning: []
+parsed_data:
+  code_version: v.6.8


### PR DESCRIPTION
The previous code returned a wrong `line_number_end`, thus all the QE
stdout errors were discarded. Moreover, the code converted lines into a
`set` to remove repetitions, but this led to random ordering of error
messages in the final `logs.error` list, causing difficulties in pytest
data_regression. Now the repeated messages are explicitly discarded so
the error message ordering in QE stdout is still preserved. Finally, a
test is added to ensure errors are correctly recorded in `logs.error`.

Fix #750