### PR TITLE
Devops: Update `pylint` version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,11 +39,13 @@ repos:
             )$
         additional_dependencies: ['toml']
 
--   repo: https://github.com/PyCQA/pylint
-    rev: v2.12.2
+-   repo: local
     hooks:
     -   id: pylint
+        name: pylint
+        entry: pylint
         language: system
+        types: [python]
         exclude: *exclude_files
 
 -   repo: https://github.com/PyCQA/pydocstyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ docs = [
 ]
 pre-commit = [
     'pre-commit~=2.17',
-    'pylint~=2.12.2',
+    'pylint~=2.17.2',
     'pylint-aiida~=0.1.1',
     'toml',
 ]
@@ -162,17 +162,18 @@ generated-members = 'self.exit_codes.*'
 
 [tool.pylint.messages_control]
 disable = [
-    'bad-continuation',
     'duplicate-code',
-    'locally-disabled',
-    'logging-format-interpolation',
+    'fixme',
     'inconsistent-return-statements',
     'import-outside-toplevel',
+    'locally-disabled',
+    'logging-format-interpolation',
     'no-else-raise',
     'too-many-arguments',
     'too-many-ancestors',
     'too-many-branches',
     'too-many-locals',
+    'use-dict-literal',
 ]
 
 [tool.pylint.basic]

--- a/src/aiida_quantumespresso/calculations/__init__.py
+++ b/src/aiida_quantumespresso/calculations/__init__.py
@@ -518,7 +518,7 @@ class BasePwCpInputGenerator(CalcJob):
         # Note the (idx+1) to convert to fortran 1-based lists
         mapping_species = {sp_name: (idx + 1) for idx, sp_name in enumerate(mapping_species)}
         # I add the first line
-        sorted_atomic_species_card_list = (['ATOMIC_SPECIES\n'] + list(sorted_atomic_species_card_list))
+        sorted_atomic_species_card_list = ['ATOMIC_SPECIES\n'] + list(sorted_atomic_species_card_list)
         atomic_species_card = ''.join(sorted_atomic_species_card_list)
         # Free memory
         del sorted_atomic_species_card_list
@@ -624,6 +624,8 @@ class BasePwCpInputGenerator(CalcJob):
         input_params['SYSTEM']['ntyp'] = len(structure.kinds)
 
         # ============ I prepare the k-points =============
+        kpoints_card = ''
+
         if cls._use_kpoints:
             try:
                 mesh, offset = kpoints.get_kpoints_mesh()
@@ -744,8 +746,7 @@ class BasePwCpInputGenerator(CalcJob):
         # Write cards now
         inputfile += atomic_species_card
         inputfile += atomic_positions_card
-        if cls._use_kpoints:
-            inputfile += kpoints_card
+        inputfile += kpoints_card
         inputfile += cell_parameters_card
         if hubbard_card is not None:
             inputfile += hubbard_card

--- a/src/aiida_quantumespresso/calculations/epw.py
+++ b/src/aiida_quantumespresso/calculations/epw.py
@@ -57,7 +57,7 @@ class EpwCalculation(CalcJob):
         spec.input('parent_folder_ph', valid_type=orm.RemoteData, help='the folder of a completed `PhCalculation`')
         # yapf: enable
 
-    def prepare_for_submission(self, folder):  # pylint: disable=too-many-statements,too-many-branches
+    def prepare_for_submission(self, folder):
         """Prepare the calculation job for submission by transforming input nodes into input files.
 
         In addition to the input files being written to the sandbox folder, a `CalcInfo` instance will be returned that
@@ -68,6 +68,8 @@ class EpwCalculation(CalcJob):
         :return: :class:`~aiida.common.datastructures.CalcInfo` instance.
         """
 
+        # pylint: disable=too-many-statements,too-many-branches
+
         def test_offset(offset):
             """Check if the grid has an offset."""
             if any(i != 0. for i in offset):
