### PR TITLE
Devops: fix the nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly Build
+name: nightly
 
 on:
     schedule:
@@ -9,22 +9,15 @@ jobs:
     tests:
 
         if: github.repository == 'aiidateam/aiida-quantumespresso'  # Prevent running the builds on forks as well
-
         runs-on: ubuntu-latest
 
         strategy:
             matrix:
-                python-version: [3.7, 3.8, 3.9]
+                python-version: ['3.8', '3.9', '3.10']
 
         services:
             postgres:
-                image: postgres:10
-                env:
-                    POSTGRES_DB: test_${{ matrix.backend }}
-                    POSTGRES_PASSWORD: ''
-                    POSTGRES_HOST_AUTH_METHOD: trust
-                ports:
-                -    5432:5432
+                image: postgres:12
             rabbitmq:
                 image: rabbitmq:latest
                 ports:
@@ -33,8 +26,7 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache python dependencies
-            id: cache-pip
+        -   name: Cache Python dependencies
             uses: actions/cache@v1
             with:
                 path: ~/.cache/pip
@@ -47,25 +39,17 @@ jobs:
             with:
                 python-version: ${{ matrix.python-version }}
 
-        -   name: Install system dependencies
-            run: |
-                sudo apt update
-                sudo apt install postgresql-12
-
-        -   name: Install python dependencies
+        -   name: Install Python dependencies
             continue-on-error: true
             id: install
             run: |
-                pip install --upgrade setuptools
-                pip install git+https://github.com/aiidateam/aiida-core@develop#egg=aiida-core[atomic_tools]
                 pip install -e .[tests]
-                reentry scan
+                pip install git+https://github.com/aiidateam/aiida-core@main#egg=aiida-core[atomic_tools]
 
         -   name: Run pytest
             continue-on-error: true
             id: tests
-            run:
-                pytest -sv tests
+            run: pytest -sv tests
 
         -   name: Slack notification
             if: steps.install.outcome == 'Failure' || steps.tests.outcome == 'Failure'
@@ -76,5 +60,5 @@ jobs:
                 SLACK_USERNAME: aiida-quantumespresso
                 SLACK_CHANNEL: dev-aiida-qe
                 SLACK_COLOR: b60205
-                SLACK_TITLE: "Nightly build against `aiida-core/develop` failed"
-                SLACK_MESSAGE: "The tests fail with the current version of `aiida-core/develop`."
+                SLACK_TITLE: "Nightly build against `aiida-core/main` failed"
+                SLACK_MESSAGE: "The tests fail with the current version of `aiida-core/main`."


### PR DESCRIPTION
The nightly build against the `develop` branch of `aiida-core` was
failing at the installation of the Python dependencies when running
against Python 3.7. The reason is that the current `develop` branch has
dropped support for Python 3.7 and the `pip` is then failing to install
a version of `pymatgen` that matches the dependency requirements. The
solution is simply to not run against Python 3.7 anymore.

In addition, as of `aiida-core==2.0` the `develop` branch has been
renamed to `main` so the workflow is updated to install that branch. As
a result, the workflow file is also renamed from `develop` to `nightly`
as the term `develop` is no longer really applicable.

Furthermore, the workflow is updated to match the exact same setup
procedure as the `ci.yml` workflow which has also recently been updated.