### PR TITLE
PP parser: attach context to the `ERROR_OUTPUT_DATAFILE_PARSE` exit code.

### DIFF
--- a/src/aiida_quantumespresso/calculations/pp.py
+++ b/src/aiida_quantumespresso/calculations/pp.py
@@ -116,7 +116,7 @@ class PpCalculation(CalcJob):
         spec.exit_code(332, 'ERROR_UNSUPPORTED_DATAFILE_FORMAT',
             message='The data file format is not supported by the parser')
         spec.exit_code(333, 'ERROR_OUTPUT_DATAFILE_PARSE',
-            message='The formatted data output file `{filename}` could not be parsed.\n{context}')
+            message='The formatted data output file `{filename}` could not be parsed: {exception}')
         # yapf: enable
 
     def prepare_for_submission(self, folder):  # pylint: disable=too-many-branches,too-many-statements

--- a/src/aiida_quantumespresso/calculations/pp.py
+++ b/src/aiida_quantumespresso/calculations/pp.py
@@ -116,7 +116,7 @@ class PpCalculation(CalcJob):
         spec.exit_code(332, 'ERROR_UNSUPPORTED_DATAFILE_FORMAT',
             message='The data file format is not supported by the parser')
         spec.exit_code(333, 'ERROR_OUTPUT_DATAFILE_PARSE',
-            message='The formatted data output file `{filename}` could not be parsed')
+            message='The formatted data output file `{filename}` could not be parsed.\n{context}')
         # yapf: enable
 
     def prepare_for_submission(self, folder):  # pylint: disable=too-many-branches,too-many-statements

--- a/src/aiida_quantumespresso/parsers/pp.py
+++ b/src/aiida_quantumespresso/parsers/pp.py
@@ -132,8 +132,8 @@ class PpParser(BaseParser):
                     key = get_key_from_filename(filename)
                     data_parsed.append((key, parsers[iflag](data_raw, self.units_dict[parsed_data['plot_num']])))
                     del data_raw
-                except Exception as exc:  # pylint: disable=broad-except
-                    return self.exit_codes.ERROR_OUTPUT_DATAFILE_PARSE.format(filename=filename, context=exc)
+                except Exception as exception:  # pylint: disable=broad-except
+                    return self.exit_codes.ERROR_OUTPUT_DATAFILE_PARSE.format(filename=filename, exception=exception)
 
         # If we don't have any parsed files, we exit. Note that this will not catch the case where there should be more
         # than one file, but the engine did not retrieve all of them. Since often we anyway don't know how many files

--- a/src/aiida_quantumespresso/parsers/pp.py
+++ b/src/aiida_quantumespresso/parsers/pp.py
@@ -132,8 +132,8 @@ class PpParser(BaseParser):
                     key = get_key_from_filename(filename)
                     data_parsed.append((key, parsers[iflag](data_raw, self.units_dict[parsed_data['plot_num']])))
                     del data_raw
-                except Exception:  # pylint: disable=broad-except
-                    return self.exit_codes.ERROR_OUTPUT_DATAFILE_PARSE.format(filename=filename)
+                except Exception as exc:  # pylint: disable=broad-except
+                    return self.exit_codes.ERROR_OUTPUT_DATAFILE_PARSE.format(filename=filename, context=exc)
 
         # If we don't have any parsed files, we exit. Note that this will not catch the case where there should be more
         # than one file, but the engine did not retrieve all of them. Since often we anyway don't know how many files


### PR DESCRIPTION
It would have been much faster to figure out the origin of the problem with the PP parser if the exit code could have told me a little bit more about it.