### PR TITLE
📚 `CHANGELOG.md`: improve release notes for `v4.5.0`

### DIFF
--- a/.github/workflows/update_changelog.py
+++ b/.github/workflows/update_changelog.py
@@ -30,6 +30,9 @@ DEFAULT_CHANGELOG_SECTIONS = """
 ### ⬆️ Update dependencies
 
 
+### 🧪 Tests
+
+
 ### ♻️ Refactor
 
 """


### PR DESCRIPTION
The release notes of `v4.5.0` did not add any explanation of the main changes and some useful code snippets. Since there was actually a breaking change related to how q-points are defined for the `PhBaseWorkChain`, adding some notes (that can then be copied to the documentation) is useful.

Moreover, the subsections for the full list of changes did not respect the same order as previous release notes, which offended the OCD of one of the more picky and annoying developers. Hence, we correct this egregious error, and also add a specific section to put commits that only affect tests.