### PR TITLE
Protocols: Update k-point sampling protocols

### DIFF
--- a/src/aiida_quantumespresso/workflows/protocols/pdos.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pdos.yaml
@@ -35,11 +35,11 @@ default_inputs:
                     num_machines: 1
                 max_wallclock_seconds: 43200  # Twelve hours
                 withmpi: True
-default_protocol: moderate
+default_protocol: balanced
 protocols:
-    moderate:
+    balanced:
         description: 'Protocol to perform a projected density of states calculation at normal precision at moderate computational cost.'
-    precise:
+    stringent:
         description: 'Protocol to perform a projected density of states structure calculation at high precision at higher computational cost.'
         dos:
             parameters:

--- a/src/aiida_quantumespresso/workflows/protocols/ph/base.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/ph/base.yaml
@@ -14,11 +14,11 @@ default_inputs:
             INPUTPH:
                 tr2_ph: 1.0e-18
 
-default_protocol: moderate
+default_protocol: balanced
 protocols:
-    moderate:
+    balanced:
         description: 'Protocol to perform the computation at normal precision at moderate computational cost.'
-    precise:
+    stringent:
         description: 'Protocol to perform the computation at high precision at higher computational cost.'
         qpoints_distance: 0.2
         ph:

--- a/src/aiida_quantumespresso/workflows/protocols/pw/bands.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pw/bands.yaml
@@ -17,11 +17,11 @@ default_inputs:
                     diagonalization: paro
                     diago_full_acc: True
                     startingpot: file
-default_protocol: moderate
+default_protocol: balanced
 protocols:
-    moderate:
+    balanced:
         description: 'Protocol to perform a band structure calculation at normal precision at moderate computational cost.'
-    precise:
+    stringent:
         description: 'Protocol to perform a band structure calculation at high precision at higher computational cost.'
         bands_kpoints_distance: 0.015
     fast:

--- a/src/aiida_quantumespresso/workflows/protocols/pw/base.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pw/base.yaml
@@ -24,15 +24,15 @@ default_inputs:
                 nosym: False
                 occupations: smearing
                 smearing: cold
-                degauss: 0.01
+                degauss: 0.02
             ELECTRONS:
                 electron_maxstep: 80
                 mixing_beta: 0.4
-default_protocol: moderate
+default_protocol: balanced
 protocols:
-    moderate:
+    balanced:
         description: 'Protocol to perform the computation at normal precision at moderate computational cost.'
-    precise:
+    stringent:
         description: 'Protocol to perform the computation at high precision at higher computational cost.'
         kpoints_distance: 0.10
         meta_parameters:
@@ -43,9 +43,11 @@ protocols:
             parameters:
                 CONTROL:
                     forc_conv_thr: 0.5e-4
+                SYSTEM:
+                    degauss: 0.0125
     fast:
         description: 'Protocol to perform the computation at low precision at minimal computational cost for testing purposes.'
-        kpoints_distance: 0.50
+        kpoints_distance: 0.30
         meta_parameters:
             conv_thr_per_atom: 0.4e-9
             etot_conv_thr_per_atom: 1.e-4
@@ -53,3 +55,5 @@ protocols:
             parameters:
                 CONTROL:
                     forc_conv_thr: 1.e-3
+                SYSTEM:
+                    degauss: 0.0275

--- a/src/aiida_quantumespresso/workflows/protocols/pw/relax.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pw/relax.yaml
@@ -13,11 +13,11 @@ default_inputs:
             parameters:
                 CONTROL:
                     calculation: scf
-default_protocol: moderate
+default_protocol: balanced
 protocols:
-    moderate:
+    balanced:
         description: 'Protocol to perform a relaxation at normal precision at moderate computational cost.'
-    precise:
+    stringent:
         description: 'Protocol to perform a relaxation at high precision at higher computational cost.'
         volume_convergence: 0.01
     fast:

--- a/src/aiida_quantumespresso/workflows/protocols/utils.py
+++ b/src/aiida_quantumespresso/workflows/protocols/utils.py
@@ -56,9 +56,15 @@ class ProtocolMixin:
         try:
             protocol_inputs = data['protocols'][protocol]
         except KeyError as exception:
