### PR TITLE
Bump default SSSP version in protocol to v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
             run: verdi code create core.code.installed -n --config .github/config/code-ph.yaml --filepath-executable $(which ph.x)
 
         -   name: Setup SSSP
-            run: aiida-pseudo install sssp -v 1.2 -x PBEsol -p efficiency
+            run: aiida-pseudo install sssp -v 1.3 -x PBEsol -p efficiency
 
         -   name: Run test script
             run: python .github/scripts/run_documentation_scripts.py

--- a/docs/source/howto/calculations/pw.md
+++ b/docs/source/howto/calculations/pw.md
@@ -207,7 +207,7 @@ from ase.build import bulk
 from aiida.orm import StructureData, load_code, load_group
 
 # Load the pseudopotential family whose pseudos to use
-family = load_group('SSSP/1.1/PBE/effiency')
+family = load_group('SSSP/1.3/PBEsol/effiency')
 structure = StructureData(ase=bulk('GaAs', 'fcc', 5.4))
 
 builder = load_code('pw').get_builder()
@@ -226,7 +226,7 @@ from ase.build import bulk
 from aiida.orm import StructureData, load_code, load_group
 
 # Load the pseudopotential family whose pseudos to use
-family = load_group('SSSP/1.1/PBE/effiency')
+family = load_group('SSSP/1.3/PBEsol/effiency')
 structure = StructureData(ase=bulk('GaAs', 'fcc', 5.4))
 
 builder = load_code('pw').get_builder()

--- a/docs/source/installation/index.md
+++ b/docs/source/installation/index.md
@@ -212,10 +212,10 @@ $ pip install aiida-pseudo
 ```
 
 At a minimum, at least one pseudo potential family should be installed.
-We recommend using the [SSSP] with the PBEsol functional:
+We recommend using the [SSSP] v1.3 with the PBEsol functional:
 
 ```console
-$ aiida-pseudo install sssp -x PBEsol
+$ aiida-pseudo install sssp -v 1.3 -x PBEsol
 ```
 
 For more detailed information on installing other pseudo potential families, please refer to the documentation of [aiida-pseudo].

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
     'aiida_core[atomic_tools]~=2.3',
-    'aiida-pseudo~=1.0',
+    'aiida-pseudo~=1.1',
     'click~=8.0',
     'importlib_resources',
     'jsonschema',

--- a/src/aiida_quantumespresso/workflows/protocols/pw/base.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pw/base.yaml
@@ -6,7 +6,7 @@ default_inputs:
     meta_parameters:
         conv_thr_per_atom: 0.2e-9
         etot_conv_thr_per_atom: 1.e-5
-    pseudo_family: 'SSSP/1.2/PBEsol/efficiency'
+    pseudo_family: 'SSSP/1.3/PBEsol/efficiency'
     pw:
         metadata:
             options:
@@ -38,7 +38,7 @@ protocols:
         meta_parameters:
             conv_thr_per_atom: 0.1e-9
             etot_conv_thr_per_atom: 0.5e-5
-        pseudo_family: 'SSSP/1.2/PBEsol/precision'
+        pseudo_family: 'SSSP/1.3/PBEsol/precision'
         pw:
             parameters:
                 CONTROL:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,7 +171,7 @@ def sssp(aiida_profile, generate_upf_data):
                 'cutoff_rho': 240.0,
             }
 
-        label = 'SSSP/1.2/PBEsol/efficiency'
+        label = 'SSSP/1.3/PBEsol/efficiency'
         family = SsspFamily.create_from_folder(dirpath, label)
 
     family.set_cutoffs(cutoffs, stringency, unit='Ry')


### PR DESCRIPTION
This is required by https://github.com/aiidalab/aiidalab-qe/pull/578. It is not that easy to decouple reading protocol from `aiida-quatumespresso` in QeApp, if the override is not provided, it will always fallback to the default pseudo family which may not aligned between the qe plugin and the qe app. 

It would be great after this change, a new patch release can be made. Or it has to be a minor version bump for `aiida-quantumespresso`?