### PR TITLE
Protocols: Set `clean_workdir` default to `False`

### DIFF
--- a/src/aiida_quantumespresso/workflows/protocols/pdos.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pdos.yaml
@@ -1,5 +1,5 @@
 default_inputs:
-    clean_workdir: True
+    clean_workdir: False
     scf:
         pw:
             parameters:

--- a/src/aiida_quantumespresso/workflows/protocols/ph/base.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/ph/base.yaml
@@ -1,5 +1,5 @@
 default_inputs:
-    clean_workdir: True
+    clean_workdir: False
     ph:
         metadata:
             options:

--- a/src/aiida_quantumespresso/workflows/protocols/pw/bands.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pw/bands.yaml
@@ -1,6 +1,6 @@
 default_inputs:
     bands_kpoints_distance: 0.025
-    clean_workdir: True
+    clean_workdir: False
     nbands_factor: 3.0
 default_protocol: moderate
 protocols:

--- a/src/aiida_quantumespresso/workflows/protocols/pw/base.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pw/base.yaml
@@ -1,5 +1,5 @@
 default_inputs:
-    clean_workdir: True
+    clean_workdir: False
     kpoints_distance: 0.15
     kpoints_force_parity: False
     meta_parameters:

--- a/src/aiida_quantumespresso/workflows/protocols/pw/relax.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pw/relax.yaml
@@ -1,5 +1,5 @@
 default_inputs:
-    clean_workdir: True
+    clean_workdir: False
     max_meta_convergence_iterations: 5
     meta_convergence: True
     volume_convergence: 0.02

--- a/src/aiida_quantumespresso/workflows/protocols/xps.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/xps.yaml
@@ -1,5 +1,5 @@
 default_inputs:
-    clean_workdir: True
+    clean_workdir: False
     abs_atom_marker: X
     voight_gamma: 0.3
     voight_sigma: 0.3

--- a/src/aiida_quantumespresso/workflows/protocols/xspectra/base.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/xspectra/base.yaml
@@ -1,5 +1,5 @@
 default_inputs:
-    clean_workdir: True
+    clean_workdir: False
     kpoints_distance: 0.15
     kpoints_force_parity: False
     xspectra:

--- a/src/aiida_quantumespresso/workflows/protocols/xspectra/core.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/xspectra/core.yaml
@@ -1,6 +1,6 @@
 default_inputs:
     abs_atom_marker: X
-    clean_workdir: True
+    clean_workdir: False
     get_powder_spectrum: False
     run_replot: False
     eps_vectors:

--- a/src/aiida_quantumespresso/workflows/protocols/xspectra/crystal.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/xspectra/crystal.yaml
@@ -1,6 +1,6 @@
 default_inputs:
     abs_atom_marker: X
-    clean_workdir: True
+    clean_workdir: False
     return_all_powder_spectra: False
     core:
         get_powder_spectrum: True

--- a/tests/workflows/protocols/pw/test_bands/test_default.yml
+++ b/tests/workflows/protocols/pw/test_bands/test_default.yml
@@ -28,7 +28,7 @@ bands:
     pseudos:
       Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
 bands_kpoints_distance: 0.025
-clean_workdir: true
+clean_workdir: false
 nbands_factor: 3.0
 relax:
   base:

--- a/tests/workflows/protocols/pw/test_base/test_default.yml
+++ b/tests/workflows/protocols/pw/test_base/test_default.yml
@@ -1,4 +1,4 @@
-clean_workdir: true
+clean_workdir: false
 kpoints_distance: 0.15
 kpoints_force_parity: false
 pw:

--- a/tests/workflows/protocols/pw/test_relax/test_default.yml
+++ b/tests/workflows/protocols/pw/test_relax/test_default.yml
@@ -65,7 +65,7 @@ base_final_scf:
         smearing: cold
     pseudos:
       Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
-clean_workdir: true
+clean_workdir: false
 max_meta_convergence_iterations: 5
 meta_convergence: true
 structure: Si2

--- a/tests/workflows/protocols/test_pdos/test_default.yml
+++ b/tests/workflows/protocols/test_pdos/test_default.yml
@@ -1,4 +1,4 @@
-clean_workdir: true
+clean_workdir: false
 dos:
   code: test.quantumespresso.dos@localhost
   metadata:

--- a/tests/workflows/protocols/xspectra/test_base/test_default.yml
+++ b/tests/workflows/protocols/xspectra/test_base/test_default.yml
@@ -1,4 +1,4 @@
-clean_workdir: true
+clean_workdir: false
 kpoints:
 - - 2
   - 2

--- a/tests/workflows/protocols/xspectra/test_core/test_default.yml
+++ b/tests/workflows/protocols/xspectra/test_core/test_default.yml
@@ -1,5 +1,5 @@
 abs_atom_marker: Si
-clean_workdir: true
+clean_workdir: false
 core_wfc_data: '# number of core states 3 =  1 0;  2 0;
 
   6.51344e-05 6.615743462459999e-3

--- a/tests/workflows/protocols/xspectra/test_crystal/test_default.yml
+++ b/tests/workflows/protocols/xspectra/test_crystal/test_default.yml
@@ -1,10 +1,10 @@
 abs_atom_marker: Si
-clean_workdir: true
+clean_workdir: false
 core:
   abs_atom_marker: Si
   get_powder_spectrum: true
   scf:
-    clean_workdir: true
+    clean_workdir: false
     kpoints_distance: 0.15
     kpoints_force_parity: false
     pw:


### PR DESCRIPTION
Fixes #915 

The current default in the protocol of all work chains is to set `clean_workdir` to `True`. This can several use cases where users have to restart from previous calculations impossible when the default inputs are used, which can be particularly confusing and frustrating for beginners.

Moreover, cleaning the working directory removes potentially valuable data that is not retrieved by the plugin (e.g. the charge density). Conversely, _not_ cleaning the working directory only really is a problem in case the user is running _a lot_ of calculations, and can be fixed easily by manually cleaning the working directories.

Here we set the default value of `clean_workdir` to `False` for all work chain protocols.