### PR TITLE
'magnetization' not present in CP output in v7.0, CG case added stress parsing in cp 

### DIFF
--- a/src/aiida_quantumespresso/parsers/parse_xml/parse.py
+++ b/src/aiida_quantumespresso/parsers/parse_xml/parse.py
@@ -138,8 +138,8 @@ def parse_xml_post_6_2(xml):
 
     lsda = inputs.get('spin', {}).get('lsda', False)
     spin_orbit_calculation = inputs.get('spin', {}).get('spinorbit', False)
-    non_colinear_calculation = outputs['magnetization']['noncolin']
-    do_magnetization = outputs['magnetization'].get('do_magnetization', False)
+    non_colinear_calculation = outputs.get('magnetization', {}).get('noncolin', False)
+    do_magnetization = outputs.get('magnetization', {}).get('do_magnetization', False)
 
     # Time reversal symmetry of the system
     if non_colinear_calculation and do_magnetization:

--- a/tests/parsers/test_cp/test_cp_default_6_6_autopilot_.yml
+++ b/tests/parsers/test_cp/test_cp_default_6_6_autopilot_.yml
@@ -94,6 +94,8 @@ trajectory:
   - 8
   array|steps:
   - 8
+  array|stresses:
+  - 0
   array|times:
   - 8
   array|velocities:

--- a/tests/parsers/test_cp/test_cp_default_6_6_cgsteps_.yml
+++ b/tests/parsers/test_cp/test_cp_default_6_6_cgsteps_.yml
@@ -94,6 +94,8 @@ trajectory:
   - 3
   array|steps:
   - 3
+  array|stresses:
+  - 0
   array|times:
   - 3
   array|velocities:

--- a/tests/parsers/test_cp/test_cp_default_6_6_verlet_.yml
+++ b/tests/parsers/test_cp/test_cp_default_6_6_verlet_.yml
@@ -115,6 +115,8 @@ trajectory:
   - 3
   array|steps:
   - 3
+  array|stresses:
+  - 0
   array|times:
   - 3
   array|velocities:

--- a/tests/parsers/test_cp/test_cp_default_default_.yml
+++ b/tests/parsers/test_cp/test_cp_default_default_.yml
@@ -222,6 +222,8 @@ trajectory:
   - 10
   array|steps:
   - 10
+  array|stresses:
+  - 0
   array|times:
   - 10
   array|velocities:


### PR DESCRIPTION
at least in cp.x, v7.0, conjugate gradient case, the magnetization key is not present in xml output.
So a default value of False is added in the parser that now does not raise an exception if the cp output is parsed.