### PR TITLE
🔧 Add upper limit to `aiida-pseudo` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = ['aiida', 'workflows']
 requires-python = '>=3.9'
 dependencies = [
     'aiida_core[atomic_tools]~=2.3',
-    'aiida-pseudo>=1.7.2',
+    'aiida-pseudo>=1.7.2,<2',
     'click~=8.0',
     'importlib_resources',
     'jsonschema',


### PR DESCRIPTION
In bd984289297e8d353c498976434b980a9d853ab6, a lower bound was set on the version of the `aiida-pseudo` dependency using `>=1.7.2`. However, this means that in case there is a major release of `aiida-pseudo`, that will be installed, potentially with breaking changes.

Here we add an additional upper limit to the `aiida-pseudo` dependency to make sure it stays within the current major version.