### PR TITLE
Protocol: Use v1.2 of SSSP and PBEsol by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
             run: verdi code create core.code.installed -n --config .github/config/code-ph.yaml --filepath-executable $(which ph.x)
 
         -   name: Setup SSSP
-            run: aiida-pseudo install sssp
+            run: aiida-pseudo install sssp -v 1.2 -x PBEsol -p efficiency
 
         -   name: Run test script
             run: python .github/scripts/run_documentation_scripts.py

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -199,11 +199,11 @@ If this is not the case, it can be installed using:
     $ pip install aiida-pseudo
 
 At a minimum, at least one pseudo potential family should be installed.
-We recommend using the |SSSP|_:
+We recommend using the |SSSP|_ with the PBEsol functional:
 
 .. code-block:: console
 
-    $ aiida-pseudo install sssp
+    $ aiida-pseudo install sssp -x PBEsol
 
 For more detailed information on installing other pseudo potential families, please refer to the documentation of |aiida-pseudo|_.
 

--- a/docs/source/tutorials/include/scripts/run_pw_basic.py
+++ b/docs/source/tutorials/include/scripts/run_pw_basic.py
@@ -14,7 +14,7 @@ structure = StructureData(ase=bulk('Si', 'fcc', 5.43))
 builder.structure = structure
 
 # Load the pseudopotential family.
-pseudo_family = load_group('SSSP/1.1/PBE/efficiency')
+pseudo_family = load_group('SSSP/1.2/PBEsol/efficiency')
 builder.pseudos = pseudo_family.get_pseudos(structure=structure)
 
 # Request the recommended wavefunction and charge density cutoffs

--- a/src/aiida_quantumespresso/workflows/protocols/pw/base.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pw/base.yaml
@@ -5,7 +5,7 @@ default_inputs:
     meta_parameters:
         conv_thr_per_atom: 0.2e-9
         etot_conv_thr_per_atom: 1.e-5
-    pseudo_family: 'SSSP/1.1/PBE/efficiency'
+    pseudo_family: 'SSSP/1.2/PBEsol/efficiency'
     pw:
         metadata:
             options:
@@ -37,7 +37,7 @@ protocols:
         meta_parameters:
             conv_thr_per_atom: 0.1e-9
             etot_conv_thr_per_atom: 0.5e-5
-        pseudo_family: 'SSSP/1.1/PBE/precision'
+        pseudo_family: 'SSSP/1.2/PBEsol/precision'
         pw:
             parameters:
                 CONTROL:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,7 +168,7 @@ def sssp(aiida_profile, generate_upf_data):
                 'cutoff_rho': 240.0,
             }
 
-        label = 'SSSP/1.1/PBE/efficiency'
+        label = 'SSSP/1.2/PBEsol/efficiency'
         family = SsspFamily.create_from_folder(dirpath, label)
 
     family.set_cutoffs(cutoffs, stringency, unit='Ry')


### PR DESCRIPTION
Now that `aiida-pseudo` v1.0 has been released with support for v1.2 of the SSSP, we can switch to using this as the default for our protocols.

A recent discussion with @giovannipizzi and Nicola also led to the decision to use PBEsol by default for the protocols, since this functional typically leads to improved results for solid state systems.