### PR TITLE
`PwCalculation`: refactor `parent_folder` validation

### DIFF
--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -52,7 +52,6 @@ from aiida.engine import ToContext, WorkChain, if_
 from aiida.orm.nodes.data.base import to_aiida_type
 import jsonschema
 
-from aiida_quantumespresso.calculations.pw import PwCalculation
 from aiida_quantumespresso.utils.mapping import prepare_process_inputs
 
 from .protocols.utils import ProtocolMixin
@@ -242,13 +241,12 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         spec.expose_inputs(
             PwBaseWorkChain,
             namespace='nscf',
-            exclude=('clean_workdir', 'pw.structure'),
+            exclude=('clean_workdir', 'pw.structure', 'pw.parent_folder'),
             namespace_options={
                 'help': 'Inputs for the `PwBaseWorkChain` of the `nscf` calculation.',
                 'validator': validate_nscf
             }
         )
-        spec.inputs['nscf']['pw'].validator = PwCalculation.validate_inputs_base
         spec.expose_inputs(
             DosCalculation,
             namespace='dos',

--- a/src/aiida_quantumespresso/workflows/pw/bands.py
+++ b/src/aiida_quantumespresso/workflows/pw/bands.py
@@ -5,7 +5,6 @@ from aiida.common import AttributeDict
 from aiida.engine import ToContext, WorkChain, if_
 
 from aiida_quantumespresso.calculations.functions.seekpath_structure_analysis import seekpath_structure_analysis
-from aiida_quantumespresso.calculations.pw import PwCalculation
 from aiida_quantumespresso.utils.mapping import prepare_process_inputs
 from aiida_quantumespresso.workflows.pw.base import PwBaseWorkChain
 from aiida_quantumespresso.workflows.pw.relax import PwRelaxWorkChain
@@ -60,7 +59,7 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
             exclude=('clean_workdir', 'pw.structure'),
             namespace_options={'help': 'Inputs for the `PwBaseWorkChain` for the SCF calculation.'})
         spec.expose_inputs(PwBaseWorkChain, namespace='bands',
-            exclude=('clean_workdir', 'pw.structure', 'pw.kpoints', 'pw.kpoints_distance'),
+            exclude=('clean_workdir', 'pw.structure', 'pw.kpoints', 'pw.kpoints_distance', 'pw.parent_folder'),
             namespace_options={'help': 'Inputs for the `PwBaseWorkChain` for the BANDS calculation.'})
         spec.input('structure', valid_type=orm.StructureData, help='The inputs structure.')
         spec.input('clean_workdir', valid_type=orm.Bool, default=lambda: orm.Bool(False),
@@ -71,7 +70,7 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
             help='Explicit kpoints to use for the BANDS calculation. Specify either this or `bands_kpoints_distance`.')
         spec.input('bands_kpoints_distance', valid_type=orm.Float, required=False,
             help='Minimum kpoints distance for the BANDS calculation. Specify either this or `bands_kpoints`.')
-        spec.inputs['bands']['pw'].validator = PwCalculation.validate_inputs_base
+
         spec.inputs.validator = validate_inputs
         spec.outline(
             cls.setup,


### PR DESCRIPTION
In 3fea26b we added validation for restarting from a `parent_folder` to the 
`PwCalculation`. Here we ran into the following problem:

1. We want to check that a `parent_folder` is present when `CONTROL.calculation`
   is `nscf` or `bands`
2. The `parent_folder` will not be present in the initial inputs of e.g. the
   `PwBandsWorkChain` `bands` name space, since it is only created on runtime.
3. The validation will hence always fail, raising a warning when the builder is put
   together using the `get_builder_from_protocol()` method.

Our solution at the time was to split up the validation in a base and full one,
and override the validator. However, a more elegant solution is to check if the 
`parent_folder` is in the name space, and only do the restart validation in this case.
Wrapping work chains that dynamically assign this input should exclude the
`parent_folder` port when exposing the inputs of the `PwBaseWorkChain`.