### PR TITLE
`PhBaseWorkChain`: better handler for convergence

### DIFF
--- a/src/aiida_quantumespresso/workflows/protocols/ph/base.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/ph/base.yaml
@@ -12,6 +12,8 @@ default_inputs:
                 withmpi: True
         parameters:
             INPUTPH:
+                alpha_mix: 0.4
+                nmix_ph: 8
                 tr2_ph: 1.0e-18
 
 default_protocol: balanced

--- a/tests/workflows/ph/test_base.py
+++ b/tests/workflows/ph/test_base.py
@@ -122,15 +122,28 @@ def test_handle_convergence_not_reached(generate_workchain_ph):
     process.setup()
     process.validate_parameters()
 
+    result = process.handle_convergence_not_reached(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert process.ctx.inputs.parameters['INPUTPH']['nmix_ph'] == 8
+
     alpha_new = PhBaseWorkChain.defaults.alpha_mix * PhBaseWorkChain.defaults.delta_factor_alpha_mix
+
+    for _ in range(2):  # this is dependent on PhBaseWorkChain.defaults.delta_factor_alpha_mix
+        result = process.handle_convergence_not_reached(process.ctx.children[-1])
+        assert isinstance(result, ProcessHandlerReport)
+        assert result.do_break
+        assert process.ctx.inputs.parameters['INPUTPH']['alpha_mix(1)'] == alpha_new
+        alpha_new = alpha_new * PhBaseWorkChain.defaults.delta_factor_alpha_mix
 
     result = process.handle_convergence_not_reached(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
     assert result.do_break
-    assert process.ctx.inputs.parameters['INPUTPH']['alpha_mix(1)'] == alpha_new
+    assert process.ctx.inputs.parameters['INPUTPH']['alpha_mix(20)'] == 0.4
 
-    result = process.inspect_process()
-    assert result.status == 0
+    result = process.handle_convergence_not_reached(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert not result.do_break
 
 
 def test_handle_diagonalization_errors(generate_workchain_ph):

--- a/tests/workflows/protocols/ph/test_base/test_default.yml
+++ b/tests/workflows/protocols/ph/test_base/test_default.yml
@@ -10,6 +10,8 @@ ph:
       withmpi: true
   parameters:
     INPUTPH:
+      alpha_mix: 0.4
+      nmix_ph: 8
       tr2_ph: 1.0e-18
 qpoints_distance: 0.3
 qpoints_force_parity: false

--- a/tests/workflows/protocols/ph/test_base/test_qpoints_list.yml
+++ b/tests/workflows/protocols/ph/test_base/test_qpoints_list.yml
@@ -10,6 +10,8 @@ ph:
       withmpi: true
   parameters:
     INPUTPH:
+      alpha_mix: 0.4
+      nmix_ph: 8
       tr2_ph: 1.0e-18
 qpoints:
 - - 2


### PR DESCRIPTION
Plain lowering down the alpha mix could not work always. The `nmix_ph` is already an improvement, leading to the usage of more iterations into the mixing. The rate of the alpha mix change is also increased, and below a certain threshold a multi mix approach is tried. Afterwards, the handler finishes the strategies.