### PR TITLE
Tests: Catch warning in `restart_mode` test for `PwBaseWorkChain`

### DIFF
--- a/src/aiida_quantumespresso/calculations/pw.py
+++ b/src/aiida_quantumespresso/calculations/pw.py
@@ -208,7 +208,7 @@ class PwCalculation(BasePwCpInputGenerator):
                 parameters.get('ELECTRONS', {}).get('startingwfc', None) == 'file'
             ]):
                 warnings.warn(
-                    f'`parent_folder` input was provided for the `{calculation_type}` `PwCalculation`, but no input'
+                    f'`parent_folder` input was provided for the `{calculation_type}` `PwCalculation`, but no input '
                     'parameters were provided to restart from this folder.\n\n'
                     'Please set one of the following in the input parameters:\n'
                     "    parameters['CONTROL']['restart_mode'] = 'restart'\n"

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -315,9 +315,8 @@ def test_restart_mode(generate_workchain_pw, generate_calc_job_node, restart_mod
     if restart_mode == 'restart':
         process = generate_workchain_pw(inputs=inputs)
     else:
-        with pytest.warns(UserWarning) as warning:
+        with pytest.warns(UserWarning, match='but no input parameters were'):
             process = generate_workchain_pw(inputs=inputs)
-        assert 'but no input parameters were' in str(warning[0])
 
     process.setup()
 

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -312,7 +312,13 @@ def test_restart_mode(generate_workchain_pw, generate_calc_job_node, restart_mod
     inputs['pw']['parent_folder'] = node.outputs.remote_folder
     inputs['pw']['parameters'] = Dict({'CONTROL': {'restart_mode': restart_mode}})
 
-    process = generate_workchain_pw(inputs=inputs)
+    if restart_mode == 'restart':
+        process = generate_workchain_pw(inputs=inputs)
+    else:
+        with pytest.warns(UserWarning) as warning:
+            process = generate_workchain_pw(inputs=inputs)
+        assert 'but no input parameters were' in str(warning[0])
+
     process.setup()
 
     assert process.ctx.inputs['parameters']['CONTROL']['restart_mode'] == expected


### PR DESCRIPTION
The `test_restart_mode` test was raising a warning related to the presence of the `parent_folder` input for `restart_mode = restart` (which is expected).

Here the test is adapted to catch the warning for this this input and make sure the message is correct.