### PR TITLE
Fixing parse_xml if no pseudo-wfcs are there in the pseudo file.

### DIFF
--- a/src/aiida_quantumespresso/parsers/parse_xml/parse.py
+++ b/src/aiida_quantumespresso/parsers/parse_xml/parse.py
@@ -297,7 +297,7 @@ def parse_xml_post_6_2(xml):
         num_electrons = band_structure['nelec']
 
         # In schema v240411 (QE v7.3.1), the `number_of_atomic_wfc` is moved to the `atomic_structure` tag as an attribute
-        num_atomic_wfc = band_structure.get('num_of_atomic_wfc', None) or outputs['atomic_structure'].get('@num_of_atomic_wfc',0)
+        num_atomic_wfc = band_structure.get('num_of_atomic_wfc', None) or outputs['atomic_structure'].get('@num_of_atomic_wfc', None)
         num_bands = band_structure.get('nbnd', None)
         num_bands_up = band_structure.get('nbnd_up', None)
         num_bands_down = band_structure.get('nbnd_dw', None)

--- a/src/aiida_quantumespresso/parsers/parse_xml/parse.py
+++ b/src/aiida_quantumespresso/parsers/parse_xml/parse.py
@@ -297,7 +297,7 @@ def parse_xml_post_6_2(xml):
         num_electrons = band_structure['nelec']
 
         # In schema v240411 (QE v7.3.1), the `number_of_atomic_wfc` is moved to the `atomic_structure` tag as an attribute
-        num_atomic_wfc = band_structure.get('num_of_atomic_wfc', None) or outputs['atomic_structure']['@num_of_atomic_wfc']
+        num_atomic_wfc = band_structure.get('num_of_atomic_wfc', None) or outputs['atomic_structure'].get('@num_of_atomic_wfc',0)
         num_bands = band_structure.get('nbnd', None)
         num_bands_up = band_structure.get('nbnd_up', None)
         num_bands_down = band_structure.get('nbnd_dw', None)


### PR DESCRIPTION
Previously, we always assume we have the `num_of_atomic_wfc` defined. However, if pseudo files do not contain info on these pseudo wavefunctions (like in the `sg15` case), this will give an error in the parsing. 

The error shows up if we use an enough recent version of Quantum ESPRESSO (> 7, but I have not tested all versions), because we use `parse_xml_post_6_2`.