### PR TITLE
🐛 Protocols: Fix `overrides` that do not have `pw` key

### DIFF
--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -159,7 +159,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         # Update the parameters based on the protocol inputs
         parameters = inputs['pw']['parameters']
 
-        if overrides and 'pseudos' in overrides['pw']:
+        if overrides and 'pseudos' in overrides.get('pw', {}):
 
             pseudos = overrides['pw']['pseudos']
 

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -135,6 +135,19 @@ def test_initial_magnetic_moments(fixture_code, generate_structure):
     assert parameters['SYSTEM']['starting_magnetization'] == {'Si': 0.25}
 
 
+def test_overrides_pseudo_family(fixture_code, generate_structure):
+    """Test specifying ``pseudo_family`` ``overrides`` for the ``get_builder_from_protocol()`` method."""
+    code = fixture_code('quantumespresso.pw')
+    structure = generate_structure('silicon')
+
+    overrides = {'pseudo_family': 'PseudoDojo/0.4/PBEsol/FR/standard/upf'}
+
+    builder = PwBaseWorkChain.get_builder_from_protocol(code, structure, overrides=overrides)
+    parameters = builder.pw.parameters.get_dict()
+    assert parameters['SYSTEM']['ecutwfc'] == 60.0
+    assert parameters['SYSTEM']['ecutrho'] == 400.0
+
+
 def test_magnetization_overrides(fixture_code, generate_structure):
     """Test magnetization ``overrides`` for the ``PwBaseWorkChain.get_builder_from_protocol`` method."""
     code = fixture_code('quantumespresso.pw')


### PR DESCRIPTION
In a94fbe41bbe81bf628a6bce490ae141c41150b31 we introduced some fixes for the `pseudos`
overrides, but also a bug that makes the `PwBaseWorkChain.get_builder_from_protocol()`
method fail in case overrides are provided that do not contain the `pw` key.

Here we fix this most egregious error, and add a test to makes sure overrides that only
specify the `pseudo_family` work as expected.