### PR TITLE
Dependencies: put upper limit `markupsafe<2.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ Documentation = 'https://aiida-quantumespresso.readthedocs.io'
 docs = [
     'Sphinx',
     'docutils',
+    'markupsafe<2.1',
     'sphinx-copybutton~=0.3.0',
     'sphinx-book-theme~=0.1.0',
     'sphinx-click~=2.7.1'


### PR DESCRIPTION
The latest release `markupsafe==2.1` breaks `jinja<3.0` and that in
turn breaks `sphinx<4.0`. Upgrading to `sphinx~=4.0` brings its own
problems with a whole host of new warnings that cannot be easily fixed
and so instead we are putting an upper limit on `markupsafe`.