### PR TITLE
Bug: `PhBaseWorkChain.set_qpoints` doesn't work as expected

### DIFF
--- a/src/aiida_quantumespresso/workflows/ph/base.py
+++ b/src/aiida_quantumespresso/workflows/ph/base.py
@@ -177,27 +177,26 @@ class PhBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         the case of the latter, the `KpointsData` will be constructed for the input `StructureData`
         from the parent_folder using the `create_kpoints_from_distance` calculation function.
         """
-
         try:
             qpoints = self.inputs.qpoints
         except AttributeError:
 
             try:
-                structure = self.ctx.inputs.ph.parent_folder.creator.output.output_structure
+                structure = self.ctx.inputs.parent_folder.creator.output.output_structure
             except AttributeError:
-                structure = self.ctx.inputs.ph.parent_folder.creator.inputs.structure
+                structure = self.ctx.inputs.parent_folder.creator.inputs.structure
 
             inputs = {
                 'structure': structure,
                 'distance': self.inputs.qpoints_distance,
-                'force_parity': self.inputs.qpoints_force_parity,
+                'force_parity': self.inputs.get('qpoints_force_parity', orm.Bool(False)),
                 'metadata': {
                     'call_link_label': 'create_qpoints_from_distance'
                 }
             }
             qpoints = create_kpoints_from_distance(**inputs)
 
-        self.ctx.inputs.ph['qpoints'] = qpoints
+        self.ctx.inputs['qpoints'] = qpoints
 
     def set_max_seconds(self, max_wallclock_seconds: None):
         """Set the `max_seconds` to a fraction of `max_wallclock_seconds` option to prevent out-of-walltime problems.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -597,7 +597,11 @@ def generate_inputs_ph(
     """Generate default inputs for a `PhCalculation."""
 
     def _generate_inputs_ph(with_output_structure=False):
-        """Generate default inputs for a `PhCalculation."""
+        """Generate default inputs for a `PhCalculation.
+
+        :param with_output_structure: whether the PwCalculation has a StructureData in its outputs.
+            This is needed to test some PhBaseWorkChain logics.
+        """
         from aiida.common import LinkType
         from aiida.orm import Dict, RemoteData
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -603,7 +603,12 @@ def generate_inputs_ph(
 
         from aiida_quantumespresso.utils.resources import get_default_options
 
-        pw_node = generate_calc_job_node(inputs={'parameters': Dict(), 'structure': generate_structure()})
+        pw_node = generate_calc_job_node(
+            entry_point_name='quantumespresso.pw', inputs={
+                'parameters': Dict(),
+                'structure': generate_structure()
+            }
+        )
         remote_folder = RemoteData(computer=fixture_localhost, remote_path='/tmp')
         remote_folder.base.links.add_incoming(pw_node, link_type=LinkType.CREATE, link_label='remote_folder')
         remote_folder.store()


### PR DESCRIPTION
Fixes #1004 

The `set_qpoints` method was untested and contained many typos and bugs, which would break the usage of the workchain when a `qpoints_distance` is used and would set wrong `qpoints` in the context inputs.