### PR TITLE
`PwCalculation/PhCalculation`: add validation for `pseudos` port

### DIFF
--- a/src/aiida_quantumespresso/calculations/pw.py
+++ b/src/aiida_quantumespresso/calculations/pw.py
@@ -181,7 +181,7 @@ class PwCalculation(BasePwCpInputGenerator):
                 )
 
     @classmethod
-    def validate_inputs(cls, value, _):
+    def validate_inputs(cls, value, port_namespace):
         """Validate the top level namespace.
 
         Check that the restart input parameters are set correctly. In case of 'nscf' and 'bands' calculations, this
@@ -196,6 +196,11 @@ class PwCalculation(BasePwCpInputGenerator):
         chain can change the ``validate_input`` validator for ``validate_inputs_base`` thereby allowing the parent
         folder to be defined during the work chains runtime, while still keep the rest of the namespace validation.
         """
+        result = super().validate_inputs(value, port_namespace)
+
+        if result is not None:
+            return result
+
         parameters = value['parameters'].get_dict()
         calculation_type = parameters.get('CONTROL', {}).get('calculation', 'scf')
 
@@ -207,7 +212,7 @@ class PwCalculation(BasePwCpInputGenerator):
                     '`PwCalculation.validate_inputs_base`.'
                 )
 
-        return cls.validate_inputs_base(value, _)
+        return cls.validate_inputs_base(value, port_namespace)
 
     @classproperty
     def filename_input_hubbard_parameters(cls):

--- a/tests/calculations/test_pw.py
+++ b/tests/calculations/test_pw.py
@@ -252,6 +252,28 @@ def test_pw_parallelization_duplicate_cmdline_flag(fixture_sandbox, generate_cal
     assert 'Conflicting' in str(exc.value)
 
 
+def test_pw_validate_pseudos_missing(fixture_sandbox, generate_calc_job, generate_inputs_pw):
+    """Test the validation for the ``pseudos`` port when it is not specified at all."""
+    entry_point_name = 'quantumespresso.pw'
+
+    inputs = generate_inputs_pw()
+    inputs.pop('pseudos', None)
+
+    with pytest.raises(ValueError, match=r'required value was not provided for the `pseudos` namespace\.'):
+        generate_calc_job(fixture_sandbox, entry_point_name, inputs)
+
+
+def test_pw_validate_pseudos_incorrect_kinds(fixture_sandbox, generate_calc_job, generate_inputs_pw, generate_upf_data):
+    """Test the validation for the ``pseudos`` port when the kinds do not match that of the structure."""
+    entry_point_name = 'quantumespresso.pw'
+
+    inputs = generate_inputs_pw()
+    inputs['pseudos'] = {'X': generate_upf_data('X')}
+
+    with pytest.raises(ValueError, match=r'The `pseudos` specified and structure kinds do not match:.*'):
+        generate_calc_job(fixture_sandbox, entry_point_name, inputs)
+
+
 @pytest.mark.parametrize('calculation', ['scf', 'relax', 'vc-relax'])
 def test_pw_validate_inputs_restart_base(
     fixture_sandbox, generate_calc_job, generate_inputs_pw, fixture_localhost, generate_remote_data, calculation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -547,14 +547,13 @@ def generate_inputs_pw(fixture_code, generate_structure, generate_kpoints_mesh, 
                 'electron_maxstep': 60,
             }
         })
+        structure = generate_structure()
         inputs = {
             'code': fixture_code('quantumespresso.pw'),
             'structure': generate_structure(),
             'kpoints': generate_kpoints_mesh(2),
             'parameters': parameters,
-            'pseudos': {
-                'Si': generate_upf_data('Si')
-            },
+            'pseudos': {kind: generate_upf_data(kind) for kind in structure.get_kind_names()},
             'metadata': {
                 'options': get_default_options()
             }


### PR DESCRIPTION
Fixes #838 

The `pseudos` port was not marked as required, making it possible to
submit a calculation without any pseudos, but this would always fail in
the `prepare_for_submission`.

The port is made required and a validator is added to check that the
pseudos provided match the set of kinds of the `structure` input.