### PR TITLE
Docs: Remove `aiida.manage.configuration.load_documentation_profile`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,9 +14,10 @@
 import pathlib
 import time
 
-from aiida.manage.configuration import load_documentation_profile
+from aiida.manage.configuration import Profile, load_profile
 
-load_documentation_profile()
+load_profile(Profile('docs', {'process_control': {}, 'storage': {}}))
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.


### PR DESCRIPTION
This was necessary when Django backends were still supported, but since
its removal in AiiDA v2.0 just loading the ORM no longer actually needs
to connect to a database. In principle, the documentation no longer
needs a profile whatsoever, except for `aiida-quantumespresso` the
AutoAPI still needs it because in loading the specifications of certain
`Process` classes, a profile is loaded. So the docs `conf.py` now loads
an empty dummy profile for this purpose.