### PR TITLE
Tests: Revert change to `fixture_code`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name,too-many-statements,unsubscriptable-object
+# pylint: disable=redefined-outer-name,too-many-statements
 """Initialise a text database and profile for pytest."""
 from collections.abc import Mapping
 import io
@@ -51,17 +51,14 @@ def fixture_code(fixture_localhost):
     """Return an ``InstalledCode`` instance configured to run calculations of given entry point on localhost."""
 
     def _fixture_code(entry_point_name):
-        from aiida.orm import InstalledCode, QueryBuilder
+        from aiida.common import exceptions
+        from aiida.orm import InstalledCode, load_code
 
         label = f'test.{entry_point_name}'
 
-        query = QueryBuilder().append(
-            InstalledCode,
-            filters={'label': label},
-        )
         try:
-            return query.first()[0]
-        except TypeError:
+            return load_code(label=label)
+        except exceptions.NotExistent:
             return InstalledCode(
                 label=label,
                 computer=fixture_localhost,


### PR DESCRIPTION
In commit a68e1e15c11f6ad4461921145c648d75c49ff26c the `fixture_code` fixture was adapted to query for the first `InstalledCode` with the test code label instead of using `load_code`, as the latter would fail when running the new parametrized PDOS tests in parallel.

However, running tests in parallel versus the same storage backend can potentially lead to all sorts of problems. So instead of providing a somewhat hacky fix for this case, we revert the changes made to `fixture_code` and avoid running the tests in parallel.