### PR TITLE
Devops: Update `tox` configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,12 +214,14 @@ split_arguments_when_comma_terminated = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py37
+envlist =
+    py{38,38,310,311}
+    py38-pre-commit
+    py38-docs-{clean,update}
 
 [testenv]
+description = Run the pytest tests
 usedevelop=True
-
-[testenv:py{36,37,38,39}]
 extras = tests
 commands = pytest {posargs}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,9 +215,8 @@ split_arguments_when_comma_terminated = true
 legacy_tox_ini = """
 [tox]
 envlist =
-    py{38,38,310,311}
+    py{38,39,310,311}
     py38-pre-commit
-    py38-docs-{clean,update}
 
 [testenv]
 description = Run the pytest tests
@@ -231,15 +230,4 @@ extras =
     tests
     pre-commit
 commands = pre-commit run {posargs}
-
-[testenv:py38-docs-{clean,update}]
-description =
-    clean: Build the documentation (remove any existing build)
-    update: Build the documentation (modify any existing build)
-extras = docs
-changedir = docs
-whitelist_externals = make
-commands =
-    clean: make clean
-    make
 """


### PR DESCRIPTION
The `tox` configuration was still using outdated Python versions. Here the Python versions are updated to those supported by the package, the environments are cleaned up a bit, and the `pre-commit` environment is added to those run by default.

The docs environment are removed, since these aren't usually used and we still have an issue with the `intersphinx_mapping` to `aiida-core`.