### PR TITLE
`MatDynCalculation`: use validator to check `flfrc` input

### DIFF
--- a/src/aiida_quantumespresso/calculations/q2r.py
+++ b/src/aiida_quantumespresso/calculations/q2r.py
@@ -19,7 +19,7 @@ class Q2rCalculation(NamelistsCalculation):
     _default_namelists = ['INPUT']
     _blocked_keywords = [
         ('INPUT', 'fildyn', PhCalculation._OUTPUT_DYNAMICAL_MATRIX_PREFIX),  # pylint: disable=protected-access
-        ('INPUT', 'flfrc', _FORCE_CONSTANTS_NAME),
+        ('INPUT', 'flfrc', _FORCE_CONSTANTS_NAME),  # Real space force constants
     ]
 
     _internal_retrieve_list = [_FORCE_CONSTANTS_NAME]


### PR DESCRIPTION
Fixes #563 

In the current approach, the `flfrc` input tag is added to the
`_blocked_keywords` class variable on the fly, since it depends on the
filename of the `force_constants` input. However, mutating class
variables can lead to undesirable behaviour. In this case, the
`_blocked_keywords` list would have multiple items for `flfrc`, which
would cause failures later on because the calculation would fail during
the preparation for submission because it looks like the user it trying
to set one of the blocked keywords.

Here we instead use a validator to make sure that the user hasn't
manually specified the `flfrc` input.

The `get_following_text()` is also factored out, since it's cleaner to
simply add these additions in the `generate_input_file` method.