### PR TITLE
`BasePwCpInputGenerator`: Remove superfluous validation

### DIFF
--- a/src/aiida_quantumespresso/calculations/__init__.py
+++ b/src/aiida_quantumespresso/calculations/__init__.py
@@ -213,16 +213,6 @@ class BasePwCpInputGenerator(CalcJob):
         else:
             settings = {}
 
-        # Check that a pseudo potential was specified for each kind present in the `StructureData`
-        kinds = [kind.name for kind in self.inputs.structure.kinds]
-        if set(kinds) != set(self.inputs.pseudos.keys()):
-            formatted_pseudos = ', '.join(list(self.inputs.pseudos.keys()))
-            formatted_kinds = ', '.join(list(kinds))
-            raise exceptions.InputValidationError(
-                'Mismatch between the defined pseudos and the list of kinds of the structure.\n'
-                f'Pseudos: {formatted_pseudos};\nKinds: {formatted_kinds}'
-            )
-
         local_copy_list = []
         remote_copy_list = []
         remote_symlink_list = []

--- a/src/aiida_quantumespresso/calculations/__init__.py
+++ b/src/aiida_quantumespresso/calculations/__init__.py
@@ -530,12 +530,6 @@ class BasePwCpInputGenerator(CalcJob):
         fixed_coords = settings.pop('FIXED_COORDS', None)
 
         if fixed_coords is not None:
-            # Note that this check is also in the validation of the top-level namespace, but this is only checked in
-            # in case the structure is provided
-            if len(fixed_coords) != len(structure.sites):
-                raise exceptions.InputValidationError(
-                    f'Input structure has {len(structure.sites)} sites, but fixed_coords has length {len(fixed_coords)}'
-                )
             fixed_coords_strings = [
                 ' {:d} {:d} {:d}'.format(*row) for row in numpy.int32(numpy.invert(fixed_coords)).tolist()  # pylint: disable=consider-using-f-string
             ]


### PR DESCRIPTION
In the `prepare_for_submission` script of the `BasePwCpInputGenerator`,
there still is some validation for the pseudopotentials (see that the elements
match those in the provided `structure`) as well as the `FIXED_COORDS`
setting. 

In general, we want to do all validation using validators of the appropriate port
or port name space. In the case of these two inputs, however, this validation is
already done by proper validators, so we can simply remove it.

Even in case the `structure` port is not in the name space because a wrapping
work chain excluded it when exposing the inputs, the validation will still occur when
the process is submitted in the steps of the work chain.