### PR TITLE
Devops: Remove Python 3.8 from the nightly workflow matrix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.9', '3.10', '3.11']
 
         services:
             postgres:


### PR DESCRIPTION
The latest release `aiida-core==2.4.0` dropped support for Python 3.8.