### PR TITLE
Dependencies: Add lower requirement `aiida-core>=2.0.4`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
-    'aiida_core[atomic_tools]~=2.0',
+    'aiida_core[atomic_tools]~=2.0,>=2.0.4',
     'aiida-pseudo~=0.7.0',
     'click~=8.0',
     'importlib_resources',


### PR DESCRIPTION
Fixes #840 

The release `aiida-core==2.0` updated the `local_copy_list` syntax to allow specifying folders with the promise to copy them recursively. However, due to a bug, the relative source path was included in the target, essentially duplicating the nesting. This would cause calculations that restarted from a `retrieved` folder, such as the `Q2rCalculation` to fail. The bug was fixed in `aiida-core==2.0.4` so we set that as a lower requirement.