-            raise ValueError(
-                f'`{protocol}` is not a valid protocol. Call ``get_available_protocols`` to show available protocols.'
-            ) from exception
+
+            alias_protocol = cls._check_if_alias(protocol)
+            if alias_protocol is not None:
+                protocol_inputs = data['protocols'][alias_protocol]
+            else:
+                raise ValueError(
+                    f'`{protocol}` is not a valid protocol. Call ``get_available_protocols`` to show available '
+                    'protocols.'
+                ) from exception
         inputs = recursive_merge(data['default_inputs'], protocol_inputs)
         inputs.pop('description')
 
@@ -76,6 +82,15 @@ class ProtocolMixin:
         """Return the contents of the protocol file for workflow class."""
         with cls.get_protocol_filepath().open() as file:
             return yaml.safe_load(file)
+
+    @staticmethod
+    def _check_if_alias(alias: str):
+        """Check if a given alias corresponds to a valid protocol."""
+        aliases_dict = {
+            'moderate': 'balanced',
+            'precise': 'stringent',
+        }
+        return aliases_dict.get(alias, None)
 
 
 def recursive_merge(left: dict, right: dict) -> dict:

--- a/src/aiida_quantumespresso/workflows/protocols/xps.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/xps.yaml
@@ -3,11 +3,11 @@ default_inputs:
     abs_atom_marker: X
     voight_gamma: 0.3
     voight_sigma: 0.3
-default_protocol: moderate
+default_protocol: balanced
 protocols:
-    moderate:
+    balanced:
         description: 'Protocol to perform an XPS calculation at normal precision at moderate computational cost.'
-    precise:
+    stringent:
         description: 'Protocol to perform an XPS calculation at high precision at higher computational cost.'
     fast:
         description: 'Protocol to perform an XPS calculation at low precision at minimal computational cost for testing purposes.'

--- a/src/aiida_quantumespresso/workflows/protocols/xspectra/base.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/xspectra/base.yaml
@@ -26,11 +26,11 @@ default_inputs:
                     num_machines: 1
                 max_wallclock_seconds: 43200  # Twelve hours
                 withmpi: True
-default_protocol: moderate
+default_protocol: balanced
 protocols:
-    moderate:
+    balanced:
         description: 'Protocol to perform an XANES dipole calculation at normal precision at moderate computational cost.'
-    precise:
+    stringent:
         description: 'Protocol to perform an XANES dipole calculation at high precision at higher computational cost.'
         kpoints_distance: 0.10
         xspectra:

--- a/src/aiida_quantumespresso/workflows/protocols/xspectra/core.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/xspectra/core.yaml
@@ -7,11 +7,11 @@ default_inputs:
         - [1., 0., 0.]
         - [0., 1., 0.]
         - [0., 0., 1.]
-default_protocol: moderate
+default_protocol: balanced
 protocols:
-    moderate:
+    balanced:
         description: 'Protocol to perform XANES dipole calculations at normal precision and moderate computational cost.'
-    precise:
+    stringent:
         description: 'Protocol to perform XANES dipole calculations at high precision and higher computational cost.'
     fast:
         description: 'Protocol to perform XANES dipole calculations at low precision and minimal computational cost for testing purposes.'

--- a/src/aiida_quantumespresso/workflows/protocols/xspectra/crystal.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/xspectra/crystal.yaml
@@ -4,11 +4,11 @@ default_inputs:
     return_all_powder_spectra: False
     core:
         get_powder_spectrum: True
-default_protocol: moderate
+default_protocol: balanced
 protocols:
-    moderate:
+    balanced:
         description: 'Protocol to perform XANES dipole calculations at normal precision and moderate computational cost.'
-    precise:
+    stringent:
         description: 'Protocol to perform XANES dipole calculations at high precision and higher computational cost.'
     fast:
         description: 'Protocol to perform XANES dipole calculations at low precision and minimal computational cost for testing purposes.'

--- a/tests/workflows/protocols/ph/test_base.py
+++ b/tests/workflows/protocols/ph/test_base.py
@@ -11,13 +11,13 @@ from aiida_quantumespresso.workflows.ph.base import PhBaseWorkChain
 def test_get_available_protocols():
     """Test ``PhBaseWorkChain.get_available_protocols``."""
     protocols = PhBaseWorkChain.get_available_protocols()
