### PR TITLE
PwBaseWorkChain: handle too high npools

### DIFF
--- a/aiida_quantumespresso/workflows/pw/base.py
+++ b/aiida_quantumespresso/workflows/pw/base.py
@@ -117,6 +117,8 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         spec.exit_code(710, 'WARNING_ELECTRONIC_CONVERGENCE_NOT_REACHED',
             message='The electronic minimization cycle did not reach self-consistency, but `scf_must_converge` '
                     'is `False` and/or `electron_maxstep` is 0.')
+        spec.exit_code(720, 'WARNING_NPOOLS_TOO_HIGH',
+            message='The npools set too high but the calculation still finished.')
         # yapf: enable
 
     @classmethod
@@ -663,3 +665,14 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         self.report_error_handled(calculation, action)
         self.results()  # Call the results method to attach the output nodes
         return ProcessHandlerReport(True, self.exit_codes.WARNING_ELECTRONIC_CONVERGENCE_NOT_REACHED)
+
+    @process_handler(priority=320, exit_codes=[
+        PwCalculation.exit_codes.ERROR_NPOOLS_TOO_HIGH,
+    ])
+    def handle_npools_too_high(self, calculation):
+        """Handle `ERROR_NPOOLS_TOO_HIGH': consider finished."""
+        self.ctx.is_finished = True
+        action = 'npools set too high for the calculation but the calculation still finished: consider finished.'
+        self.report_error_handled(calculation, action)
+        self.results()  # Call the results method to attach the output nodes
+        return ProcessHandlerReport(True, self.exit_codes.WARNING_NPOOLS_TOO_HIGH)

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -204,6 +204,18 @@ def test_handle_electronic_convergence_warning(generate_workchain_pw, generate_s
     assert result == PwBaseWorkChain.exit_codes.WARNING_ELECTRONIC_CONVERGENCE_NOT_REACHED
 
 
+def test_handle_npools_too_high(generate_workchain_pw):
+    """Test `PwBaseWorkChain.handle_handle_npools_too_high`."""
+    process = generate_workchain_pw(exit_code=PwCalculation.exit_codes.ERROR_NPOOLS_TOO_HIGH)
+    process.setup()
+
+    calculation = process.ctx.children[-1]
+    result = process.handle_npools_too_high(calculation)
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert result.exit_code == PwBaseWorkChain.exit_codes.WARNING_NPOOLS_TOO_HIGH
+
+
 def test_sanity_check_no_bands(generate_workchain_pw):
     """Test that `sanity_check_insufficient_bands` does not except if there is no `output_band`, which is optional."""
     process = generate_workchain_pw(exit_code=ExitCode(0))


### PR DESCRIPTION
hi @mbercx , as I mentioned I add a handler for npool too high error. 
The implement is, I simply finish the PwBaseWorkChain and tag exit status to higher than 700 to indicate the 'warnings'. 