### PR TITLE
Try to fix the RTD build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,12 +54,12 @@ intersphinx_mapping = {
 }
 
 # Settings for the `autoapi.extenstion` automatically generating API docs
-filepath_docs = pathlib.Path(__file__).parent.parent
+filepath_docs = pathlib.Path(__file__).parent.parent.resolve()
 filepath_src = filepath_docs.parent / 'src'
 autoapi_type = 'python'
 autoapi_dirs = [filepath_src]
 autoapi_ignore = [filepath_src / 'aiida_quantumespresso' / '*cli*']
-autoapi_root = str(filepath_docs / 'source' / 'reference' / 'api' / 'auto')
+autoapi_root = (filepath_docs / 'source' / 'reference' / 'api' / 'auto').as_posix()
 autoapi_keep_files = True
 autoapi_add_toctree_entry = False
 


### PR DESCRIPTION
Seems some issue with the `sphinx-autoapi` generation. I'm finding both a warning that there is a non-existing document in the `toctree`:

```
/home/docs/checkouts/readthedocs.org/user_builds/aiida-quantumespresso/checkouts/1034/docs/source/reference/api/auto/aiida_quantumespresso/calculations/functions/index.rst:10: WARNING: toctree contains reference to nonexisting document 'home/docs/checkouts/readthedocs.org/user_builds/aiida-quantumespresso/checkouts/1034/docs/source/reference/api/auto/aiida_quantumespresso/calculations/functions/xspectra/index'
```

and that the corresponding document isn't included in any `toctree`:

```
/home/docs/checkouts/readthedocs.org/user_builds/aiida-quantumespresso/checkouts/1034/docs/source/reference/api/auto/aiida_quantumespresso/calculations/functions/xspectra/index.rst: WARNING: document isn't included in any toctree
```