### PR TITLE
DevOps: update nightly to show as failed on error

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,9 @@ name: nightly
 on:
     schedule:
     -   cron: '0 0 * * *'  # Run every day at midnight
+    pull_request:
+        paths:
+        - '.github/workflows/nightly.yml'
 
 jobs:
 
@@ -40,19 +43,17 @@ jobs:
                 python-version: ${{ matrix.python-version }}
 
         -   name: Install Python dependencies
-            continue-on-error: true
             id: install
             run: |
                 pip install -e .[tests]
                 pip install git+https://github.com/aiidateam/aiida-core@main#egg=aiida-core[atomic_tools]
 
         -   name: Run pytest
-            continue-on-error: true
             id: tests
             run: pytest -sv tests
 
         -   name: Slack notification
-            if: steps.install.outcome == 'Failure' || steps.tests.outcome == 'Failure'
+            if: always()
             uses: rtCamp/action-slack-notify@master
             env:
                 SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
In order to let the final step to always run, which is to post to Slack
in case of a failed step, the previous steps enabled `continue-on-error`.
However, this has the undesirable side-effect that the workflow would be
marked as successful.

Instead, we use `if: always()` which will guarantee that the last step
is run while showing the correct exit status.

In addition, we add a condition for the workflow to be run when a pull
request is opened with changes to the workflow itself.