### PR TITLE
Fix nightly build tests

### DIFF
--- a/tests/calculations/test_ph/test_serialize_builder.yml
+++ b/tests/calculations/test_ph/test_serialize_builder.yml
@@ -1,4 +1,4 @@
-code: test.quantumespresso.ph@localhost-test
+code: test.quantumespresso.ph@localhost
 metadata:
   options:
     max_wallclock_seconds: 1800

--- a/tests/workflows/protocols/pw/test_bands/test_default.yml
+++ b/tests/workflows/protocols/pw/test_bands/test_default.yml
@@ -1,6 +1,6 @@
 bands:
   pw:
-    code: test.quantumespresso.pw@localhost-test
+    code: test.quantumespresso.pw@localhost
     metadata:
       options:
         max_wallclock_seconds: 43200
@@ -35,7 +35,7 @@ relax:
     kpoints_distance: 0.15
     kpoints_force_parity: false
     pw:
-      code: test.quantumespresso.pw@localhost-test
+      code: test.quantumespresso.pw@localhost
       metadata:
         options:
           max_wallclock_seconds: 43200
@@ -72,7 +72,7 @@ scf:
   kpoints_distance: 0.15
   kpoints_force_parity: false
   pw:
-    code: test.quantumespresso.pw@localhost-test
+    code: test.quantumespresso.pw@localhost
     metadata:
       options:
         max_wallclock_seconds: 43200

--- a/tests/workflows/protocols/pw/test_base/test_default.yml
+++ b/tests/workflows/protocols/pw/test_base/test_default.yml
@@ -2,7 +2,7 @@ clean_workdir: true
 kpoints_distance: 0.15
 kpoints_force_parity: false
 pw:
-  code: test.quantumespresso.pw@localhost-test
+  code: test.quantumespresso.pw@localhost
   metadata:
     options:
       max_wallclock_seconds: 43200

--- a/tests/workflows/protocols/pw/test_relax/test_default.yml
+++ b/tests/workflows/protocols/pw/test_relax/test_default.yml
@@ -2,7 +2,7 @@ base:
   kpoints_distance: 0.15
   kpoints_force_parity: false
   pw:
-    code: test.quantumespresso.pw@localhost-test
+    code: test.quantumespresso.pw@localhost
     metadata:
       options:
         max_wallclock_seconds: 43200
@@ -36,7 +36,7 @@ base_final_scf:
   kpoints_distance: 0.15
   kpoints_force_parity: false
   pw:
-    code: test.quantumespresso.pw@localhost-test
+    code: test.quantumespresso.pw@localhost
     metadata:
       options:
         max_wallclock_seconds: 43200

--- a/tests/workflows/protocols/test_pdos/test_default.yml
+++ b/tests/workflows/protocols/test_pdos/test_default.yml
@@ -1,6 +1,6 @@
 clean_workdir: true
 dos:
-  code: test.quantumespresso.dos@localhost-test
+  code: test.quantumespresso.dos@localhost
   metadata:
     options:
       max_wallclock_seconds: 43200
@@ -14,7 +14,7 @@ nscf:
   kpoints_distance: 0.1
   kpoints_force_parity: false
   pw:
-    code: test.quantumespresso.pw@localhost-test
+    code: test.quantumespresso.pw@localhost
     metadata:
       options:
         max_wallclock_seconds: 43200
@@ -41,7 +41,7 @@ nscf:
     pseudos:
       Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
 projwfc:
-  code: test.quantumespresso.projwfc@localhost-test
+  code: test.quantumespresso.projwfc@localhost
   metadata:
     options:
       max_wallclock_seconds: 43200
@@ -55,7 +55,7 @@ scf:
   kpoints_distance: 0.15
   kpoints_force_parity: false
   pw:
-    code: test.quantumespresso.pw@localhost-test
+    code: test.quantumespresso.pw@localhost
     metadata:
       options:
         max_wallclock_seconds: 43200

--- a/tests/workflows/protocols/xspectra/test_base/test_default.yml
+++ b/tests/workflows/protocols/xspectra/test_base/test_default.yml
@@ -7,7 +7,7 @@ kpoints:
   - 0.0
   - 0.0
 xspectra:
-  code: test.quantumespresso.xspectra@localhost-test
+  code: test.quantumespresso.xspectra@localhost
   core_wfc_data: '# number of core states 3 =  1 0;  2 0;
 
     6.51344e-05 6.615743462459999e-3


### PR DESCRIPTION
Due to the changes in https://github.com/aiidateam/aiida-core/commit/fda91e2e79bc0c84f43b83dc22894ad4cc77cd36, the `aiida_localhost` fixture now has the label `localhost` instead of `localhost-test`. Here we simply update the pytest data regression files to reflect this change.