### PR TITLE
`PhBaseWorkChain`: skip q-points validation if ports are excluded

### DIFF
--- a/src/aiida_quantumespresso/workflows/ph/base.py
+++ b/src/aiida_quantumespresso/workflows/ph/base.py
@@ -69,9 +69,11 @@ class PhBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         # yapf: enable
 
     @classmethod
-    def validate_inputs(cls, inputs, ctx=None):  # pylint: disable=unused-argument
+    def validate_inputs(cls, value, port_namespace):  # pylint: disable=unused-argument
         """Validate the top level namespace."""
-        if 'qpoints_distance' not in inputs and 'qpoints' not in inputs:
+
+        if (('qpoints_distance' in port_namespace or 'qpoints' in port_namespace) and
+            'qpoints_distance' not in value and 'qpoints' not in value):
             return 'Neither `qpoints` nor `qpoints_distance` were specified.'
 
     @classmethod


### PR DESCRIPTION
Currently, the top-level `validate_inputs` validator for the `PhBaseWorkChain` will always check if either the `qpoints` or `qpoints_distance` inputs are provided. However, there are cases where a higher-level work chain that wraps the `PhBaseWorkChain` might provide the q-points input on the fly. Such a work chain would have to set the `PhBaseWorkChain` validator to `None` in its own `define` method.

However, as also discussed for a similar case for the `PwCalculation` in a389629, it's more elegant to check if the `qpoints_distance` and `qpoints` ports are present in the namespace. Typically a work chain that provides the q-points input on the fly will exclude these ports when exposing the `PhBaseWorkChain` inputs. By checking if the ports are present in the validator, we avoid having to set the validator to `None` as well in the higher-level work chain.