### PR TITLE
Docs: Address warning from `pydata-sphinx-theme`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,6 +118,7 @@ html_theme_options = {
     'github_url': 'https://github.com/aiidateam/aiida-quantumespresso',
     'twitter_url': 'https://twitter.com/aiidateam',
     'use_edit_page_button': True,
+    'navigation_with_keys': False,
     'logo': {
         'text': 'AiiDA Quantum ESPRESSO',
         'image_light': '_static/logo_aiida_quantumespresso-light.png',


### PR DESCRIPTION
The warning read:

    The default value for `navigation_with_keys` will change to `False`
    in the next release. If you wish to preserve the old behavior for
    your site, set `navigation_with_keys=True` in the `html_theme_options`
    dict in your `conf.py` file. Be aware that `navigation_with_keys = True`
    has negative accessibility implications:
    https://github.com/pydata/pydata-sphinx-theme/issues/1492

Here we set `navigation_with_keys=False` to avoid the negative accessibility implications.