-    assert sorted(protocols.keys()) == ['fast', 'moderate', 'precise']
+    assert sorted(protocols.keys()) == ['balanced', 'fast', 'stringent']
     assert all('description' in protocol for protocol in protocols.values())
 
 
 def test_get_default_protocol():
     """Test ``PhBaseWorkChain.get_default_protocol``."""
-    assert PhBaseWorkChain.get_default_protocol() == 'moderate'
+    assert PhBaseWorkChain.get_default_protocol() == 'balanced'
 
 
 def test_default(fixture_code, data_regression, serialize_builder):

--- a/tests/workflows/protocols/pw/test_bands.py
+++ b/tests/workflows/protocols/pw/test_bands.py
@@ -10,13 +10,13 @@ from aiida_quantumespresso.workflows.pw.bands import PwBandsWorkChain
 def test_get_available_protocols():
     """Test ``PwBandsWorkChain.get_available_protocols``."""
     protocols = PwBandsWorkChain.get_available_protocols()
-    assert sorted(protocols.keys()) == ['fast', 'moderate', 'precise']
+    assert sorted(protocols.keys()) == ['balanced', 'fast', 'stringent']
     assert all('description' in protocol for protocol in protocols.values())
 
 
 def test_get_default_protocol():
     """Test ``PwBandsWorkChain.get_default_protocol``."""
-    assert PwBandsWorkChain.get_default_protocol() == 'moderate'
+    assert PwBandsWorkChain.get_default_protocol() == 'balanced'
 
 
 def test_default(fixture_code, generate_structure, data_regression, serialize_builder):

--- a/tests/workflows/protocols/pw/test_bands/test_default.yml
+++ b/tests/workflows/protocols/pw/test_bands/test_default.yml
@@ -25,7 +25,7 @@ bands:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
-        degauss: 0.01
+        degauss: 0.02
         ecutrho: 240.0
         ecutwfc: 30.0
         nosym: false
@@ -65,7 +65,7 @@ relax:
           electron_maxstep: 80
           mixing_beta: 0.4
         SYSTEM:
-          degauss: 0.01
+          degauss: 0.02
           ecutrho: 240.0
           ecutwfc: 30.0
           nosym: false
@@ -101,7 +101,7 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
-        degauss: 0.01
+        degauss: 0.02
         ecutrho: 240.0
         ecutwfc: 30.0
         nosym: false

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -11,13 +11,13 @@ from aiida_quantumespresso.workflows.pw.base import PwBaseWorkChain
 def test_get_available_protocols():
     """Test ``PwBaseWorkChain.get_available_protocols``."""
     protocols = PwBaseWorkChain.get_available_protocols()
-    assert sorted(protocols.keys()) == ['fast', 'moderate', 'precise']
+    assert sorted(protocols.keys()) == ['balanced', 'fast', 'stringent']
     assert all('description' in protocol for protocol in protocols.values())
 
 
 def test_get_default_protocol():
     """Test ``PwBaseWorkChain.get_default_protocol``."""
-    assert PwBaseWorkChain.get_default_protocol() == 'moderate'
+    assert PwBaseWorkChain.get_default_protocol() == 'balanced'
 
 
 def test_default(fixture_code, generate_structure, data_regression, serialize_builder):
