### PR TITLE
Deps: bump aiida-pseudo to v1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = ['aiida', 'workflows']
 requires-python = '>=3.9'
 dependencies = [
     'aiida_core[atomic_tools]~=2.3',
-    'aiida-pseudo~=1.1',
+    'aiida-pseudo>=1.7.2',
     'click~=8.0',
     'importlib_resources',
     'jsonschema',


### PR DESCRIPTION
The Materials Cloud link to the SSSP pseudopotentials is now
changes and broken. This has been fixed in aiida-pseudo v1.7.2.