### PR TITLE
Allowing tetrahedra_opt option for nscf

### DIFF
--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -131,8 +131,8 @@ def validate_nscf(value, _):
     parameters = value['pw']['parameters'].get_dict()
     if parameters.get('CONTROL', {}).get('calculation', 'scf') != 'nscf':
         return '`CONTOL.calculation` in `nscf.pw.parameters` is not set to `nscf`.'
-    if parameters.get('SYSTEM', {}).get('occupations', None) != 'tetrahedra':
-        return '`SYSTEM.occupations` in `nscf.pw.parameters` is not set to `tetrahedra`.'
+    if parameters.get('SYSTEM', {}).get('occupations', None) not in ['tetrahedra', 'tetrahedra_opt']:
+        return '`SYSTEM.occupations` in `nscf.pw.parameters` is not set to `tetrahedra` or `tetrahedra_opt`.'
 
 
 def validate_dos(value, _):


### PR DESCRIPTION
For AiiDAlab QE app, we need to allowed tetrahedra_opt for nscf 

