### PR TITLE
`PhCalculation`: Fix bug when `only_initialization=True`

### DIFF
--- a/src/aiida_quantumespresso/calculations/ph.py
+++ b/src/aiida_quantumespresso/calculations/ph.py
@@ -298,11 +298,6 @@ class PhCalculation(CalcJob):
             with folder.open(f'{self._PREFIX}.EXIT', 'w') as handle:
                 handle.write('\n')
 
-                remote_copy_list.append((
-                    parent_folder.computer.uuid,
-                    os.path.join(parent_folder.get_remote_path(), self._FOLDER_DYNAMICAL_MATRIX), '.'
-                ))
-
         codeinfo = datastructures.CodeInfo()
         codeinfo.cmdline_params = (list(settings.pop('CMDLINE', [])) + ['-in', self.metadata.options.input_filename])
         codeinfo.stdout_name = self.metadata.options.output_filename

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -511,7 +511,7 @@ def generate_inputs_ph(fixture_sandbox, fixture_localhost, fixture_code, generat
         from aiida_quantumespresso.utils.resources import get_default_options
 
         inputs = {
-            'code': fixture_code('quantumespresso.matdyn'),
+            'code': fixture_code('quantumespresso.ph'),
             'parent_folder': generate_remote_data(fixture_localhost, fixture_sandbox.abspath, 'quantumespresso.pw'),
             'qpoints': generate_kpoints_mesh(2),
             'parameters': Dict({'INPUTPH': {}}),


### PR DESCRIPTION
Fixes #811 

When the `only_initialization` setting is set to `True` the plugin would
add an instruction to the `remote_copy_list` to copy `DYN_MAT` folder
from the `parent_folder`. However, this would fail if the `parent_folder`
was that of a `PwCalculation`, which is one of the main use cases of the
`PhCalculation`.

It is not entirely clear why this was added in the commit that added it
https://github.com/aiidateam/aiida-quantumespresso/commit/dfdca7e1317484afedcf522b5adea17dc3f8533a which was just adding a plugin
for EPW. We assume it was added by mistake and so remove it.