@@ -76,7 +78,6 @@ class EpwCalculation(CalcJob):
                     'at the level of epw.x'
                 )
 
-        # pylint: disable=too-many-statements,too-many-branches
         local_copy_list = []
         remote_copy_list = []
         remote_symlink_list = []

--- a/src/aiida_quantumespresso/calculations/functions/xspectra/get_spectra_by_element.py
+++ b/src/aiida_quantumespresso/calculations/functions/xspectra/get_spectra_by_element.py
@@ -66,8 +66,8 @@ def get_spectra_by_element(elements_list, equivalent_sites_data, **kwargs):
         ]
 
         spectra_by_element[element] = np.column_stack((
-            sum([array[:, 0] for array in corrected_spectra]) / len(corrected_spectra),
-            sum([array[:, 1] for array in corrected_spectra])
+            sum(array[:, 0] for array in corrected_spectra) / len(corrected_spectra),
+            sum(array[:, 1] for array in corrected_spectra)
         ))
 
     all_final_spectra = {}

--- a/src/aiida_quantumespresso/calculations/functions/xspectra/get_xps_spectra.py
+++ b/src/aiida_quantumespresso/calculations/functions/xspectra/get_xps_spectra.py
@@ -73,7 +73,7 @@ def get_spectra_by_element(elements_list, equivalent_sites_data, voight_gamma, v
             final_spectra_y_labels = []
             final_spectra_y_units = []
 
-            total_multiplicity = sum([i[0] for i in points[element]])
+            total_multiplicity = sum(i[0] for i in points[element])
 
             final_spectra = orm.XyData()
             max_core_level_shift = points[element][-1][1]

--- a/src/aiida_quantumespresso/calculations/matdyn.py
+++ b/src/aiida_quantumespresso/calculations/matdyn.py
@@ -60,7 +60,7 @@ class MatdynCalculation(NamelistsCalculation):
         if parameters.get('INPUT', {}).get('flfrc', None) is not None:
             return '`INPUT.flfrc` is set automatically from the `force_constants` input.'
 
-    def generate_input_file(self, parameters):
+    def generate_input_file(self, parameters):  # pylint: disable=arguments-differ
         """Generate namelist input_file content given a dict of parameters.
 
         :param parameters: 'dict' containing the fortran namelists and parameters to be used.

--- a/src/aiida_quantumespresso/calculations/xspectra.py
+++ b/src/aiida_quantumespresso/calculations/xspectra.py
@@ -95,7 +95,7 @@ class XspectraCalculation(NamelistsCalculation):
             message='The spectrum data file could not be read using NumPy genfromtxt'
         )
 
-    def generate_input_file(self, parameters):
+    def generate_input_file(self, parameters):  # pylint: disable=arguments-differ
         """Add kpoint handling to the inherited method.
 
         This checks that the offset for the mesh is in a valid format, converts the offset

--- a/src/aiida_quantumespresso/cli/utils/validate.py
+++ b/src/aiida_quantumespresso/cli/utils/validate.py
@@ -60,11 +60,11 @@ def validate_hubbard_parameters(structure, parameters, hubbard_u=None, hubbard_v
 
         try:
             hubbard_file = load_node(pk=hubbard_file_pk)
-        except exceptions.NotExistent:
-            ValueError(f'{hubbard_file_pk} is not a valid pk')
+        except exceptions.NotExistent as exc:
+            raise ValueError(f'{hubbard_file_pk} is not a valid pk') from exc
         else:
             if not isinstance(hubbard_file, SinglefileData):
-                ValueError(f'Node<{hubbard_file_pk}> is not a SinglefileData but {type(hubbard_file)}')
+                raise ValueError(f'Node<{hubbard_file_pk}> is not a SinglefileData but {type(hubbard_file)}')
 
         parameters['SYSTEM']['lda_plus_u'] = True
         parameters['SYSTEM']['lda_plus_u_kind'] = 2

--- a/src/aiida_quantumespresso/data/force_constants.py
+++ b/src/aiida_quantumespresso/data/force_constants.py
@@ -178,7 +178,7 @@ def parse_q2r_force_constants_file(lines, also_force_constants=False):
         parsed_data['atom_list'] = atom_list
 
         # read lrigid (flag for dielectric constant and effective charges
-        has_done_electric_field = (lines[current_line].split()[0] == 'T')
+        has_done_electric_field = lines[current_line].split()[0] == 'T'
         parsed_data['has_done_electric_field'] = has_done_electric_field
         current_line += 1
 

--- a/src/aiida_quantumespresso/parsers/parse_xml/exceptions.py
+++ b/src/aiida_quantumespresso/parsers/parse_xml/exceptions.py
@@ -4,9 +4,7 @@
 
 class XMLParseError(Exception):
     """Raised when the XML output could not be parsed."""
-    pass
 
 
 class XMLUnsupportedFormatError(Exception):
     """Raised when the XML output has an unsupported format."""
-    pass

--- a/src/aiida_quantumespresso/utils/resources.py
+++ b/src/aiida_quantumespresso/utils/resources.py
@@ -152,14 +152,14 @@ def get_pw_parallelization_parameters(
     time_single_cpu = np.prod(fft_grid) * nspin * nkpoints * niterations * scaling_law[0] * nbands**scaling_law[1]
 
     # The number of nodes is the maximum number we can use that is dividing nkpoints
-    num_machines = max([m for m in range(1, max_num_machines + 1) if nkpoints % m == 0])
+    num_machines = max(m for m in range(1, max_num_machines + 1) if nkpoints % m == 0)
 
     # If possible try to make number of kpoints even by changing the number of machines
     if (
         num_machines == 1 and nkpoints > 6 and max_num_machines > 1 and
         time_single_cpu / default_num_mpiprocs_per_machine > target_time_seconds
     ):
-        num_machines = max([m for m in range(1, max_num_machines + 1) if (nkpoints + 1) % m == 0])
+        num_machines = max(m for m in range(1, max_num_machines + 1) if (nkpoints + 1) % m == 0)
 
     # Now we will try to decrease the number of processes per machine (by not more than one fourth)
     # until we manage to get an efficient plane wave parallelization
@@ -185,7 +185,7 @@ def get_pw_parallelization_parameters(
 
     # Increase the number of machines in case of memory problem during initialization
     if calculation.get_scheduler_stderr() and 'OOM' in calculation.get_scheduler_stderr():
-        num_machines = max([i for i in range(num_machines, max_num_machines + 1) if i % num_machines == 0])
+        num_machines = max(i for i in range(num_machines, max_num_machines + 1) if i % num_machines == 0)
 
     estimated_time = time_single_cpu / (num_mpiprocs_per_machine * num_machines)
     max_wallclock_seconds = min(ceil(estimated_time / round_interval) * round_interval, max_wallclock_seconds)

--- a/src/aiida_quantumespresso/utils/validation/trajectory.py
+++ b/src/aiida_quantumespresso/utils/validation/trajectory.py
@@ -117,6 +117,6 @@ def verify_convergence_stress(
     except (KeyError, IndexError) as exception:
         raise ValueError('the `stress` array does not exist or the given index exceeds the length.') from exception
 
-    pressure = (numpy.trace(stress) / 3.)
+    pressure = numpy.trace(stress) / 3.
 
     return abs(pressure - reference_pressure) < threshold

--- a/tests/parsers/test_pp.py
+++ b/tests/parsers/test_pp.py
@@ -137,11 +137,16 @@ def test_pp_default_1d(
     data_array = results['output_data'].get_array('data')
     coords_array = results['output_data'].get_array('x_coordinates')
     units_array = results['output_data'].get_array('x_coordinates_units')
-    num_regression.check({
-        'data_array': data_array,
-        'coords_array': coords_array
-    },
-                         default_tolerance=dict(atol=0, rtol=1e-18))
+    num_regression.check(
+        data_dict={
+            'data_array': data_array,
+            'coords_array': coords_array
+        },
+        default_tolerance={
+            'atol': 0,
+            'rtol': 1e-18
+        }
+    )
     data_regression.check({'parameters': results['output_parameters'].get_dict(), 'units_array': units_array.tolist()})
 
 
@@ -170,12 +175,17 @@ def test_pp_default_1d_spherical(
     data_units_array = results['output_data'].get_array('data_units')
     data_int_units_array = results['output_data'].get_array('integrated_data_units')
     coords_units_array = results['output_data'].get_array('x_coordinates_units')
-    num_regression.check({
-        'data_array': data_array,
-        'data_array_int': data_array_int,
-        'coords_array': coords_array
-    },
-                         default_tolerance=dict(atol=0, rtol=1e-18))
+    num_regression.check(
+        data_dict={
+            'data_array': data_array,
+            'data_array_int': data_array_int,
+            'coords_array': coords_array
+        },
+        default_tolerance={
+            'atol': 0,
+            'rtol': 1e-18
+        }
+    )
     data_regression.check({
         'parameters': results['output_parameters'].get_dict(),
         'data_units_array': data_units_array.tolist(),
@@ -204,11 +214,16 @@ def test_pp_default_2d(
     coords_array = results['output_data'].get_array('xy_coordinates').flatten()
     data_units_array = results['output_data'].get_array('data_units')
     coords_units_array = results['output_data'].get_array('xy_coordinates_units')
-    num_regression.check({
-        'data_array': data_array,
-        'coords_array': coords_array
-    },
-                         default_tolerance=dict(atol=0, rtol=1e-18))
+    num_regression.check(
+        data_dict={
+            'data_array': data_array,
+            'coords_array': coords_array
+        },
+        default_tolerance={
+            'atol': 0,
+            'rtol': 1e-18
+        }
+    )
     data_regression.check({
         'parameters': results['output_parameters'].get_dict(),
         'data_units': data_units_array.tolist(),
@@ -236,7 +251,10 @@ def test_pp_default_polar(
     data_units_array = results['output_data'].get_array('data_units')
     num_regression.check({
         'data_array': data_array,
-    }, default_tolerance=dict(atol=0, rtol=1e-18))
+    }, default_tolerance={
+        'atol': 0,
+        'rtol': 1e-18
+    })
     data_regression.check({
         'parameters': results['output_parameters'].get_dict(),
         'data_units': data_units_array.tolist(),
@@ -263,11 +281,15 @@ def test_pp_default_3d(
     voxel_array = results['output_data'].get_array('voxel').flatten()
     data_units_array = results['output_data'].get_array('data_units')
     coordinates_units_array = results['output_data'].get_array('coordinates_units')
-    num_regression.check({
-        'data_array': data_array,
-        'voxel_array': voxel_array,
-    },
-                         default_tolerance=dict(atol=0, rtol=1e-18))
+    num_regression.check(
+        data_dict={
+            'data_array': data_array,
+            'voxel_array': voxel_array
+        }, default_tolerance={
+            'atol': 0,
+            'rtol': 1e-18
+        }
+    )
     data_regression.check({
         'parameters': results['output_parameters'].get_dict(),
         'data_units': data_units_array.tolist(),


### PR DESCRIPTION
Besides bumping the version of `pylint` in `pyproject.toml`:

- Set the `pylint` `repo` to `local` in the pre-commit config.
- Remove the deprecated `bad-continuation` check from the disabled checks.
- Disable the `fixme` check to avoid complaints about `TODO` statements.
- Disable the `use-dict-literal` check; using literal dictionaries is slightly faster, but I find the `dict()` calls easier to read in some cases.