### PR TITLE
Fix bug in `wrap_bare_dict_inputs`

### DIFF
--- a/src/aiida_quantumespresso/utils/mapping.py
+++ b/src/aiida_quantumespresso/utils/mapping.py
@@ -88,10 +88,11 @@ def wrap_bare_dict_inputs(port_namespace, inputs):
             continue
 
         port = port_namespace[key]
+        valid_types = port.valid_type if isinstance(port.valid_type, (list, tuple)) else (port.valid_type,)
 
         if isinstance(port, PortNamespace):
             wrapped[key] = wrap_bare_dict_inputs(port, value)
-        elif port.valid_type == Dict and isinstance(value, dict):
+        elif Dict in valid_types and isinstance(value, dict):
             wrapped[key] = Dict(value)
         else:
             wrapped[key] = value


### PR DESCRIPTION
From `aiida-core==2.1.0`, the `valid_type` of an input is extended on the fly with `None` in case the port is not required. This causes an issue in the `wrap_bare_dict_inputs` function, which checks if the `valid_type` is _equal_ to `Dict`. Here we adapt the function to check if `Dict` is one of the valid types after converting the valid types into a tuple if necessary.