### PR TITLE
adding nbands_factor logic into PdosWorkChain

### DIFF
--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -434,7 +434,7 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
 
             if 'nbands_factor' in self.inputs:
                 factor = self.inputs.nbands_factor.value
-                parameters = self.ctx.workchain_scf.outputs.output_parameters.base.attributes.get('number_of_bands')
+                parameters = self.ctx.workchain_scf.outputs.output_parameters.get_dict()
                 nbands = int(parameters['number_of_bands'])
                 nelectron = int(parameters['number_of_electrons'])
                 nbnd = max(int(0.5 * nelectron * factor), int(0.5 * nelectron) + 4, nbands)
@@ -442,7 +442,7 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
 
             else:
                 inputs.pw.parameters['SYSTEM']['nbnd'] = (
-                    self.ctx.workchain_scf.outputs.output_parameters['number_of_bands']
+                    self.ctx.workchain_scf.outputs.output_parameters.base.attributes.get('number_of_bands')
                 )
         inputs.pw.structure = self.inputs.structure
 

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -440,10 +440,6 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
                 nbnd = max(int(0.5 * nelectron * factor), int(0.5 * nelectron) + 4, nbands)
                 inputs.pw.parameters['SYSTEM']['nbnd'] = nbnd
 
-            else:
-                inputs.pw.parameters['SYSTEM']['nbnd'] = (
-                    self.ctx.workchain_scf.outputs.output_parameters.base.attributes.get('number_of_bands')
-                )
         inputs.pw.structure = self.inputs.structure
 
         inputs.metadata.call_link_label = 'nscf'

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -429,22 +429,22 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
 
         """
         inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, 'nscf'))
+
         if 'scf' in self.inputs:
             inputs.pw.parent_folder = self.ctx.scf_parent_folder
 
-            if 'nbands_factor' in self.inputs:
-                factor = self.inputs.nbands_factor.value
-                parameters = self.ctx.workchain_scf.outputs.output_parameters.get_dict()
-                nbands = int(parameters['number_of_bands'])
-                nelectron = int(parameters['number_of_electrons'])
-                nbnd = max(int(0.5 * nelectron * factor), int(0.5 * nelectron) + 4, nbands)
-                inputs.pw.parameters['SYSTEM']['nbnd'] = nbnd
+        if 'nbands_factor' in self.inputs:
+            inputs.pw.parameters = inputs.pw.parameters.get_dict()
+            factor = self.inputs.nbands_factor.value
+            parameters = self.ctx.workchain_scf.outputs.output_parameters.get_dict()
+            nbands = int(parameters['number_of_bands'])
+            nelectron = int(parameters['number_of_electrons'])
+            nbnd = max(int(0.5 * nelectron * factor), int(0.5 * nelectron) + 4, nbands)
+            inputs.pw.parameters['SYSTEM']['nbnd'] = nbnd
 
         inputs.pw.structure = self.inputs.structure
 
         inputs.metadata.call_link_label = 'nscf'
-
-
 
         inputs = prepare_process_inputs(PwBaseWorkChain, inputs)
 

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -434,7 +434,7 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
 
             if 'nbands_factor' in self.inputs:
                 factor = self.inputs.nbands_factor.value
-                parameters = self.ctx.workchain_scf.outputs.output_parameters.get_dict()
+                parameters = self.ctx.workchain_scf.outputs.output_parameters.base.attributes.get('number_of_bands')
                 nbands = int(parameters['number_of_bands'])
                 nelectron = int(parameters['number_of_electrons'])
                 nbnd = max(int(0.5 * nelectron * factor), int(0.5 * nelectron) + 4, nbands)

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -118,6 +118,9 @@ def validate_inputs(value, _):
             if value['dos']['parameters']['DOS'].get(par, None) is None:
                 return f'The `{par}`` parameter must be set in case `align_to_fermi` is set to `True`.'
 
+    if 'nbands_factor' in value and 'nbnd' in value['nscf']['pw']['parameters'].base.attributes.get('SYSTEM', {}):
+        return PdosWorkChain.exit_codes.ERROR_INVALID_INPUT_NUMBER_OF_BANDS.message
+
 
 def validate_scf(value, _):
     """Validate the scf parameters."""
@@ -304,6 +307,8 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
             message='the PROJWFC sub process failed')
         spec.exit_code(404, 'ERROR_SUB_PROCESS_FAILED_BOTH',
             message='both the DOS and PROJWFC sub process failed')
+        spec.exit_code(405, 'ERROR_INVALID_INPUT_NUMBER_OF_BANDS',
+            message='Cannot specify both `nbands_factor` and `nscf.pw.parameters.SYSTEM.nbnd`.')
 
         spec.expose_outputs(PwBaseWorkChain, namespace='nscf')
         spec.expose_outputs(DosCalculation, namespace='dos')

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -431,20 +431,22 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, 'nscf'))
         if 'scf' in self.inputs:
             inputs.pw.parent_folder = self.ctx.scf_parent_folder
+
+            if 'nbands_factor' in self.inputs:
+                factor = self.inputs.nbands_factor.value
+                parameters = self.ctx.workchain_scf.outputs.output_parameters.get_dict()
+                nbands = int(parameters['number_of_bands'])
+                nelectron = int(parameters['number_of_electrons'])
+                nbnd = max(int(0.5 * nelectron * factor), int(0.5 * nelectron) + 4, nbands)
+                inputs.pw.parameters['SYSTEM']['nbnd'] = nbnd
+
+            else:
+                inputs.pw.parameters['SYSTEM']['nbnd'] = self.ctx.workchain_scf.outputs.output_parameters['number_of_bands']
         inputs.pw.structure = self.inputs.structure
 
         inputs.metadata.call_link_label = 'nscf'
 
-        if 'nbands_factor' in self.inputs:
-            factor = self.inputs.nbands_factor.value
-            parameters = self.ctx.workchain_scf.outputs.output_parameters.get_dict()
-            nbands = int(parameters['number_of_bands'])
-            nelectron = int(parameters['number_of_electrons'])
-            nbnd = max(int(0.5 * nelectron * factor), int(0.5 * nelectron) + 4, nbands)
-            inputs.pw.parameters['SYSTEM']['nbnd'] = nbnd
 
-        else:
-            inputs.pw.parameters['SYSTEM']['nbnd'] = self.ctx.workchain_scf.outputs.output_parameters['number_of_bands']
 
         inputs = prepare_process_inputs(PwBaseWorkChain, inputs)
 

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -441,7 +441,9 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
                 inputs.pw.parameters['SYSTEM']['nbnd'] = nbnd
 
             else:
-                inputs.pw.parameters['SYSTEM']['nbnd'] = self.ctx.workchain_scf.outputs.output_parameters['number_of_bands']
+                inputs.pw.parameters['SYSTEM']['nbnd'] = (
+                    self.ctx.workchain_scf.outputs.output_parameters['number_of_bands']
+                )
         inputs.pw.structure = self.inputs.structure
 
         inputs.metadata.call_link_label = 'nscf'


### PR DESCRIPTION
In this PR, we introduce a new input parameter, nbands_factor, to the PdosWorkChain. This parameter replicates the functionality available in the BandsWorkChain, allowing the calculation of additional bands during the PwCalculation (NSCF). It ensures that an appropriate number of extra bands are computed. This enhancement provides more flexibility and consistency in band structure and PDOS workflows.



This address #1043 