### PR TITLE
`PwBaseWorkChain`: handler for BFGS history failure

### DIFF
--- a/src/aiida_quantumespresso/utils/defaults/calculation/__init__.py
+++ b/src/aiida_quantumespresso/utils/defaults/calculation/__init__.py
@@ -24,5 +24,4 @@ pw = AttributeDict({
     'wf_collect': True,
     'trust_radius_min': 1.0e-3,
     'ion_dynamics': 'bfgs',
-    'cell_dynamics': 'bfgs'
 })

--- a/src/aiida_quantumespresso/utils/defaults/calculation/__init__.py
+++ b/src/aiida_quantumespresso/utils/defaults/calculation/__init__.py
@@ -21,5 +21,8 @@ pw = AttributeDict({
     'press_conv_thr': 0.5,
     'smearing': '',
     'startmag': 0.,
-    'wf_collect': False,
+    'wf_collect': True,
+    'trust_radius_min': 1.0e-3,
+    'ion_dynamics': 'bfgs',
+    'cell_dynamics': 'bfgs'
 })

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -33,7 +33,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         'delta_factor_max_seconds': 0.95,
         'delta_factor_nbnd': 0.05,
         'delta_minimum_nbnd': 4,
-        'delta_factor_trast_radius_min': 0.1,
+        'delta_factor_trust_radius_min': 0.1,
     })
 
     @classmethod

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -525,7 +525,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
 
         self.ctx.inputs.structure = calculation.outputs.output_structure
 
-        self.set_restart_type(RestartType.FROM_SCRATCH)
+        self.set_restart_type(RestartType.FROM_CHARGE_DENSITY, calculation.outputs.remote_folder)
         self.report_error_handled(calculation, action)
         return ProcessHandlerReport(True)
 
@@ -547,7 +547,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         self.ctx.inputs.structure = calculation.outputs.output_structure
         action = 'no ionic convergence but clean shutdown: restarting from scratch but using output structure.'
 
-        self.set_restart_type(RestartType.FROM_SCRATCH)
+        self.set_restart_type(RestartType.FROM_CHARGE_DENSITY, calculation.outputs.remote_folder)
         self.report_error_handled(calculation, action)
         return ProcessHandlerReport(True)
 

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -484,29 +484,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         return ProcessHandlerReport(True, self.exit_codes.ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF)
 
     @process_handler(
-        priority=560,
-        exit_codes=[
-            PwCalculation.exit_codes.ERROR_IONIC_CONVERGENCE_NOT_REACHED,
-            PwCalculation.exit_codes.ERROR_IONIC_CYCLE_EXCEEDED_NSTEP,
-            PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_FAILURE,
-            PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_AND_FINAL_SCF_FAILURE,
-        ]
-    )
-    def handle_relax_recoverable_ionic_convergence_error(self, calculation):
-        """Handle various exit codes for recoverable `relax` calculations with failed ionic convergence.
-
-        These exit codes signify that the ionic convergence thresholds were not met, but the output structure is usable,
-        so the solution is to simply restart from scratch but from the output structure.
-        """
-        self.ctx.inputs.structure = calculation.outputs.output_structure
-        action = 'no ionic convergence but clean shutdown: restarting from scratch but using output structure.'
-
-        self.set_restart_type(RestartType.FROM_SCRATCH)
-        self.report_error_handled(calculation, action)
-        return ProcessHandlerReport(True)
-
-    @process_handler(
-        priority=559,
+        priority=561,
         exit_codes=[
             PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_FAILURE,
             PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_AND_FINAL_SCF_FAILURE,
@@ -546,6 +524,28 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             return ProcessHandlerReport(False)
 
         self.ctx.inputs.structure = calculation.outputs.output_structure
+
+        self.set_restart_type(RestartType.FROM_SCRATCH)
+        self.report_error_handled(calculation, action)
+        return ProcessHandlerReport(True)
+
+    @process_handler(
+        priority=560,
+        exit_codes=[
+            PwCalculation.exit_codes.ERROR_IONIC_CONVERGENCE_NOT_REACHED,
+            PwCalculation.exit_codes.ERROR_IONIC_CYCLE_EXCEEDED_NSTEP,
+            PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_FAILURE,
+            PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_AND_FINAL_SCF_FAILURE,
+        ]
+    )
+    def handle_relax_recoverable_ionic_convergence_error(self, calculation):
+        """Handle various exit codes for recoverable `relax` calculations with failed ionic convergence.
+
+        These exit codes signify that the ionic convergence thresholds were not met, but the output structure is usable,
+        so the solution is to simply restart from scratch but from the output structure.
+        """
+        self.ctx.inputs.structure = calculation.outputs.output_structure
+        action = 'no ionic convergence but clean shutdown: restarting from scratch but using output structure.'
 
         self.set_restart_type(RestartType.FROM_SCRATCH)
         self.report_error_handled(calculation, action)

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -205,10 +205,18 @@ def test_handle_vcrelax_converged_except_final_scf(generate_workchain_pw):
         PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_AND_FINAL_SCF_FAILURE,
     )
 )
