### PR TITLE
``PwBaseWorkChain``: improve diagonalization handler

### DIFF
--- a/src/aiida_quantumespresso/common/types.py
+++ b/src/aiida_quantumespresso/common/types.py
@@ -40,12 +40,3 @@ class RestartType(enum.Enum):
     FROM_SCRATCH = 'from_scratch'
     FROM_CHARGE_DENSITY = 'from_charge_density'
     FROM_WAVE_FUNCTIONS = 'from_wave_functions'
-
-
-class DiagonalizationType(enum.Enum):
-    """Enumeration of avaliable diagonalization algorithms in Quantum ESPRESSO."""
-
-    CG = 'cg'
-    DAVIDSON = 'david'
-    PPCG = 'ppcg'
-    PARO = 'paro'

--- a/src/aiida_quantumespresso/common/types.py
+++ b/src/aiida_quantumespresso/common/types.py
@@ -40,3 +40,12 @@ class RestartType(enum.Enum):
     FROM_SCRATCH = 'from_scratch'
     FROM_CHARGE_DENSITY = 'from_charge_density'
     FROM_WAVE_FUNCTIONS = 'from_wave_functions'
+
+
+class DiagonalizationType(enum.Enum):
+    """Enumeration of avaliable diagonalization algorithms in Quantum ESPRESSO."""
+
+    CG = 'cg'
+    DAVIDSON = 'david'
+    PPCG = 'ppcg'
+    PARO = 'paro'

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -414,7 +414,10 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             self.ctx.diagonalizations = ['david', 'ppcg', 'paro', 'cg']
 
         current = self.ctx.inputs.parameters['ELECTRONS'].get('diagonalization', 'david')
-        self.ctx.diagonalizations.remove(current)
+        try:
+            self.ctx.diagonalizations.remove(current)
+        except ValueError:  # if it is different from the one we support in the handler
+            pass
 
         if not self.ctx.diagonalizations:
             action = 'found diagonalization issues but already exploited different algorithms, aborting...'

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -120,6 +120,16 @@ def test_handle_diagonalization_errors(generate_workchain_pw, exit_code):
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'ppcg'
+    assert result.do_break
+
+    result = process.handle_diagonalization_errors(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'paro'
+    assert result.do_break
+
+    result = process.handle_diagonalization_errors(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
     assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'cg'
     assert result.do_break
 

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -138,9 +138,6 @@ def test_handle_diagonalization_errors(generate_workchain_pw, exit_code):
     assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'cg'
     assert result.do_break
 
-    result = process.handle_diagonalization_errors(process.ctx.children[-1])
-    assert result.do_break
-
     result = process.inspect_process()
     assert result == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
 
@@ -176,9 +173,6 @@ def test_handle_diagonalization_errors_not_from_david(generate_workchain_pw, exi
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
     assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'cg'
-    assert result.do_break
-
-    result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert result.do_break
 
     result = process.inspect_process()

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -109,6 +109,11 @@ def test_handle_known_unrecoverable_failure(generate_workchain_pw):
     'exit_code', (
         PwCalculation.exit_codes.ERROR_COMPUTING_CHOLESKY,
         PwCalculation.exit_codes.ERROR_DIAGONALIZATION_TOO_MANY_BANDS_NOT_CONVERGED,
+        PwCalculation.exit_codes.ERROR_S_MATRIX_NOT_POSITIVE_DEFINITE,
+        PwCalculation.exit_codes.ERROR_ZHEGVD_FAILED,
+        PwCalculation.exit_codes.ERROR_QR_FAILED,
+        PwCalculation.exit_codes.ERROR_EIGENVECTOR_CONVERGENCE,
+        PwCalculation.exit_codes.ERROR_BROYDEN_FACTORIZATION,
     )
 )
 def test_handle_diagonalization_errors(generate_workchain_pw, exit_code):
@@ -121,6 +126,46 @@ def test_handle_diagonalization_errors(generate_workchain_pw, exit_code):
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
     assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'ppcg'
+    assert result.do_break
+
+    result = process.handle_diagonalization_errors(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'paro'
+    assert result.do_break
+
+    result = process.handle_diagonalization_errors(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'cg'
+    assert result.do_break
+
+    result = process.handle_diagonalization_errors(process.ctx.children[-1])
+    assert result.do_break
+
+    result = process.inspect_process()
+    assert result == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
+
+
+@pytest.mark.parametrize(
+    'exit_code', (
+        PwCalculation.exit_codes.ERROR_COMPUTING_CHOLESKY,
+        PwCalculation.exit_codes.ERROR_DIAGONALIZATION_TOO_MANY_BANDS_NOT_CONVERGED,
+        PwCalculation.exit_codes.ERROR_S_MATRIX_NOT_POSITIVE_DEFINITE,
+        PwCalculation.exit_codes.ERROR_ZHEGVD_FAILED,
+        PwCalculation.exit_codes.ERROR_QR_FAILED,
+        PwCalculation.exit_codes.ERROR_EIGENVECTOR_CONVERGENCE,
+        PwCalculation.exit_codes.ERROR_BROYDEN_FACTORIZATION,
+    )
+)
+def test_handle_diagonalization_errors_not_from_david(generate_workchain_pw, exit_code):
+    """Test `PwBaseWorkChain.handle_diagonalization_errors` starting from a different diagonalization."""
+    process = generate_workchain_pw(exit_code=exit_code)
+    process.setup()
+
+    process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] = 'ppcg'
+
+    result = process.handle_diagonalization_errors(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'david'
     assert result.do_break
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])


### PR DESCRIPTION
Fixes #880 

The current handler for diagonalization errors is switching 
from the default value (``david``) to conjugate gradient (``cg``). 
While being a safe solution, the ``cg`` algorithm is rather slow
compared to other options, now fully supported by the plugin (#901).
Therefore, we implement a new strategy, which simply switches to 
different algorithms before resorting to ``cg``.