### PR TITLE
BUG in the ions sections in case tehre are no settings: I set fixed coords to None

### DIFF
--- a/src/aiida_quantumespresso/parsers/pw.py
+++ b/src/aiida_quantumespresso/parsers/pw.py
@@ -274,8 +274,9 @@ class PwParser(BaseParser):
 
         if 'settings' in self.node.inputs:
             settings = _uppercase_dict(self.node.inputs.settings.get_dict(), dict_name='settings')
-
-        fixed_coords = settings.get('FIXED_COORDS', None)
+            fixed_coords = settings.get('FIXED_COORDS', None)
+        else:
+            fixed_coords = None
 
         # Through the `cell_dofree` the degrees of freedom of the cell can be constrained, which makes the threshold on
         # the stress hard to interpret. Therefore, unless the `cell_dofree` is set to the default `all` where the cell

--- a/src/aiida_quantumespresso/parsers/pw.py
+++ b/src/aiida_quantumespresso/parsers/pw.py
@@ -274,9 +274,10 @@ class PwParser(BaseParser):
 
         if 'settings' in self.node.inputs:
             settings = _uppercase_dict(self.node.inputs.settings.get_dict(), dict_name='settings')
-            fixed_coords = settings.get('FIXED_COORDS', None)
         else:
-            fixed_coords = None
+            settings = {}
+
+        fixed_coords = settings.get('FIXED_COORDS', None)
 
         # Through the `cell_dofree` the degrees of freedom of the cell can be constrained, which makes the threshold on
         # the stress hard to interpret. Therefore, unless the `cell_dofree` is set to the default `all` where the cell

--- a/tests/parsers/test_pw.py
+++ b/tests/parsers/test_pw.py
@@ -19,13 +19,16 @@ def generate_inputs(generate_structure):
         kpoints.set_cell_from_structure(structure)
         kpoints.set_kpoints_mesh_from_density(0.15)
 
-        return AttributeDict({
+        inputs = {
             'structure': generate_structure(),
             'kpoints': kpoints,
             'parameters': orm.Dict(parameters),
-            'settings': orm.Dict(settings),
             'metadata': metadata or {}
-        })
+        }
+        if settings:
+            inputs['settings'] = orm.Dict(settings)
+
+        return AttributeDict(inputs)
 
     return _generate_inputs
 


### PR DESCRIPTION
at line 278 
fixed_coords = settings.get('FIXED_COORDS', None) may be accessed before settings is defined.

Example of crash:


*** 1 LOG MESSAGES:
+-> REPORT at 2023-06-17 04:00:21.513690+00:00
 | [16139|PwCalculation|on_except]: Traceback (most recent call last):
 |   File "/home/jovyan/.local/lib/python3.9/site-packages/plumpy/process_states.py", line 228, in execute
 |     result = self.run_fn(*self.args, **self.kwargs)
 |   File "/home/jovyan/.local/lib/python3.9/site-packages/aiida/engine/processes/calcjobs/calcjob.py", line 675, in parse
 |     exit_code_retrieved = self.parse_retrieved_output(retrieved_temporary_folder)
 |   File "/home/jovyan/.local/lib/python3.9/site-packages/aiida/engine/processes/calcjobs/calcjob.py", line 786, in parse_retrieved_output
 |     exit_code = parser.parse(**parse_kwargs)
 |   File "/home/jovyan/.local/lib/python3.9/site-packages/aiida_quantumespresso/parsers/pw.py", line 151, in parse
 |     exit_code = validator(trajectory, parsed_parameters, logs_stdout)
 |   File "/home/jovyan/.local/lib/python3.9/site-packages/aiida_quantumespresso/parsers/pw.py", line 244, in validate_ionic
 |     if not self.is_ionically_converged(trajectory):
 |   File "/home/jovyan/.local/lib/python3.9/site-packages/aiida_quantumespresso/parsers/pw.py", line 278, in is_ionically_converged
 |     fixed_coords = settings.get('FIXED_COORDS', None)
 | UnboundLocalError: local variable 'settings' referenced before assignment