### PR TITLE
Devops: Address various deprecation warnings from `aiida-core`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ testpaths = [
     'tests',
 ]
 filterwarnings = [
+    'ignore:Object of type .* not in session, .* operation along .* will not proceed:sqlalchemy.exc.SAWarning',
     'ignore:Creating AiiDA configuration folder.*:UserWarning',
     'ignore::DeprecationWarning:frozendict:',
     'ignore::DeprecationWarning:pkg_resources:',

--- a/src/aiida_quantumespresso/workflows/xps.py
+++ b/src/aiida_quantumespresso/workflows/xps.py
@@ -21,7 +21,7 @@ from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin, recur
 PwCalculation = CalculationFactory('quantumespresso.pw')
 PwBaseWorkChain = WorkflowFactory('quantumespresso.pw.base')
 PwRelaxWorkChain = WorkflowFactory('quantumespresso.pw.relax')
-XyData = DataFactory('array.xy')
+XyData = DataFactory('core.array.xy')
 
 
 def validate_inputs(inputs, _):

--- a/src/aiida_quantumespresso/workflows/xspectra/core.py
+++ b/src/aiida_quantumespresso/workflows/xspectra/core.py
@@ -147,7 +147,7 @@ class XspectraCoreWorkChain(ProtocolMixin, WorkChain):
         )
         spec.input(
             'upf2plotcore_code',
-            valid_type=orm.Code,
+            valid_type=orm.AbstractCode,
             required=False,
             help='The code node required for upf2plotcore.sh configured for ``aiida-shell``. '
             'Must be provided if `core_wfc_data` is not provided.'

--- a/src/aiida_quantumespresso/workflows/xspectra/crystal.py
+++ b/src/aiida_quantumespresso/workflows/xspectra/crystal.py
@@ -19,7 +19,7 @@ PwBaseWorkChain = WorkflowFactory('quantumespresso.pw.base')
 PwRelaxWorkChain = WorkflowFactory('quantumespresso.pw.relax')
 XspectraBaseWorkChain = WorkflowFactory('quantumespresso.xspectra.base')
 XspectraCoreWorkChain = WorkflowFactory('quantumespresso.xspectra.core')
-XyData = DataFactory('array.xy')
+XyData = DataFactory('core.array.xy')
 
 
 class XspectraCrystalWorkChain(ProtocolMixin, WorkChain):
@@ -128,7 +128,7 @@ class XspectraCrystalWorkChain(ProtocolMixin, WorkChain):
         )
         spec.input(
             'upf2plotcore_code',
-            valid_type=orm.Code,
+            valid_type=orm.AbstractCode,
             required=False,
             help=(
                 'Code node for the upf2plotcore.sh ShellJob code.'

--- a/tests/parsers/test_neb.py
+++ b/tests/parsers/test_neb.py
@@ -57,7 +57,7 @@ def test_neb_default(fixture_localhost, generate_calc_job_node, generate_parser,
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
-    assert not [log for log in orm.Log.objects.get_logs_for(node) if log.levelname == 'ERROR']
+    assert not [log for log in orm.Log.collection.get_logs_for(node) if log.levelname == 'ERROR']
     assert 'output_parameters' in results
     assert 'output_mep' in results
     assert 'output_trajectory' in results
@@ -89,7 +89,7 @@ def test_neb_all_iterations(
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
-    assert not [log for log in orm.Log.objects.get_logs_for(node) if log.levelname == 'ERROR']
+    assert not [log for log in orm.Log.collection.get_logs_for(node) if log.levelname == 'ERROR']
     assert 'output_parameters' in results
     assert 'output_mep' in results
     assert 'output_trajectory' in results

--- a/tests/parsers/test_open_grid.py
+++ b/tests/parsers/test_open_grid.py
@@ -20,8 +20,8 @@ def test_open_grid_default(fixture_localhost, generate_calc_job_node, generate_p
 
     data_regression.check({
         'output_parameters': results['output_parameters'].get_dict(),
-        'kpoints_mesh': results['kpoints_mesh'].attributes,
-        'kpoints': results['kpoints'].attributes,
+        'kpoints_mesh': results['kpoints_mesh'].base.attributes.all,
+        'kpoints': results['kpoints'].base.attributes.all,
     })
 
     num_regression.check({

--- a/tests/parsers/test_ph.py
+++ b/tests/parsers/test_ph.py
@@ -22,7 +22,7 @@ def test_ph_default(test_name, fixture_localhost, generate_calc_job_node, genera
 
     assert calcfunction.is_finished, calcfunction.exception
     assert calcfunction.is_finished_ok, calcfunction.exit_message
-    assert not [log for log in orm.Log.objects.get_logs_for(node) if log.levelname == 'ERROR']
+    assert not [log for log in orm.Log.collection.get_logs_for(node) if log.levelname == 'ERROR']
     assert 'output_parameters' in results
     data_regression.check(results['output_parameters'].get_dict())
 


### PR DESCRIPTION
AiiDA v2.5 upgraded to Sqlalchemy v2 which as of v2.0.19 emits a warning
that is entirely consequential but was too difficult to actually address.
As a workaround, `aiida-core` simply filters the warning. This works for
normal usage, but `pytest` eliminates the filter and so the warnings do
show up in the final warning report of `pytest`. Therefore the warning
has to be explicitly ignored in the `pytest` config as well.