### PR TITLE
Tests: Add support for any `Data` to `serialize_builder`

### DIFF
--- a/tests/calculations/test_ph.py
+++ b/tests/calculations/test_ph.py
@@ -64,3 +64,11 @@ def test_ph_initialization_only(fixture_sandbox, generate_inputs_ph, generate_ca
     inputs['settings'] = orm.Dict({'only_initialization': True})
     generate_calc_job(fixture_sandbox, entry_point_name, inputs)
     assert (Path(fixture_sandbox.abspath) / f'{PhCalculation._PREFIX}.EXIT').exists()  # pylint: disable=protected-access
+
+
+def test_serialize_builder(fixture_code, generate_inputs_ph, data_regression, serialize_builder):
+    """Test the ``serialize_builder`` fixture using a process builder for the ``PhCalculation``."""
+    code = fixture_code('quantumespresso.ph')
+    builder = code.get_builder()
+    builder._update(**generate_inputs_ph())  # pylint: disable=protected-access
+    data_regression.check(serialize_builder(builder))

--- a/tests/calculations/test_ph/test_serialize_builder.yml
+++ b/tests/calculations/test_ph/test_serialize_builder.yml
@@ -1,0 +1,11 @@
+code: test.quantumespresso.ph@localhost-test
+metadata:
+  options:
+    max_wallclock_seconds: 1800
+    resources:
+      num_machines: 1
+    withmpi: false
+parameters:
+  INPUTPH: {}
+parent_folder: 076c4a75b0e7f3de89d0f21d3c4fad9c09fb83054f8e6c467b875095d93fd154
+qpoints: 3a91e383b97279decd5729f70ce57e2f5cbb3c6b219e0b2dca6a4ee9d60328d0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def serialize_builder():
 
     def serialize_data(data):
         # pylint: disable=too-many-return-statements
-        from aiida.orm import AbstractCode, BaseType, Dict
+        from aiida.orm import AbstractCode, BaseType, Data, Dict, RemoteData
         from aiida.plugins import DataFactory
 
         StructureData = DataFactory('core.structure')
@@ -102,6 +102,14 @@ def serialize_builder():
 
         if isinstance(data, UpfData):
             return f'{data.element}<md5={data.md5}>'
+
+        if isinstance(data, RemoteData):
+            # For `RemoteData` we compute the hash of the repository. The value returned by `Node._get_hash` is not
+            # useful since it includes the hash of the absolute filepath and the computer UUID which vary between tests
+            return data.base.repository.hash()
+
+        if isinstance(data, Data):
+            return data.base.caching._get_hash()  # pylint: disable=protected-access
 
         return data
 


### PR DESCRIPTION
The `serialize_builder` fixture is updated to add support for the `RemoteData` class as well as adding a fallback for any other `Data` implementations.

The fallback simply computes the hash of the node as computed by the `Data.base.caching._get_hash()` method. Note that we cannot use the public `get_hash` method as that requires the node to be stored which is not always the case.

For the `RemoteData` a custom solution was necessary as its hash includes the absolute filepath of the folder as well as the UUID of the computer, however, these vary from tests to tests and would cause the comparison to always fail. Instead, the hash of the repository contents is used which is the interesting part that we want compare.