### PR TITLE
DevOps: only run Slack notification if tests failed

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,9 +3,13 @@ name: nightly
 on:
     schedule:
     -   cron: '0 0 * * *'  # Run every day at midnight
+    push:
+        paths:
+        - '.github/workflows/nightly.yml'
     pull_request:
         paths:
         - '.github/workflows/nightly.yml'
+
 
 jobs:
 
@@ -53,7 +57,7 @@ jobs:
             run: pytest -sv tests
 
         -   name: Slack notification
-            if: always()
+            if: always() && (steps.install.outcome == 'Failure' || steps.tests.outcome == 'Failure')
             uses: rtCamp/action-slack-notify@master
             env:
                 SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
The workflow was recently adapted to correct the action being marked as
successful even when the tests failed. This was done by removing the
`continue-on-error` option, which ignores the error. To still have the
Slack option run on error, the `if: always()` condition was added. This
works in the case of an error, but it also made that the step would
always run, even when the tests pass just fine. The solution is to keep
the explicit check on the exit status of the install and tests steps.