### PR TITLE
Allow null `pseudo_family` by extracting `z_valence` from pseudos

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,10 +322,11 @@ def generate_calc_job_node(fixture_localhost):
 def generate_upf_data():
     """Return a `UpfData` instance for the given element a file for which should exist in `tests/fixtures/pseudos`."""
 
-    def _generate_upf_data(element):
-        """Return `UpfData` node."""
-        from aiida_pseudo.data.pseudo import UpfData
-        content = f'<UPF version="2.0.1"><PP_HEADER\nelement="{element}"\nz_valence="4.0"\n/></UPF>\n'
+    from aiida_pseudo.data.pseudo import UpfData
+
+    def _generate_upf_data(element: str, z_valence: float = 4.0) -> UpfData:
+        """Return a `UpfData` node."""
+        content = f'<UPF version="2.0.1"><PP_HEADER\nelement="{element}"\nz_valence="{z_valence}"\n/></UPF>\n'
         stream = io.BytesIO(content.encode('utf-8'))
         return UpfData(stream, filename=f'{element}.upf')
 


### PR DESCRIPTION
In the pw base workchain's `get_builder_from_protocol` method, we use the `pseudo_family` input (`str`) to fetch the family and use it to define defaults for pseudos and cutoffs, as well as to obtain the Z value for converting moments to starting magnetization. This PR removes the dependency on `pseudo_family` by relying on the overrides for pseudos and cutoffs (now required if no pseudo family provided), as well by constructing a `z_valences` dictionary from the pseudos themselves and using it in the magnetization conversion. By removing the dependency, this PR allows scenarios where pseudos are provided that do not belong to the supported families (e.g., uploading custom pseudos in the QE app).