### PR TITLE
`PwCalculation`: Fix restart validation for `nscf`/`bands`

### DIFF
--- a/src/aiida_quantumespresso/calculations/pw.py
+++ b/src/aiida_quantumespresso/calculations/pw.py
@@ -175,21 +175,16 @@ class PwCalculation(BasePwCpInputGenerator):
         parameters = value['parameters'].get_dict()
         calculation_type = parameters.get('CONTROL', {}).get('calculation', 'scf')
 
-        # Check that the restart input parameters are set correctly
-        if calculation_type in ('nscf', 'bands'):
-            if parameters.get('ELECTRONS', {}).get('startingpot', 'file') != 'file':
-                return f'`startingpot` should be set to `file` for a `{calculation_type}` calculation.'
-            if parameters.get('CONTROL', {}).get('restart_mode', 'from_scratch') != 'from_scratch':
-                warnings.warn(f'`restart_mode` should be set to `from_scratch` for a `{calculation_type}` calculation.')
-        elif 'parent_folder' in value:
+        # If a `parent_folder` input is provided, make sure the inputs are set to restart
+        if 'parent_folder' in value and calculation_type not in ('nscf', 'bands'):
             if not any([
                 parameters.get('CONTROL', {}).get('restart_mode', None) == 'restart',
                 parameters.get('ELECTRONS', {}).get('startingpot', None) == 'file',
                 parameters.get('ELECTRONS', {}).get('startingwfc', None) == 'file'
             ]):
                 warnings.warn(
-                    '`parent_folder` input was provided for the `PwCalculation`, but no '
-                    'input parameters are set to restart from these files.'
+                    f'`parent_folder` input was provided for the `{calculation_type}` `PwCalculation`, but no input'
+                    'parameters (e.g. `restart_mode`, `startingpot`, ...) are set to restart from this folder.'
                 )
 
     @classmethod
@@ -197,9 +192,8 @@ class PwCalculation(BasePwCpInputGenerator):
         """Validate the top level namespace.
 
         Check that the restart input parameters are set correctly. In case of 'nscf' and 'bands' calculations, this
-        means ``parent_folder`` is provided, ``startingpot`` is set to 'file' and ``restart_mode`` is 'from_scratch'.
-        For other calculations, if the ``parent_folder`` is provided, the restart settings must be set to use some of
-        the outputs.
+        means ``parent_folder`` is provided. For other calculations, if the ``parent_folder`` is provided, the restart
+        settings must be set to use some of the outputs.
 
         Note that the validator is split in two methods: ``validate_inputs`` and ``validate_inputs_base``. This is to
         facilitate work chains that wrap this calculation that will provide the ``parent_folder`` themselves and so do

--- a/src/aiida_quantumespresso/calculations/pw.py
+++ b/src/aiida_quantumespresso/calculations/pw.py
@@ -184,7 +184,11 @@ class PwCalculation(BasePwCpInputGenerator):
             ]):
                 warnings.warn(
                     f'`parent_folder` input was provided for the `{calculation_type}` `PwCalculation`, but no input'
-                    'parameters (e.g. `restart_mode`, `startingpot`, ...) are set to restart from this folder.'
+                    'parameters were provided to restart from this folder.\n\n'
+                    'Please set one of the following in the input parameters:\n'
+                    "    parameters['CONTROL']['restart_mode'] = 'restart'\n"
+                    "    parameters['ELECTRONS']['startingpot'] = 'file'\n"
+                    "    parameters['ELECTRONS']['startingwfc'] = 'file'\n"
                 )
 
     @classmethod

--- a/tests/calculations/test_pw.py
+++ b/tests/calculations/test_pw.py
@@ -330,18 +330,10 @@ def test_pw_validate_inputs_restart_nscf(
     inputs['parent_folder'] = remote_data
     generate_calc_job(fixture_sandbox, entry_point_name, inputs)
 
-    # Set `startingpot` to `'atomic'` -> raise
-    parameters['ELECTRONS']['startingpot'] = 'atomic'
-    inputs['parameters'] = orm.Dict(parameters)
-    with pytest.raises(ValueError, match='`startingpot` should be set to `file` for a `.*` calculation.'):
-        generate_calc_job(fixture_sandbox, entry_point_name, inputs)
-
-    # Set `restart_mode` to `'restart'` -> warning
-    parameters['ELECTRONS'].pop('startingpot')
+    # Set `restart_mode` to `'restart'` -> works
     parameters['CONTROL']['restart_mode'] = 'restart'
     inputs['parameters'] = orm.Dict(parameters)
-    with pytest.warns(Warning, match='`restart_mode` should be set to `from_scratch` for a `.*`.'):
-        generate_calc_job(fixture_sandbox, entry_point_name, inputs)
+    generate_calc_job(fixture_sandbox, entry_point_name, inputs)
 
 
 def test_fixed_coords(fixture_sandbox, generate_calc_job, generate_inputs_pw, file_regression):


### PR DESCRIPTION
Fixes #905

For interrupted runs, restarting from a previous `nscf`/`bands` run with `CONTROL.restart_mode` set to `restart` is a valid use case. Here we remove the validation that raised a warning when the user tried to restart an interrupted run with this input.