### PR TITLE
DevOps: address deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ pre-commit = [
 tests = [
     'pgtest~=1.3',
     'pytest~=6.0',
-    'pytest-regressions~=1.0'
+    'pytest-regressions~=2.3'
 ]
 tcod = [
     'aiida-tcod'
@@ -186,6 +186,7 @@ testpaths = [
     'tests',
 ]
 filterwarnings = [
+    'ignore:Creating AiiDA configuration folder.*:UserWarning',
     'ignore::DeprecationWarning:frozendict:',
     'ignore::DeprecationWarning:pkg_resources:',
     'ignore::DeprecationWarning:sqlalchemy_utils:',

--- a/src/aiida_quantumespresso/parsers/parse_raw/base.py
+++ b/src/aiida_quantumespresso/parsers/parse_raw/base.py
@@ -150,7 +150,7 @@ def convert_qe_to_aiida_structure(output_dict, input_structure=None):
         structure = StructureData(cell=cell_dict['lattice_vectors'])
 
         for kind_name, position in output_dict['atoms']:
-            symbol = re.sub('\d+', '', kind_name)
+            symbol = re.sub(r'\d+', '', kind_name)
             structure.append_atom(position=position, symbols=symbol, name=kind_name)
 
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -689,9 +689,7 @@ def generate_workchain_ph(generate_workchain, generate_inputs_ph, generate_calc_
 
 
 @pytest.fixture
-def generate_workchain_pdos(
-    generate_workchain, generate_inputs_pw, fixture_localhost, fixture_code, generate_remote_data
-):
+def generate_workchain_pdos(generate_workchain, generate_inputs_pw, fixture_code):
     """Generate an instance of a `PdosWorkChain`."""
 
     def _generate_workchain_pdos():
@@ -712,9 +710,6 @@ def generate_workchain_pdos(
         nscf_pw_inputs['parameters']['CONTROL']['calculation'] = 'nscf'
         nscf_pw_inputs['parameters']['SYSTEM']['occupations'] = 'tetrahedra'
         nscf_pw_inputs['parameters']['SYSTEM']['nosym'] = True
-        nscf_pw_inputs['parent_folder'] = generate_remote_data(
-            computer=fixture_localhost, remote_path='/path/to/remote'
-        )
 
         nscf = {'pw': nscf_pw_inputs, 'kpoints': kpoints}
 


### PR DESCRIPTION
Addresses all current deprecation warnings but one. The final remaining
warning comes from the standard library because the `imp` module is
being imported, which is deprecated and will be removed in Python 3.12.

The module is being imported by the `past` library, which in turn is
being imported by the `uncertainties` package that is used by our direct
dependency `pint`. There is an open issue on `uncertainties` for this:

    https://github.com/lebigot/uncertainties/issues/152

however, the package maintainer doesn't seem to be very active.