### PR TITLE
Fixing grant for HORIZON-EUROHPC-JU-2021-COE-1 in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ See the `LICENSE.txt` file for more details.
 ## Acknowledgements
 We acknowledge support from:
 * the [NCCR MARVEL](http://nccr-marvel.ch/) funded by the Swiss National Science Foundation;
-* the EU Centre of Excellence "[MaX – Materials Design at the Exascale](http://www.max-centre.eu/)" (Horizon 2020 EINFRA-5, Grant No. 676598; H2020-INFRAEDI-2018-1, Grant No. 824143; HORIZON-EUROHPC-JU-2021-COE-1, Grant No. 101093324);
+* the EU Centre of Excellence "[MaX – Materials Design at the Exascale](http://www.max-centre.eu/)" (Horizon 2020 EINFRA-5, Grant No. 676598; H2020-INFRAEDI-2018-1, Grant No. 824143; HORIZON-EUROHPC-JU-2021-COE-1, Grant No. 101093374);
 * the European Union's Horizon 2020 research and innovation programme (Grant No. 957189, [project BIG-MAP](https://www.big-map.eu), also part of the [BATTERY 2030+ initiative](https://battery2030.eu), Grant No. 957213);
 * the [swissuniversities P-5 project "Materials Cloud"](https://www.materialscloud.org/swissuniversities).
 


### PR DESCRIPTION
Fixing: HORIZON-EUROHPC-JU-2021-COE-1, Grant No. 101093324.
The correct number is 101093374