### PR TITLE
Devops: Add explicit sphinx.configuration key to RTD conf

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,4 +15,5 @@ python:
 # Let the build fail if there are any warnings
 sphinx:
     builder: html
+    configuration: docs/source/conf.py
     fail_on_warning: true


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

Copy pasted from https://github.com/aiidateam/aiida-core/commit/8440416a58d901e0030c7088c41be8ed94922594#diff-cde814ef2f549dc093f5b8fc533b7e8f47e7b32a8081e0760e57d5c25a1139d9R28