### PR TITLE
CLI: Fix bug in `aiida-quantumespresso workflow launch pw-base`

### DIFF
--- a/src/aiida_quantumespresso/cli/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/cli/workflows/pw/base.py
@@ -42,6 +42,9 @@ def launch_workflow(
     cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure, unit='Ry')
 
     parameters = {
+        'CONTROL': {
+            'calculation': 'scf',
+        },
         'SYSTEM': {
             'ecutwfc': ecutwfc or cutoff_wfc,
             'ecutrho': ecutrho or cutoff_rho,


### PR DESCRIPTION
The command would not specify the `CONTROL` key for the input parameters resulting in an exception in the upload step. This was not discovered by tests because the workflow is not actually run and the exception is only hit when the calcjob is actually executed.