### PR TITLE
Dependencies: Update requirement `aiida-pseudo~=1.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
     'aiida_core[atomic_tools]~=2.1',
-    'aiida-pseudo~=0.8.0',
+    'aiida-pseudo~=1.0',
     'click~=8.0',
     'importlib_resources',
     'jsonschema',


### PR DESCRIPTION
The package is now considered stable. By upgrading to the first major version, future minor version updates which often contain new established family versions, will be automatically supported without explicitly having to update the version requirement in this package.