### PR TITLE
Devops: fix the CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,8 @@ name: cd
 
 on:
     push:
+        branches:
+        -   'master'
         tags:
         -   'v[0-9]+.[0-9]+.[0-9]+*'
 
@@ -14,7 +16,7 @@ jobs:
 
         steps:
         -   name: Checkout source
-        -   uses: actions/checkout@v2
+            uses: actions/checkout@v2
 
         -   name: Set up Python 3.8
             uses: actions/setup-python@v2
@@ -22,7 +24,7 @@ jobs:
                 python-version: '3.8'
 
         -   name: Validate the tag version against the package version
-        -   run: python .github/workflows/validate_release_tag.py $GITHUB_REF
+            run: python .github/workflows/validate_release_tag.py $GITHUB_REF
 
     pre-commit:
 
@@ -95,7 +97,6 @@ jobs:
         -   name: Run pytest
             run: pytest -sv tests
 
-
     publish:
 
         name: Publish to PyPI
@@ -116,7 +117,6 @@ jobs:
 
         -   name: Build and publish
             run: flit publish
-
             env:
                 FLIT_USERNAME: __token__
                 FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}


### PR DESCRIPTION
Certain steps accidentally had a `-` in front of the `name` as well as
the `uses` key. This made it such that they were interpreted as two
separate steps and so the first one would lack the required `uses`
attribute.

In addition, the workflow should only run on the `master` branch in case
the tagged commit also occurs on other branches, to prevent running the
workflow more than once.