### PR TITLE
`Q2rCalculation`: Fix copying from `parent_folder`

### DIFF
--- a/src/aiida_quantumespresso/calculations/q2r.py
+++ b/src/aiida_quantumespresso/calculations/q2r.py
@@ -15,6 +15,7 @@ class Q2rCalculation(NamelistsCalculation):
     _FORCE_CONSTANTS_NAME = 'real_space_force_constants.dat'
     _OUTPUT_SUBFOLDER = PhCalculation._FOLDER_DYNAMICAL_MATRIX  # pylint: disable=protected-access
     _INPUT_SUBFOLDER = os.path.join('.', PhCalculation._FOLDER_DYNAMICAL_MATRIX)  # pylint: disable=protected-access
+    _default_parent_output_folder = PhCalculation._FOLDER_DYNAMICAL_MATRIX  # pylint: disable=protected-access
 
     _default_namelists = ['INPUT']
     _blocked_keywords = [

--- a/src/aiida_quantumespresso/parsers/ph.py
+++ b/src/aiida_quantumespresso/parsers/ph.py
@@ -38,8 +38,8 @@ class PhParser(Parser):
 
         # Look for dynamical matrices
         dynmat_files = []
-        dynmat_folder = PhCalculation._FOLDER_DYNAMICAL_MATRIX
-        dynmat_prefix = os.path.split(PhCalculation._OUTPUT_DYNAMICAL_MATRIX_PREFIX)[1]
+        dynmat_folder = PhCalculation._FOLDER_DYNAMICAL_MATRIX  # pylint: disable=protected-access
+        dynmat_prefix = os.path.split(PhCalculation._OUTPUT_DYNAMICAL_MATRIX_PREFIX)[1]  # pylint: disable=protected-access
 
         natural_sort = lambda string: [int(c) if c.isdigit() else c.lower() for c in re.split(r'(\d+)', string)]
         for filename in sorted(retrieved.list_object_names(dynmat_folder), key=natural_sort):

--- a/tests/calculations/test_q2r.py
+++ b/tests/calculations/test_q2r.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Tests for the `Q2rCalculation` class."""
+# pylint: disable=protected-access
+from pathlib import Path
+
+from aiida.common import datastructures
+
+from aiida_quantumespresso.calculations.ph import PhCalculation
+from aiida_quantumespresso.calculations.q2r import Q2rCalculation
+
+
+def test_q2r_default(fixture_sandbox, generate_calc_job, generate_inputs_q2r, file_regression):
+    """Test a default `Q2rCalculation`."""
+    entry_point_name = 'quantumespresso.q2r'
+
+    inputs = generate_inputs_q2r()
+    calc_info = generate_calc_job(fixture_sandbox, entry_point_name, inputs)
+    parent_folder = inputs['parent_folder']
+    remote_copy_folder = Path(parent_folder.get_remote_path()) / PhCalculation._FOLDER_DYNAMICAL_MATRIX
+
+    remote_copy_list = [(parent_folder.computer.uuid, str(remote_copy_folder), PhCalculation._FOLDER_DYNAMICAL_MATRIX)]
+    retrieve_list = [Q2rCalculation._DEFAULT_OUTPUT_FILE] + Q2rCalculation._internal_retrieve_list
+
+    # Check the attributes of the returned `CalcInfo`
+    assert isinstance(calc_info, datastructures.CalcInfo)
+    assert sorted(calc_info.remote_copy_list) == sorted(remote_copy_list)
+    assert sorted(calc_info.retrieve_list) == sorted(retrieve_list)
+
+    with fixture_sandbox.open('aiida.in') as handle:
+        input_written = handle.read()
+
+    # Checks on the files written to the sandbox folder as raw input
+    assert sorted(fixture_sandbox.get_content_list()) == sorted(['aiida.in'])
+    file_regression.check(input_written, encoding='utf-8', extension='.in')

--- a/tests/calculations/test_q2r/test_q2r_default.in
+++ b/tests/calculations/test_q2r/test_q2r_default.in
@@ -1,0 +1,4 @@
+&INPUT
+  fildyn = 'DYN_MAT/dynamical-matrix-'
+  flfrc = 'real_space_force_constants.dat'
+/


### PR DESCRIPTION
Fixes #823 

When providing a `RemoteData` node as a `parent_folder` to the
`Q2rCalculation`, the contents of the `out` folder are now copied to the
`DYN_MAT` folder for the `q2r.x` calculation. This is because for
`RemoteData` input the `_default_parent_output_folder` is used, which is
defined as `out` for the parent `NamelistsCalculation` class, but not
overriden by `Q2rCalculation`.

Here we override the `_default_parent_output_folder` class variable so
the contents of the `DYN_MAT` folder are also copied when a `RemoteData`
input is provided.