### PR TITLE
Refactor: Replace deprecated `Code` data type

### DIFF
--- a/.github/config/code-ph.yaml
+++ b/.github/config/code-ph.yaml
@@ -1,8 +1,7 @@
 ---
 label: ph
 description: Quantum ESPRESSO ph.x
-input_plugin: quantumespresso.ph
-on_computer: true
+default_calc_job_plugin: quantumespresso.ph
 computer: localhost
 prepend_text: ' '
 append_text: ' '

--- a/.github/config/code-pw.yaml
+++ b/.github/config/code-pw.yaml
@@ -1,8 +1,7 @@
 ---
 label: pw
 description: Quantum ESPRESSO pw.x
-input_plugin: quantumespresso.pw
-on_computer: true
+default_calc_job_plugin: quantumespresso.pw
 computer: localhost
 prepend_text: ' '
 append_text: ' '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,10 +125,10 @@ jobs:
             run: verdi computer configure core.local localhost -n --config .github/config/localhost-config.yaml
 
         -   name: Setup `pw.x`
-            run: verdi code setup -n --config .github/config/code-pw.yaml --remote-abs-path $(which pw.x)
+            run: verdi code create core.code.installed -n --config .github/config/code-pw.yaml --filepath-executable $(which pw.x)
 
         -   name: Setup `ph.x`
-            run: verdi code setup -n --config .github/config/code-ph.yaml --remote-abs-path $(which ph.x)
+            run: verdi code create core.code.installed -n --config .github/config/code-ph.yaml --filepath-executable $(which ph.x)
 
         -   name: Setup SSSP
             run: aiida-pseudo install sssp

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -159,7 +159,7 @@ In this example, we will setup the ``pw.x`` code that is installed on the comput
 
         .. code-block:: console
 
-            $ verdi code setup -n --on-computer -Y localhost -L pw -P quantumespresso.pw --remote-abs-path /path/to/pw.x
+            $ verdi code create core.code.installed -n --computer localhost --label pw --default-calc-job-plugin quantumespresso.pw --filepath-executable /path/to/pw.x
 
     .. tab-item:: API
 
@@ -167,13 +167,14 @@ In this example, we will setup the ``pw.x`` code that is installed on the comput
 
         .. code-block:: python
 
-            from aiida.orm import Code
+            from aiida.orm import InstalledCode
 
             computer = load_computer('localhost')
-            code = Code(
+            code = InstalledCode(
                 label='pw',
-                remote_computer_exec=(computer, '/path/to/pw.x')
-                input_plugin_name='quantumespresso.pw',
+                computer=computer,
+                filepath_executable='/path/to/pw.x',
+                default_calc_job_plugin='quantumespresso.pw',
             ).store()
 
 .. important::

--- a/src/aiida_quantumespresso/tools/pwinputparser.py
+++ b/src/aiida_quantumespresso/tools/pwinputparser.py
@@ -4,7 +4,7 @@ import copy
 import re
 
 from aiida.common.folders import Folder
-from aiida.orm import Code, Dict
+from aiida.orm import Dict, load_code
 from aiida.plugins import CalculationFactory, DataFactory
 import numpy as np
 from qe_tools.parsers import PwInputFile as BasePwInputFile
@@ -69,7 +69,7 @@ def create_builder_from_file(input_folder, input_file_name, code, metadata, pseu
     :param input_file_name: the name of the input file
     :type input_file_name: str
     :param code: the code associated with the calculation
-    :type code: aiida.orm.Code or str
+    :type code: aiida.orm.AbstractCode or str
     :param metadata: metadata values for the calculation (e.g. resources)
     :type metadata: dict
     :param pseudo_folder_path: the folder containing the upf files (if None, then input_folder is used)
@@ -83,7 +83,7 @@ def create_builder_from_file(input_folder, input_file_name, code, metadata, pseu
     builder.metadata = metadata
 
     if isinstance(code, str):
-        code = Code.get_from_string(code)
+        code = load_code(code)
     builder.code = code
 
     # read input_file

--- a/src/aiida_quantumespresso/workflows/ph/base.py
+++ b/src/aiida_quantumespresso/workflows/ph/base.py
@@ -73,7 +73,7 @@ class PhBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         if isinstance(code, str):
             code = orm.load_code(code)
 
-        type_check(code, orm.Code)
+        type_check(code, orm.AbstractCode)
 
         inputs = cls.get_protocol_inputs(protocol, overrides)
 

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -151,7 +151,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         if isinstance(code, str):
             code = orm.load_code(code)
 
-        type_check(code, orm.Code)
+        type_check(code, orm.AbstractCode)
         type_check(electronic_type, ElectronicType)
         type_check(spin_type, SpinType)
 


### PR DESCRIPTION
The `Code` data plugin has been deprecated. When using it to compare types, it should be replaced with `AbstractCode`. For concrete instances, the `InstalledCode` and `PortableCode` plugins should be used for the "remote" and "local" variant of `Code`, respectively.

Old documentation is also updated to use `load_code` to load a code instance instead of the various other old and deprecated methods that were still being suggested.