### PR TITLE
`XspectraParser`: Parse parameters from CalcJob inputs

### DIFF
--- a/src/aiida_quantumespresso/parsers/xspectra.py
+++ b/src/aiida_quantumespresso/parsers/xspectra.py
@@ -87,6 +87,19 @@ class XspectraParser(Parser):
         xy_data.set_y(y_arrays, y_names, y_units)
 
         parsed_data, logs = parse_stdout_xspectra(filecontent=out_file, codename='XSpectra')
+
+        # Parse some additional info which the stdout does not reliably report
+        parameters = self.node.inputs.parameters.base.attributes.get('INPUT_XSPECTRA', {})
+
+        xepsilon_defaults = {
+            '1': 0,
+            '2': 0,
+            '3': 1,
+        }
+        raw_xepsilon = [parameters.get(f'xepsilon({n})', xepsilon_defaults[n]) for n in ['1', '2', '3']]
+        parsed_data['xepsilon'] = [float(n) for n in raw_xepsilon]
+        parsed_data['xcoordcrys'] = parameters.get('xcoordcrys', True)
+        parsed_data['xonly_plot'] = parameters.get('xonly_plot', False)
         self.emit_logs(logs)
 
         self.out('spectra', xy_data)
@@ -165,16 +178,6 @@ def parse_stdout_xspectra(filecontent, codename=None, message_map=None):
     # Parse the necessary information for data plotting: core level energy of the
     # absorbing atom and the energy zero of the spectrum (typically the Fermi level)
     for line in lines:
-        if 'xepsilon' in line:
-            eps_vector_string = line.split(':')[-1].strip()
-            eps_vector_list = [float(i) for i in eps_vector_string.split('   ')]
-            parsed_data['epsilon_vector'] = eps_vector_list
-        if 'xonly_plot:' in line:
-            is_only_plot_string = line.split(':')[-1].strip()
-            if is_only_plot_string == 'FALSE':
-                parsed_data['plot_only'] = False
-            elif is_only_plot_string == 'TRUE':
-                parsed_data['plot_only'] = True
         if 'From SCF save directory' in line:
             if '(spin polarized work)' in line:
                 spin = True
@@ -206,7 +209,7 @@ def parse_stdout_xspectra(filecontent, codename=None, message_map=None):
             parsed_data['fermi_energy'] = ef_energy
             parsed_data['fermi_energy_units'] = ef_energy_units
 
-        # parse dynamical RAM estimates
+        # parse per-process dynamical RAM estimates
         if 'Estimated max dynamical RAM per process' in line:
             value = line.split('>')[-1]
             match = re.match(r'\s+([+-]?\d+(\.\d*)?|\.\d+([eE][+-]?\d+)?)\s*(Mb|MB|GB)', value)
@@ -217,7 +220,7 @@ def parse_stdout_xspectra(filecontent, codename=None, message_map=None):
                 except (IndexError, ValueError):
                     pass
 
-        # parse dynamical RAM estimates
+        # parse total dynamical RAM estimates
         if 'Estimated total dynamical RAM' in line:
             value = line.split('>')[-1]
             match = re.match(r'\s+([+-]?\d+(\.\d*)?|\.\d+([eE][+-]?\d+)?)\s*(Mb|MB|GB)', value)
@@ -247,9 +250,8 @@ def parse_stdout_xspectra(filecontent, codename=None, message_map=None):
                 parsed_data['code_version'] = line.split(codestring)[1].split('starts on')[0].strip()
 
             # Parse the walltime
-            # XSpectra does not appear next to the timing data, so we must find either 'xanes' or 'nrixs' instead.
-            if 'xanes' in line or 'nrixs' in line:
-                if 'WALL' in line:
+            # XSpectra does not appear next to the timing data, so we must find 'xanes' instead.
+            if 'xanes' in line and 'WALL' in line:
                     try:
                         time = line.split('CPU')[1].split('WALL')[0].strip()
                         parsed_data['wall_time'] = time

--- a/tests/parsers/test_xspectra.py
+++ b/tests/parsers/test_xspectra.py
@@ -7,7 +7,11 @@ from aiida.common import AttributeDict
 
 def generate_inputs():
     """Return only those inputs that the parser will expect to be there."""
-    return AttributeDict()
+
+    parameters = {'INPUT_XSPECTRA': {}, 'PLOT': {}, 'PSEUDOS': {}, 'CUT_OCC': {}}
+
+    inputs = {'parameters': orm.Dict(parameters)}
+    return AttributeDict(inputs)
 
 
 def test_xspectra_default(fixture_localhost, generate_calc_job_node, generate_parser, data_regression, num_regression):

--- a/tests/parsers/test_xspectra/test_xspectra_default.yml
+++ b/tests/parsers/test_xspectra/test_xspectra_default.yml
@@ -4,10 +4,6 @@ parameters:
   core_level_energy_units: eV
   energy_zero: '4.1718'
   energy_zero_units: eV
-  epsilon_vector:
-  - 1.0
-  - 0.0
-  - 0.0
   estimated_ram_per_process: 4.54
   estimated_ram_per_process_units: MB
   estimated_ram_total: 72.59
@@ -18,9 +14,14 @@ parameters:
   highest_occupied_level_units: eV
   lsda: false
   lumo_found: false
-  plot_only: false
   wall_time: 5.77s
   wall_time_seconds: 5.77
+  xcoordcrys: true
+  xepsilon:
+  - 0.0
+  - 0.0
+  - 1.0
+  xonly_plot: false
 xspectra:
   labels:
   - energy

--- a/tests/parsers/test_xspectra/test_xspectra_spin.yml
+++ b/tests/parsers/test_xspectra/test_xspectra_spin.yml
@@ -4,10 +4,6 @@ parameters:
   core_level_energy_units: eV
   energy_zero: '6.8316'
   energy_zero_units: eV
-  epsilon_vector:
-  - 1.0
-  - 0.0
-  - 0.0
   estimated_ram_per_process: 5.08
   estimated_ram_per_process_units: MB
   estimated_ram_total: 81.31
@@ -20,9 +16,14 @@ parameters:
   lowest_unoccupied_level_units: eV
   lsda: true
   lumo_found: true
-  plot_only: false
   wall_time: 6.33s
   wall_time_seconds: 6.33
+  xcoordcrys: true
+  xepsilon:
+  - 0.0
+  - 0.0
+  - 1.0
+  xonly_plot: false
 xspectra:
   labels:
   - energy


### PR DESCRIPTION
Addresses a request made in PR: aiidateam#852

Updates the method for the `XspectraParser` class to parse the following parameters from the input of the CalcJob class, rather than the stdout:

* The polarisation (epsilon) vectors used in the calculation
* The coordinate system used for the calculation (either crystallographic or cartesian)
* Whether the calculation was a re-plot or a full calculation (`xonly_plot`)

Keyword `plot_only` in `output_parameters` is also changed to `only_plot_spectrum` in order to clarify its meaning.

The changes were made necessary as, during further testing involving calculation restarts, it was found that XSpectra stores the polarisation and k-vector used for the calculation in its save file using a cartesian basis regardless of the setting used in the calculation itself. When performing a re-start or re-plot calculation the code reports the polarisation/k-vector stored in the save file, on a cartesian basis, which causes confusion for the Parser - particularly in the case of a restarted calculation as the polarisation vector is then reported twice: once at the initial read of the input file and then again when the save file is read (and in potentially different coordinate systems, depending on calculation settings). It was therefore decided to move the parsing of these parameters from the raw output to just taking them directly from the CalcJob inputs.