### PR TITLE
`PwBaseWorkChain`: Fix `kpoints` override in `get_builder_from_protocol`

### DIFF
--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -230,7 +230,10 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         if 'parallelization' in inputs['pw']:
             builder.pw['parallelization'] = orm.Dict(inputs['pw']['parallelization'])
         builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
-        builder.kpoints_distance = orm.Float(inputs['kpoints_distance'])
+        if 'kpoints' in inputs:
+            builder.kpoints = inputs['kpoints']
+        else:
+            builder.kpoints_distance = orm.Float(inputs['kpoints_distance'])
         builder.kpoints_force_parity = orm.Bool(inputs['kpoints_force_parity'])
         # pylint: enable=no-member
 


### PR DESCRIPTION
Fixes #746 

The `kpoints` input is currently ignored when passed through the `overrides` input argument of the
`PwBaseWorkChain.get_builder_from_protocol()` method. Here we check if the `kpoints` input has been provided, and if so set it in favor of the `kpoints_distance` input.