### PR TITLE
Bump Python version for RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-    version: 3.8
     install:
         - method: pip
           path: .


### PR DESCRIPTION
The readthedocs (RTD) build was failing with the following error:

```
read the docs ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1
```

This was due to a change in the support for `urllib`, see:

https://github.com/urllib3/urllib3/issues/2168

Which requires Python > 3.8. Hence here we update the Python version.