### PR TITLE
👌 Fix error message for `ERROR_CHARGE_IS_WRONG`

### DIFF
--- a/src/aiida_quantumespresso/calculations/pw.py
+++ b/src/aiida_quantumespresso/calculations/pw.py
@@ -153,7 +153,9 @@ class PwCalculation(BasePwCpInputGenerator):
                     'BFGS algorithm and electronic convergence failed in the final SCF.')
 
         spec.exit_code(531, 'ERROR_CHARGE_IS_WRONG',
-            message='The electronic minimization cycle did not reach self-consistency.')
+            message='The difference between the total charge and the number of electrons exceeds the threshold. '
+                    'Smearing might be required, check the output file for details.'
+            )
         spec.exit_code(541, 'ERROR_SYMMETRY_NON_ORTHOGONAL_OPERATION',
             message='The variable cell optimization broke the symmetry of the k-points.')
         spec.exit_code(542, 'ERROR_RADIAL_FFT_SIGNIFICANT_VOLUME_CONTRACTION',


### PR DESCRIPTION
Fix the copy-paste error and add a proper error message for the `ERROR_CHARGE_IS_WRONG` exit code, see #976.

The comment/hint in the error message regarding the usage of smearing is based on the source code of QE:
https://gitlab.com/QEF/q-e/-/blob/develop/PW/src/electrons.f90#L1062-1071