### PR TITLE
add `should_run_scf` for PwBandsWorkChain

### DIFF
--- a/src/aiida_quantumespresso/workflows/pw/bands.py
+++ b/src/aiida_quantumespresso/workflows/pw/bands.py
@@ -289,7 +289,7 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
             inputs.pw.parameters['SYSTEM']['nbnd'] = nbnd
 
         # Otherwise set the current number of bands, unless explicitly set in the inputs
-        elif "scf" in self.inputs:
+        elif 'scf' in self.inputs:
             inputs.pw.parameters['SYSTEM'].setdefault('nbnd', self.ctx.current_number_of_bands)
 
         inputs = prepare_process_inputs(PwBaseWorkChain, inputs)


### PR DESCRIPTION
This PR sets the `scf` step as an option in the `PwBandsWorkChain`.

Use case:
- In aiidalab-qe, we want to run one `scf` in the main workflow, then pass the `remote_folder` to plugins, such as `bands` and `pdos`. This requires that the `scf` calculation is an option in the `PwBandsWorkChain`. 
 #https://github.com/aiidalab/aiidalab-qe/pull/631
