### PR TITLE
Remove the use of deprecated `distutils` package

### DIFF
--- a/aiida_quantumespresso/parsers/cp.py
+++ b/aiida_quantumespresso/parsers/cp.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-from distutils.version import LooseVersion
-
 from aiida.orm import Dict, TrajectoryData
 import numpy
+from packaging.version import Version
 from qe_tools import CONSTANTS
 
 from .base import Parser
@@ -81,7 +80,7 @@ class CpParser(Parser):
             ]
 
             # order of atom in the output trajectory changed somewhere after 6.5
-            if LooseVersion(out_dict['creator_version']) > LooseVersion('6.5'):
+            if Version(out_dict['creator_version']) > Version('6.5'):
                 new_cp_ordering = True
             else:
                 new_cp_ordering = False
@@ -145,7 +144,7 @@ class CpParser(Parser):
                 except IndexError:
                     matrix = numpy.array(numpy.matrix(matrix))
 
-                if LooseVersion(out_dict['creator_version']) > LooseVersion('5.1'):
+                if Version(out_dict['creator_version']) > Version('5.1'):
                     # Between version 5.1 and 5.1.1, someone decided to change
                     # the .evp output format, without any way to know that this
                     # happened... SVN commit 11158.

--- a/aiida_quantumespresso/parsers/parse_xml/parse.py
+++ b/aiida_quantumespresso/parsers/parse_xml/parse.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from distutils.version import StrictVersion
 from urllib.error import URLError
 
 import numpy as np
+from packaging.version import Version
 from qe_tools import CONSTANTS
 from xmlschema import XMLSchema
 
@@ -95,7 +95,7 @@ def parse_xml_post_6_2(xml):
         for err in errors:
             logs.error.append(str(err))
 
-    xml_version = StrictVersion(xml_dictionary['general_info']['xml_format']['@VERSION'])
+    xml_version = Version(xml_dictionary['general_info']['xml_format']['@VERSION'])
     inputs = xml_dictionary.get('input', {})
     outputs = xml_dictionary['output']
 
@@ -285,7 +285,7 @@ def parse_xml_post_6_2(xml):
             degauss = smearing_xml['@degauss']
 
             # Versions below 19.03.04 (Quantum ESPRESSO<=6.4.1) incorrectly print degauss in Ry instead of Hartree
-            if xml_version < StrictVersion('19.03.04'):
+            if xml_version < Version('19.03.04'):
                 degauss *= CONSTANTS.ry_to_ev
             else:
                 degauss *= CONSTANTS.hartree_to_ev


### PR DESCRIPTION
Fixes #807 

With the acceptance of PEP 632, this module was deprecated in Python 3.10
and it will be removed in Python 3.12. The `LooseVersion` and
`StrictVersion` classes are replaced by `packaging.version.Version` as
recommended by the PEP itself, see:

    https://peps.python.org/pep-0632/#migration-advice