### PR TITLE
Dependencies: restrict `pydantic` to at least `1.10.8`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     'importlib_resources',
     'jsonschema',
     'numpy',
-    'pydantic',
+    'pydantic~=1.10,>=1.10.8',
     'packaging',
     'qe-tools~=2.0',
     'xmlschema~=1.2,>=1.2.5'


### PR DESCRIPTION
The release of `typing_extensions` version `4.6.0` highlighted a bug in `pydantic` related to the `Literal` type for Python versions 3.8 and 3.9. This was fixed in `pydantic` version `1.10.8`.

Here the version of `pydantic` is set to be a compatible release with `1.10` but at least `1.10.8`.