### PR TITLE
⬆️ Reintroduce upper limit to `aiida-pseudo` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = ['aiida', 'workflows']
 requires-python = '>=3.9'
 dependencies = [
     'aiida_core[atomic_tools]~=2.3',
-    'aiida-pseudo>=1.7.2',
+    'aiida-pseudo>=1.7.2,<2',
     'click~=8.0',
     'importlib_resources',
     'jsonschema',


### PR DESCRIPTION
In 904cbee313397812b6e7eb7fdb4d0634e483366e we added an upper limit to the `aiida-pseudo` dependency to avoid installing the next major version automatically when it is released. Unfortunately, this change was accidentally reverted in 4a6cdc22ec7f868a497abfd384bfeed39dfee3dc due to some rushed `git` shenanigans. Here we reintroduce this upper limit for a quick patch release.