### PR TITLE
🧪 Fix `test_immigrate` tests

### DIFF
--- a/tests/tools/test_immigrate.py
+++ b/tests/tools/test_immigrate.py
@@ -35,8 +35,9 @@ def test_create_builder(fixture_sandbox, fixture_code, generate_upf_data, genera
 
     builder = create_builder_from_file(in_folderpath, 'test_pw_default.in', code, metadata, upf_folderpath)
 
-    # In certain versions of `aiida-core` the builder comes with the `stash` namespace by default.
+    # In more recent versions of `aiida-core` the builder comes with the `stash` and `unstash` namespace by default.
     builder['metadata']['options'].pop('stash', None)
+    builder['metadata']['options'].pop('unstash', None)
 
     assert builder['code'] == code
     assert builder['metadata'] == metadata
@@ -95,8 +96,9 @@ def test_create_builder_nonzero_ibrav(
 
     builder = create_builder_from_file(in_folderpath, 'test_pw_ibrav.in', code, metadata, upf_folderpath)
 
-    # In certain versions of `aiida-core` the builder comes with the `stash` namespace by default.
+    # In more recent versions of `aiida-core` the builder comes with the `stash` and `unstash` namespace by default.
     builder['metadata']['options'].pop('stash', None)
+    builder['metadata']['options'].pop('unstash', None)
 
     assert builder['code'] == code
     assert builder['metadata'] == metadata


### PR DESCRIPTION
In the following commit:

https://github.com/aiidateam/aiida-core/commit/6ab3ed1bd1c9befdebaad6937c876d06b81ccc4a

The unstashing feature was added, adding a default `unstash` key in the `metadata.options`. This broke the `test_immigrate` tests, since the `metadata` is checked versus the one given as an input to the `create_builder_from_file` function.

The (patchy) solution is to simply pop the `unstash` key from the `metadata.options`, similar as we did for the `stash` one. However, perhaps we should avoid having such default keys in the options, see:

https://github.com/aiidateam/aiida-core/pull/6826#issuecomment-3230353809