### PR TITLE
Dependendies: Update Python requirements

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,7 +60,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.6', '3.7', '3.8', '3.9']
+                python-version: ['3.8', '3.9', '3.10']
 
         services:
             postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.6', '3.7', '3.8', '3.9']
+                python-version: ['3.8', '3.9', '3.10']
 
         services:
             postgres:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,12 @@ classifiers = [
     'Framework :: AiiDA',
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
 ]
 keywords = ['aiida', 'workflows']
-requires-python = '>=3.6'
+requires-python = '>=3.8'
 dependencies = [
     'psycopg2-binary<2.9',
     'aiida_core[atomic_tools]~=1.4,>=1.4.4',


### PR DESCRIPTION
Align requirements with `aiida-core==2.0` which was just released:

* Drop support for Python 3.6 and 3.7
* Add support for Python 3.10