### PR TITLE
Docs: Fix build by pinning `sphinx-autoapi~=3.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ docs = [
     'sphinx-click~=4.4.0',
     'sphinx-design~=0.4.1',
     'sphinxcontrib-details-directive~=0.1.0',
-    'sphinx-autoapi~=3.0',
+    'sphinx-autoapi~=3.0.0',
     'myst_parser~=1.0.0',
 ]
 pre-commit = [


### PR DESCRIPTION
The more recent release v3.1.0 of `sphinx-autoapi` causes the build to fail because there are warnings about the generated API files not being found. The exact cause of the bug is unknown as of yet and therefore, as a workaround we are pinning the dependency for now.