### PR TITLE
CLI: add test for data structure import

### DIFF
--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 
 def mock_launch_process(*_, **__):
-    """Mock the :meth:`~aiida_quantumespresso.cli.utilslaunch.launch_process` to be a no-op."""
+    """Mock the :meth:`~aiida_quantumespresso.cli.utils.launch.launch_process` to be a no-op."""
     return
 
 

--- a/tests/cli/data/test_structure.py
+++ b/tests/cli/data/test_structure.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Tests for the ``data structure import`` command."""
+from pathlib import Path
+import re
+
+import pytest
+
+from aiida_quantumespresso.cli.data.structure import cmd_import
+
+
+@pytest.mark.usefixtures('aiida_profile')
+def test_command_import(run_cli_command, filepath_tests):
+    """Test invoking the calculation launch command with only required inputs."""
+    filepath = str(Path(filepath_tests, 'cli', 'fixtures', 'pw.in').absolute())
+    options = [filepath]
+    result = run_cli_command(cmd_import, options=options)
+    match = r'.*parsed and stored StructureData<(\d+)> with formula (.+?)'
+    assert re.match(match, ' '.join(result.output_lines))
+
+    options = [filepath, '--dry-run']
+    result = run_cli_command(cmd_import, options=options)
+    match = r'.*parsed structure with formula (.+?)'
+    assert re.match(match, ' '.join(result.output_lines))

--- a/tests/cli/fixtures/pw.in
+++ b/tests/cli/fixtures/pw.in
@@ -1,0 +1,38 @@
+&CONTROL
+  calculation = 'scf'
+  etot_conv_thr =   2.0000000000d-05
+  forc_conv_thr =   1.0000000000d-04
+  outdir = './out/'
+  prefix = 'aiida'
+  pseudo_dir = './pseudo/'
+  tprnfor = .true.
+  tstress = .true.
+  verbosity = 'high'
+/
+&SYSTEM
+  degauss =   1.4699723600d-02
+  ecutrho =   2.4000000000d+02
+  ecutwfc =   3.0000000000d+01
+  ibrav = 0
+  nat = 2
+  nosym = .false.
+  ntyp = 1
+  occupations = 'smearing'
+  smearing = 'cold'
+/
+&ELECTRONS
+  conv_thr =   4.0000000000d-10
+  electron_maxstep = 80
+  mixing_beta =   4.0000000000d-01
+/
+ATOMIC_SPECIES
+Si     28.0855 Si.pbesol-n-rrkjus_psl.1.0.0.UPF
+ATOMIC_POSITIONS crystal
+Si           0.0000000000       0.0000000000       0.0000000000 
+Si           0.2500000000       0.2500000000       0.2500000000 
+K_POINTS automatic
+11 11 11 0 0 0
+CELL_PARAMETERS angstrom
+      2.7154800000       2.7154800000       0.0000000000
+      2.7154800000       0.0000000000       2.7154800000
+      0.0000000000       2.7154800000       2.7154800000


### PR DESCRIPTION
A test case for data structure import via cmdline using a QE pw.x input file is added to improve the robustness of the code.