@@ -28,6 +28,21 @@ def test_default(fixture_code, generate_structure, data_regression, serialize_bu
 
     assert isinstance(builder, ProcessBuilder)
     data_regression.check(serialize_builder(builder))
+
+
+@pytest.mark.parametrize('old_protocol,new_protocol', (
+    ('moderate', 'balanced'),
+    ('precise', 'stringent'),
+))
+def test_old_protocol_names(fixture_code, generate_structure, serialize_builder, old_protocol, new_protocol):
+    """Test that the old protocol names still work and produce the same builder contents."""
+    code = fixture_code('quantumespresso.pw')
+    structure = generate_structure('silicon')
+
+    old_builder = PwBaseWorkChain.get_builder_from_protocol(code, structure, protocol=old_protocol)
+    new_builder = PwBaseWorkChain.get_builder_from_protocol(code, structure, protocol=new_protocol)
+
+    assert serialize_builder(old_builder) == serialize_builder(new_builder)
 
 
 def test_electronic_type(fixture_code, generate_structure):

--- a/tests/workflows/protocols/pw/test_base/test_default.yml
+++ b/tests/workflows/protocols/pw/test_base/test_default.yml
@@ -22,7 +22,7 @@ pw:
       electron_maxstep: 80
       mixing_beta: 0.4
     SYSTEM:
-      degauss: 0.01
+      degauss: 0.02
       ecutrho: 240.0
       ecutwfc: 30.0
       nosym: false

--- a/tests/workflows/protocols/pw/test_relax.py
+++ b/tests/workflows/protocols/pw/test_relax.py
@@ -10,13 +10,13 @@ from aiida_quantumespresso.workflows.pw.relax import PwRelaxWorkChain
 def test_get_available_protocols():
     """Test ``PwRelaxWorkChain.get_available_protocols``."""
     protocols = PwRelaxWorkChain.get_available_protocols()
-    assert sorted(protocols.keys()) == ['fast', 'moderate', 'precise']
+    assert sorted(protocols.keys()) == ['balanced', 'fast', 'stringent']
     assert all('description' in protocol for protocol in protocols.values())
 
 
 def test_get_default_protocol():
     """Test ``PwRelaxWorkChain.get_default_protocol``."""
-    assert PwRelaxWorkChain.get_default_protocol() == 'moderate'
+    assert PwRelaxWorkChain.get_default_protocol() == 'balanced'
 
 
 def test_default(fixture_code, generate_structure, data_regression, serialize_builder):

--- a/tests/workflows/protocols/pw/test_relax/test_default.yml
+++ b/tests/workflows/protocols/pw/test_relax/test_default.yml
@@ -26,7 +26,7 @@ base:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
-        degauss: 0.01
+        degauss: 0.02
         ecutrho: 240.0
         ecutwfc: 30.0
         nosym: false
@@ -59,7 +59,7 @@ base_final_scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
-        degauss: 0.01
+        degauss: 0.02
         ecutrho: 240.0
         ecutwfc: 30.0
         nosym: false

--- a/tests/workflows/protocols/test_pdos.py
+++ b/tests/workflows/protocols/test_pdos.py
@@ -24,13 +24,13 @@ def get_pdos_generator_inputs(fixture_code, generate_structure):
 def test_get_available_protocols():
     """Test ``PdosWorkChain.get_available_protocols``."""
     protocols = PdosWorkChain.get_available_protocols()
-    assert sorted(protocols.keys()) == ['fast', 'moderate', 'precise']
+    assert sorted(protocols.keys()) == ['balanced', 'fast', 'stringent']
     assert all('description' in protocol for protocol in protocols.values())
 
 
 def test_get_default_protocol():
     """Test ``PdosWorkChain.get_default_protocol``."""
-    assert PdosWorkChain.get_default_protocol() == 'moderate'
+    assert PdosWorkChain.get_default_protocol() == 'balanced'
 
 
 def test_default(get_pdos_generator_inputs, data_regression, serialize_builder):

--- a/tests/workflows/protocols/test_pdos/test_default.yml
+++ b/tests/workflows/protocols/test_pdos/test_default.yml
@@ -79,7 +79,7 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
-        degauss: 0.01
+        degauss: 0.02
         ecutrho: 240.0
         ecutwfc: 30.0
         nosym: false

--- a/tests/workflows/protocols/xspectra/test_base.py
+++ b/tests/workflows/protocols/xspectra/test_base.py
@@ -66,13 +66,13 @@ def get_xspectra_generator_inputs(fixture_code, generate_xspectra_calc_job_node)
 def test_get_available_protocols():
     """Test ``XspectraBaseWorkChain.get_available_protocols()``."""
     protocols = XspectraBaseWorkChain.get_available_protocols()
-    assert sorted(protocols.keys()) == ['fast', 'moderate', 'precise', 'replot']
+    assert sorted(protocols.keys()) == ['balanced', 'fast', 'replot', 'stringent']
     assert all('description' in protocol for protocol in protocols.values())
 
 
 def test_get_default_protocol():
     """Test ``XspectraBaseWorkChain.get_default_protocol``."""
-    assert XspectraBaseWorkChain.get_default_protocol() == 'moderate'
+    assert XspectraBaseWorkChain.get_default_protocol() == 'balanced'
 
 
 def test_default(get_xspectra_generator_inputs, data_regression, serialize_builder):

--- a/tests/workflows/protocols/xspectra/test_core.py
+++ b/tests/workflows/protocols/xspectra/test_core.py
@@ -11,13 +11,13 @@ from aiida_quantumespresso.workflows.xspectra.core import XspectraCoreWorkChain
 def test_get_available_protocols():
     """Test ``XspectraCoreWorkChain.get_available_protocols``."""
     protocols = XspectraCoreWorkChain.get_available_protocols()
-    assert sorted(protocols.keys()) == ['fast', 'moderate', 'precise']
+    assert sorted(protocols.keys()) == ['balanced', 'fast', 'stringent']
     assert all('description' in protocol for protocol in protocols.values())
 
 
 def test_get_default_protocol():
     """Test ``XspectraCoreWorkChain.get_default_protocol``."""
-    assert XspectraCoreWorkChain.get_default_protocol() == 'moderate'
+    assert XspectraCoreWorkChain.get_default_protocol() == 'balanced'
 
 
 def test_get_available_treatments():
@@ -37,7 +37,7 @@ def test_overrides(fixture_code, generate_structure):
     pw_code = fixture_code('quantumespresso.pw')
     xs_code = fixture_code('quantumespresso.xspectra')
     structure = generate_structure('silicon')
-    protocol = 'moderate'
+    protocol = 'balanced'
     treatment_type = 'full'  # default treatment, sets `tot_charge` = 1
     overrides = {
         'scf': {

--- a/tests/workflows/protocols/xspectra/test_core/test_default.yml
+++ b/tests/workflows/protocols/xspectra/test_core/test_default.yml
@@ -41,7 +41,7 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
-        degauss: 0.01
+        degauss: 0.02
         ecutrho: 240.0
         ecutwfc: 30.0
         nosym: false

--- a/tests/workflows/protocols/xspectra/test_crystal.py
+++ b/tests/workflows/protocols/xspectra/test_crystal.py
@@ -11,13 +11,13 @@ from aiida_quantumespresso.workflows.xspectra.crystal import XspectraCrystalWork
 def test_get_available_protocols():
     """Test ``XspectraCrystalWorkChain.get_available_protocols``."""
     protocols = XspectraCrystalWorkChain.get_available_protocols()
-    assert sorted(protocols.keys()) == ['fast', 'moderate', 'precise']
+    assert sorted(protocols.keys()) == ['balanced', 'fast', 'stringent']
     assert all('description' in protocol for protocol in protocols.values())
 
 
 def test_get_default_protocol():
     """Test ``XspectraCrystalWorkChain.get_default_protocol``."""
-    assert XspectraCrystalWorkChain.get_default_protocol() == 'moderate'
+    assert XspectraCrystalWorkChain.get_default_protocol() == 'balanced'
 
 
 def test_default(fixture_code, generate_structure, data_regression, serialize_builder, generate_upf_data):

--- a/tests/workflows/protocols/xspectra/test_crystal/test_default.yml
+++ b/tests/workflows/protocols/xspectra/test_crystal/test_default.yml
@@ -29,7 +29,7 @@ core:
           electron_maxstep: 80
           mixing_beta: 0.4
         SYSTEM:
-          degauss: 0.01
+          degauss: 0.02
           ecutrho: 240.0
           ecutwfc: 30.0
           nosym: false
@@ -105,7 +105,7 @@ relax:
           electron_maxstep: 80
           mixing_beta: 0.4
         SYSTEM:
-          degauss: 0.01
+          degauss: 0.02
           ecutrho: 240.0
           ecutwfc: 30.0
           nosym: false


### PR DESCRIPTION
Based on more extensive tests that also involved a broad range of smearings, a new set of protocols were devised:

| Name       | Smearing (Ry) | k-points distance (1/A) |
|------------|---------------|-------------------------|
| Precision  |        0.0125 |                    0.10 |
| Efficiency |        0.0200 |                    0.15 |
| Fast       |        0.0275 |                    0.30 |

Here we already update the values in the `PwBaseWorkChain` protocol file. In a future PR it would be nice to set up a system for protocol aliasing, so we can also change the names without breaking protocol methods downstream.