-def test_handle_relax_recoverable_ionic_convergence_error(generate_workchain_pw, generate_structure, exit_code):
+def test_handle_relax_recoverable_ionic_convergence_error(
+    generate_workchain_pw, generate_structure, generate_remote_data, fixture_localhost, exit_code
+):
     """Test `PwBaseWorkChain.handle_relax_recoverable_ionic_convergence_error`."""
     structure = generate_structure()
-    process = generate_workchain_pw(pw_outputs={'output_structure': structure}, exit_code=exit_code)
+    remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
+    process = generate_workchain_pw(
+        pw_outputs={
+            'output_structure': structure,
+            'remote_folder': remote_data
+        }, exit_code=exit_code
+    )
     process.setup()
 
     result = process.handle_relax_recoverable_ionic_convergence_error(process.ctx.children[-1])
@@ -228,11 +236,17 @@ def test_handle_relax_recoverable_ionic_convergence_error(generate_workchain_pw,
     )
 )
 def test_handle_relax_recoverable_ionic_convergence_bfgs_history_error(
-    generate_workchain_pw, generate_structure, exit_code
+    generate_workchain_pw, generate_structure, generate_remote_data, fixture_localhost, exit_code
 ):
     """Test `PwBaseWorkChain.handle_relax_recoverable_ionic_convergence_bfgs_history_error`."""
     structure = generate_structure()
-    process = generate_workchain_pw(pw_outputs={'output_structure': structure}, exit_code=exit_code)
+    remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
+    process = generate_workchain_pw(
+        pw_outputs={
+            'output_structure': structure,
+            'remote_folder': remote_data
+        }, exit_code=exit_code
+    )
     process.setup()
 
     # For `relax`, switch to `damp` immediately and then to `fire`

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -219,6 +219,8 @@ def test_handle_relax_recoverable_ionic_convergence_error(
     )
     process.setup()
 
+    process.ctx.inputs.parameters['CONTROL']['calculation'] = 'relax'
+    process.ctx.inputs.parameters.setdefault('IONS', {})['ion_dynamics'] = 'bfgs'
     result = process.handle_relax_recoverable_ionic_convergence_error(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
     assert result.do_break
@@ -249,23 +251,19 @@ def test_handle_relax_recoverable_ionic_convergence_bfgs_history_error(
     )
     process.setup()
 
-    # For `relax`, switch to `damp` immediately and then to `fire`
+    # For `relax`, switch to `damp`
     process.ctx.inputs.parameters['CONTROL']['calculation'] = 'relax'
+    process.ctx.inputs.parameters.setdefault('IONS', {})['ion_dynamics'] = 'bfgs'
     result = process.handle_relax_recoverable_ionic_convergence_bfgs_history_error(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
     assert result.do_break
     assert result.exit_code.status == 0
     assert process.ctx.inputs.parameters['IONS']['ion_dynamics'] == 'damp'
 
-    result = process.handle_relax_recoverable_ionic_convergence_bfgs_history_error(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert result.do_break
-    assert result.exit_code.status == 0
-    assert process.ctx.inputs.parameters['IONS']['ion_dynamics'] == 'fire'
-
     # For `vc-relax`, try changing first the `trust_min_radius`
     process.ctx.inputs.parameters['CONTROL']['calculation'] = 'vc-relax'
-    process.ctx.inputs.parameters['IONS']['ion_dynamics'] = 'bfgs'
+    process.ctx.inputs.parameters.setdefault('IONS', {})['ion_dynamics'] = 'bfgs'
+    process.ctx.inputs.parameters.setdefault('CELL', {})['cell_dynamics'] = 'bfgs'
     result = process.handle_relax_recoverable_ionic_convergence_bfgs_history_error(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
     assert result.do_break

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -280,14 +280,6 @@ def test_handle_relax_recoverable_ionic_convergence_bfgs_history_error(
     assert process.ctx.inputs.parameters['IONS']['ion_dynamics'] == 'damp'
     assert process.ctx.inputs.parameters['CELL']['cell_dynamics'] == 'damp-w'
 
-    result = process.handle_relax_recoverable_ionic_convergence_bfgs_history_error(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert not result.do_break
-    assert result.exit_code.status == 0
-
-    result = process.inspect_process()
-    assert result.status == 0
-
 
 def test_handle_vcrelax_recoverable_fft_significant_volume_contraction_error(generate_workchain_pw, generate_structure):
     """Test `PwBaseWorkChain.handle_vcrelax_recoverable_fft_significant_volume_contraction_error`."""


### PR DESCRIPTION
Sometimes the BFGS algorithm for ionic minimizaiton fails, and the current handler simply restart from scratch. This might work, but here we try to improve upon this simplistic solution, trying first to lower the trusted radius, and then trying to switch algorithm.