### PR TITLE
xmlschema dep to 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     'pydantic~=1.10,>=1.10.8',
     'packaging',
     'qe-tools~=2.0',
-    'xmlschema~=1.2,>=1.2.5'
+    'xmlschema~=2.0'
 ]
 
 [project.urls]

--- a/src/aiida_quantumespresso/parsers/parse_raw/cp.py
+++ b/src/aiida_quantumespresso/parsers/parse_raw/cp.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from xml.dom.minidom import parseString
-
-from xmlschema.etree import ElementTree
+from xml.etree import ElementTree
 
 from aiida_quantumespresso.parsers import QEOutputParsingError
 from aiida_quantumespresso.parsers.parse_xml.cp.legacy import parse_cp_xml_output

--- a/src/aiida_quantumespresso/parsers/parse_xml/pw/parse.py
+++ b/src/aiida_quantumespresso/parsers/parse_xml/pw/parse.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from xmlschema.etree import ElementTree
+from xml.etree import ElementTree
 
 from aiida_quantumespresso.parsers.parse_xml.exceptions import XMLParseError
 from aiida_quantumespresso.parsers.parse_xml.parse import parse_xml_post_6_2


### PR DESCRIPTION
Fixes #989 

the interface is unchanged but a moved module

the test suite is passing in python 3.12. 

tested with

```
aiida-core==2.4.2
aiida-pseudo==1.4.0
-e git+ssh://git@github.com/rikigigi/aiida-quantumespresso@9d36452ab616a4ce64842c2acdb27d12ee8d1fdc#egg=aiida_quantumespresso
aio-pika==6.8.1
aiormq==3.3.1
alembic==1.12.1
archive-path==0.4.2
ase==3.22.1
asn1crypto==1.5.1
astroid==2.15.8
asttokens==2.4.1
async-generator==1.10
attrs==23.1.0
bcrypt==4.1.1
certifi==2023.11.17
cffi==1.16.0
cfgv==3.4.0
charset-normalizer==3.3.2
circus==0.18.0
click==8.1.7
click-spinner==0.1.10
contourpy==1.2.0
cryptography==41.0.7
cycler==0.12.1
decorator==5.1.1
deprecation==2.1.0
dill==0.3.7
disk-objectstore==0.6.0
distlib==0.3.7
docstring-parser==0.15
elementpath==4.1.5
executing==2.0.1
filelock==3.13.1
fonttools==4.45.1
future==0.18.3
graphviz==0.20.1
greenlet==3.0.1
identify==2.5.32
idna==3.6
importlib-metadata==4.13.0
importlib-resources==6.1.1
iniconfig==2.0.0
ipython==8.18.1
isort==5.12.0
jedi==0.18.2
Jinja2==3.1.2
joblib==1.3.2
jsonschema==3.2.0
kiwipy==0.7.8
kiwisolver==1.4.5
latexcodec==2.0.1
lazy-object-proxy==1.9.0
Mako==1.3.0
MarkupSafe==2.1.3
matplotlib==3.8.2
matplotlib-inline==0.1.6
mccabe==0.7.0
monty==2023.11.3
mpmath==1.3.0
multidict==6.0.4
nest-asyncio==1.5.8
networkx==3.2.1
nodeenv==1.8.0
numpy==1.26.2
packaging==23.2
palettable==3.3.3
pamqp==2.3.0
pandas==2.1.3
paramiko==2.12.0
parso==0.8.3
pexpect==4.9.0
pg8000==1.30.3
pgsu==0.2.4
pgtest==1.3.2
Pillow==10.1.0
Pint==0.16.1
platformdirs==4.0.0
plotly==5.18.0
pluggy==1.3.0
plumpy==0.21.10
ply==3.11
pre-commit==2.21.0
prompt-toolkit==3.0.41
psutil==5.9.6
psycopg2-binary==2.9.9
ptyprocess==0.7.0
pure-eval==0.2.2
py==1.11.0
pybtex==0.24.0
PyCifRW==4.4.6
pycparser==2.21
pydantic==1.10.13
Pygments==2.17.2
pylint==2.17.7
pylint_aiida==0.1.1
pymatgen==2023.11.12
PyMySQL==0.9.3
PyNaCl==1.5.0
pyparsing==3.1.1
pyrsistent==0.20.0
pytest==6.2.5
pytest-datadir==1.5.0
pytest-regressions==2.5.0
python-dateutil==2.8.2
pytray==0.3.4
pytz==2021.3
PyYAML==6.0.1
pyzmq==25.1.1
qe-tools==2.1.0
requests==2.31.0
ruamel.yaml==0.18.5
ruamel.yaml.clib==0.2.8
scipy==1.11.4
scramp==1.4.4
seekpath==1.9.7
setuptools==69.0.2
shortuuid==1.0.11
six==1.16.0
spglib==2.1.0
SQLAlchemy==1.4.50
stack-data==0.6.3
sympy==1.12
tabulate==0.8.10
tenacity==8.2.3
toml==0.10.2
tomlkit==0.12.3
tornado==6.4
tqdm==4.66.1
traitlets==5.14.0
typing_extensions==4.8.0
tzdata==2023.3
uncertainties==3.1.7
upf-to-json==0.9.5
urllib3==2.1.0
virtualenv==20.24.7
wcwidth==0.2.12
wrapt==1.16.0
xmlschema==2.5.0
yarl==1.9.3
zipp==3.17.0

```

solves https://github.com/aiidateam/aiida-quantumespresso/issues/989