### PR TITLE
`XspectraCrystalWorkChain`: Enable Symmetry Data Inputs

### DIFF
--- a/src/aiida_quantumespresso/workflows/functions/get_xspectra_structures.py
+++ b/src/aiida_quantumespresso/workflows/functions/get_xspectra_structures.py
@@ -360,6 +360,7 @@ def get_xspectra_structures(structure, **kwargs):  # pylint: disable=too-many-st
             new_supercell = get_supercell_result['new_supercell']
             output_params['supercell_factors'] = multiples
 
+        result['supercell'] = new_supercell
         output_params['supercell_num_sites'] = len(new_supercell.sites)
         output_params['supercell_cell_matrix'] = new_supercell.cell
         output_params['supercell_cell_lengths'] = new_supercell.cell_lengths

--- a/src/aiida_quantumespresso/workflows/xspectra/crystal.py
+++ b/src/aiida_quantumespresso/workflows/xspectra/crystal.py
@@ -461,15 +461,10 @@ class XspectraCrystalWorkChain(ProtocolMixin, WorkChain):
             # We assume otherwise that the user knows what they're doing and has set everything else
             # to their preferences correctly.
             for site_label, value in equivalent_sites_data.items():
-                entry_invalid = False
-
                 if not set(required_keys).issubset(set(value.keys())) :
                     invalid_entries.append(site_label)
-                    entry_invalid = True
                 elif value['symbol'] not in input_elements:
                     input_elements.append(value['symbol'])
-
-                if not entry_invalid:
                     if value['site_index'] < 0 or value['site_index'] >= len(structure.sites):
                         raise ValidationError(
                             f'The site index for {site_label} ({value["site_index"]}) is outside the range of '

--- a/src/aiida_quantumespresso/workflows/xspectra/crystal.py
+++ b/src/aiida_quantumespresso/workflows/xspectra/crystal.py
@@ -461,25 +461,20 @@ class XspectraCrystalWorkChain(ProtocolMixin, WorkChain):
             # We assume otherwise that the user knows what they're doing and has set everything else
             # to their preferences correctly.
             for site_label, value in equivalent_sites_data.items():
-                required_keys_found = []
+                entry_invalid = False
 
-                if value['site_index'] < 0:
-                    raise ValidationError(
-                        f'The site index for {site_label} ({value["site_index"]}) is below the range of '
-                        + f'sites within the structure (0-{len(structure.sites) -1}).'
-                    )
-                if value['site_index'] >= len(structure.sites):
-                    raise ValidationError(
-                        f'The site index for {site_label} ({value["site_index"]}) is above the range of '
-                        + f'sites within the structure (0-{len(structure.sites) -1}).'
-                    )
-                for key in value:
-                    if key in required_keys:
-                        required_keys_found.append(key)
-                if sorted(required_keys_found) != required_keys:
+                if not set(required_keys).issubset(set(value.keys())) :
                     invalid_entries.append(site_label)
+                    entry_invalid = True
                 elif value['symbol'] not in input_elements:
                     input_elements.append(value['symbol'])
+
+                if not entry_invalid:
+                    if value['site_index'] < 0 or value['site_index'] >= len(structure.sites):
+                        raise ValidationError(
+                            f'The site index for {site_label} ({value["site_index"]}) is outside the range of '
+                            + f'sites within the structure (0-{len(structure.sites) -1}).'
+                        )
 
             if len(invalid_entries) != 0:
                 raise ValidationError(
@@ -490,7 +485,7 @@ class XspectraCrystalWorkChain(ProtocolMixin, WorkChain):
             if sorted_input_elements != absorbing_elements_list:
                 raise ValidationError(
                     f'Elements defined for sites in `equivalent_sites_data` ({sorted_input_elements}) do not match the'
-                    + f'list of absorbing elements ({absorbing_elements_list})'
+                    + f' list of absorbing elements ({absorbing_elements_list})'
                 )
 
 


### PR DESCRIPTION
# Overview
In this PR we add an input namespace for the `XspectraCrystalWorkChain` which allows the user to define the spacegroup and equivalent sites data for the incoming structure, thus instructing the WorkChain to generate structures and run calculations for only the sites specified. The new `symmetry_data` input requires entries for the system's spacegroup number (Int) and equivalent sites data (Dict). The former must simply be a valid spacegroup number (1-230) while the latter must contain an entry for each site (in the format `site_<index>_<element>`), where the minimal data required are the `kind_name`, `element`, `site_index`, and `multiplicity`.

In order to not be too restrictive on the user and make it easier to use external packages to build input symmetry data, we limit input validation to simple checks which ensure that the required data are present and that the data provided won't cause an obvious crash. Thus beyond the minimum required information, any extra data provided in the entries of the `equivalent_sites_data` node will be kept in case they may be needed by the user outside of the `WorkChain` (e.g. the list of symmetrically equivalent sites, which the `WorkChain` doesn't need).

# Changes
* Adds the `symmetry_data` input namespace to `XspectraCrystalWorkChain`, which the `WorkChain` will use to generate structures and set the list of polarisation vectors to calculate.
* Adds input validation steps for the symmetry data to check for required information and for entries which may cause a crash, though does not check for issues beyond this in order to maximise flexibility of use.
* Fixes an oversight in `get_xspectra_structures` where the `supercell` entry was not returned to the outputs when external symmetry data were provided by the user.