### PR TITLE
`Q2rCalculation`: Add the `output_parameters` output to the spec

### DIFF
--- a/src/aiida_quantumespresso/calculations/q2r.py
+++ b/src/aiida_quantumespresso/calculations/q2r.py
@@ -32,6 +32,7 @@ class Q2rCalculation(NamelistsCalculation):
         super().define(spec)
         spec.input('parent_folder', valid_type=(orm.RemoteData, orm.FolderData), required=True)
         spec.output('force_constants', valid_type=ForceConstantsData)
+        spec.output('output_parameters', valid_type=orm.Dict)
         spec.exit_code(330, 'ERROR_READING_FORCE_CONSTANTS_FILE',
             message='The force constants file could not be read.')
         # yapf: enable


### PR DESCRIPTION
Fixes #971 

The `Q2rCalculation` did not declare the `output_parameters` output even though the `Q2rParser` attaches it always. This would lead to the calculation excepting because an unknown output would be attached. This was uncaught by the test because the `Parser.parse_from_node` method does not automatically validate the outputs. This is because the output spec that is checked is that of the `calcfunction` (which accepts anything) and not that of the `Q2rCalculation`.