### PR TITLE
Fix in PdosWorkChain to allow retrieval of nbands params from finished SCF calc when no SCF is to be launched

### DIFF
--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -46,12 +46,11 @@ Related Resources:
     (see `this post <https://lists.quantum-espresso.org/pipermail/users/2017-November/039656.html>`_).
 
 """
+import jsonschema
 from aiida import orm, plugins
 from aiida.common import AttributeDict
 from aiida.engine import ToContext, WorkChain, if_
 from aiida.orm.nodes.data.base import to_aiida_type
-import jsonschema
-
 from aiida_quantumespresso.utils.mapping import prepare_process_inputs
 
 from .protocols.utils import ProtocolMixin
@@ -451,6 +450,9 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
 
         if 'scf' in self.inputs:
             inputs.pw.parent_folder = self.ctx.scf_parent_folder
+        else:
+            # to get the SCF workchain from the remote given in input when no SCF is to be run
+            self.ctx.workchain_scf = inputs.pw.parent_folder.creator.caller
 
         if 'nbands_factor' in self.inputs:
             inputs.pw.parameters = inputs.pw.parameters.get_dict()

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -96,6 +96,9 @@ def validate_inputs(value, _):
 
     - Check that either the `scf` or `nscf.pw.parent_folder` inputs is provided.
     - Check that the `Emin`, `Emax` and `DeltaE` inputs are the same for the `dos` and `projwfc` namespaces.
+    - Warn the user when both `energy_range_vs_fermi` and `Emin` and `Emax` are specified.
+    - Raise error when `nbands_factor` is specified and `nscf.pw.parameters.SYSTEM.nbnd` is also specified.
+    - Check that when `serial_clean` is set to `True`, the `scf` inputs are provided.
     """
     # Check that either the `scf` input or `nscf.pw.parent_folder` is provided.
     import warnings
@@ -121,6 +124,9 @@ def validate_inputs(value, _):
 
     if 'nbands_factor' in value and 'nbnd' in value['nscf']['pw']['parameters'].base.attributes.get('SYSTEM', {}):
         return PdosWorkChain.exit_codes.ERROR_INVALID_INPUT_NUMBER_OF_BANDS.message
+
+    if value.get('serial_clean', False) and not 'scf' in value:
+        return 'When `serial_clean` is set to `True`, the `scf` inputs are required.'
 
 
 def validate_scf(value, _):
@@ -451,13 +457,14 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         if 'scf' in self.inputs:
             inputs.pw.parent_folder = self.ctx.scf_parent_folder
         else:
-            # to get the SCF workchain from the remote given in input when no SCF is to be run
-            self.ctx.workchain_scf = inputs.pw.parent_folder.creator.caller
+            # No SCF calculation has been launched, `workchain_scf` is not in ctx
+            # but `nscf.pw.parent_folder` is given if inputs are valid
+            self.ctx.scf_parent_folder = inputs.pw.parent_folder
 
         if 'nbands_factor' in self.inputs:
             inputs.pw.parameters = inputs.pw.parameters.get_dict()
             factor = self.inputs.nbands_factor.value
-            parameters = self.ctx.workchain_scf.outputs.output_parameters.get_dict()
+            parameters = self.ctx.scf_parent_folder.creator.outputs.output_parameters.get_dict()
             nbands = int(parameters['number_of_bands'])
             nelectron = int(parameters['number_of_electrons'])
             nbnd = max(int(0.5 * nelectron * factor), int(0.5 * nelectron) + 4, nbands)


### PR DESCRIPTION
In the case where no SCF workchain is explicitly launched, `workchain_scf` is not in `self.ctx` so an error occurs when trying to get the `output_parameters` of the SCF workchain and retrieve the number of bands used when launching Nscf WorkChain.

### Workflow functionality enhancement:
* Updated the `run_nscf` method to handle the scenario where an SCF workchain is not run by adding `workchain_scf` to `self.ctx` when 'scf' is not in `self.inputs`. The `workchain_scf` is the caller of the creator of the `parent_folder` specified in 'nscf' inputs.