### PR TITLE
First steps to make protocols scheduler agnostic

### DIFF
--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -381,6 +381,11 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
             metadata_dos['options'] = recursive_merge(metadata_dos['options'], options)
             metadata_projwfc['options'] = recursive_merge(metadata_projwfc['options'], options)
 
+        metadata_dos['options'] = cls.set_default_resources(metadata_dos['options'], dos_code.computer.scheduler_type)
+        metadata_projwfc['options'] = cls.set_default_resources(
+            metadata_projwfc['options'], projwfc_code.computer.scheduler_type
+        )
+
         builder = cls.get_builder()
         builder.structure = structure
         builder.clean_workdir = orm.Bool(inputs['clean_workdir'])

--- a/src/aiida_quantumespresso/workflows/ph/base.py
+++ b/src/aiida_quantumespresso/workflows/ph/base.py
@@ -125,7 +125,9 @@ class PhBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         metadata = inputs['ph']['metadata']
 
         if options:
-            metadata['options'] = recursive_merge(inputs['ph']['metadata']['options'], options)
+            metadata['options'] = recursive_merge(metadata['options'], options)
+
+        metadata['options'] = cls.set_default_resources(metadata['options'], code.computer.scheduler_type)
 
         # pylint: disable=no-member
         builder = cls.get_builder()

--- a/src/aiida_quantumespresso/workflows/protocols/pdos.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pdos.yaml
@@ -21,8 +21,6 @@ default_inputs:
                 DeltaE: 0.01
         metadata:
             options:
-                resources:
-                    num_machines: 1
                 max_wallclock_seconds: 43200  # Twelve hours
                 withmpi: True
     projwfc:
@@ -31,8 +29,6 @@ default_inputs:
                 DeltaE: 0.01
         metadata:
             options:
-                resources:
-                    num_machines: 1
                 max_wallclock_seconds: 43200  # Twelve hours
                 withmpi: True
 default_protocol: balanced

--- a/src/aiida_quantumespresso/workflows/protocols/ph/base.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/ph/base.yaml
@@ -6,8 +6,6 @@ default_inputs:
     ph:
         metadata:
             options:
-                resources:
-                    num_machines: 1
                 max_wallclock_seconds: 43200  # Twelve hours
                 withmpi: True
         parameters:

--- a/src/aiida_quantumespresso/workflows/protocols/pw/base.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pw/base.yaml
@@ -10,8 +10,6 @@ default_inputs:
     pw:
         metadata:
             options:
-                resources:
-                    num_machines: 1
                 max_wallclock_seconds: 43200  # Twelve hours
                 withmpi: True
         parameters:

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -236,7 +236,9 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         metadata = inputs['pw']['metadata']
 
         if options:
-            metadata['options'] = recursive_merge(inputs['pw']['metadata']['options'], options)
+            metadata['options'] = recursive_merge(metadata['options'], options)
+
+        metadata['options'] = cls.set_default_resources(metadata['options'], code.computer.scheduler_type)
 
         # pylint: disable=no-member
         builder = cls.get_builder()

--- a/tests/workflows/protocols/pw/test_bands.py
+++ b/tests/workflows/protocols/pw/test_bands.py
@@ -6,6 +6,8 @@ import pytest
 from aiida_quantumespresso.common.types import ElectronicType, RelaxType, SpinType
 from aiida_quantumespresso.workflows.pw.bands import PwBandsWorkChain
 
+pytestmark = pytest.mark.usefixtures('pseudo_family')
+
 
 def test_get_available_protocols():
     """Test ``PwBandsWorkChain.get_available_protocols``."""

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -7,6 +7,8 @@ import pytest
 from aiida_quantumespresso.common.types import ElectronicType, SpinType
 from aiida_quantumespresso.workflows.pw.base import PwBaseWorkChain
 
+pytestmark = pytest.mark.usefixtures('pseudo_family')
+
 
 def test_get_available_protocols():
     """Test ``PwBaseWorkChain.get_available_protocols``."""

--- a/tests/workflows/protocols/pw/test_relax.py
+++ b/tests/workflows/protocols/pw/test_relax.py
@@ -7,6 +7,8 @@ import pytest
 from aiida_quantumespresso.common.types import ElectronicType, RelaxType, SpinType
 from aiida_quantumespresso.workflows.pw.relax import PwRelaxWorkChain
 
+pytestmark = pytest.mark.usefixtures('pseudo_family')
+
 
 def test_get_available_protocols():
     """Test ``PwRelaxWorkChain.get_available_protocols``."""

--- a/tests/workflows/protocols/test_pdos.py
+++ b/tests/workflows/protocols/test_pdos.py
@@ -9,6 +9,8 @@ from aiida_quantumespresso.common.types import ElectronicType, SpinType
 
 PdosWorkChain = WorkflowFactory('quantumespresso.pdos')
 
+pytestmark = pytest.mark.usefixtures('pseudo_family')
+
 
 @pytest.fixture
 def get_pdos_generator_inputs(fixture_code, generate_structure):


### PR DESCRIPTION
Fixes #1010 

The current protocols implicitly rely on the `Slurm` scheduler, thus causing errors when users try to use ad different one, e.g. SGE as described in the issue. 
Here, the documentation of the `get_builder_from_protocol` method is extended to make the users aware of this behavior. Moreover, a warning is added in case no explicit `resources` are provided via the `options` argument, as this will cause errors in future versions.

@sphuber @mbercx Suggestions for a different phrasing or place where to put the additional documentation are very welcome. Moreover, I used a `UserWarning` because a `DeprecationWarning` somehow didn't appear. I'm not sure whether they are filtered at some point?
