### PR TITLE
Remove unrecoverable handler

### DIFF
--- a/src/aiida_quantumespresso/workflows/bands/base.py
+++ b/src/aiida_quantumespresso/workflows/bands/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Workchain to run a Quantum ESPRESSO bands.x calculation with automated error handling and restarts."""
 from aiida.common import AttributeDict
-from aiida.engine import BaseRestartWorkChain, ProcessHandlerReport, process_handler, while_
+from aiida.engine import BaseRestartWorkChain, while_
 from aiida.plugins import CalculationFactory
 
 BandsCalculation = CalculationFactory('quantumespresso.bands')

--- a/src/aiida_quantumespresso/workflows/bands/base.py
+++ b/src/aiida_quantumespresso/workflows/bands/base.py
@@ -28,7 +28,7 @@ class BandsBaseWorkChain(BaseRestartWorkChain):
             cls.results,
         )
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
-            message='The calculation failed with an unrecoverable error.')
+            message='The calculation failed with an unrecoverable error. [deprecated]')
         # yapf: enable
 
     def setup(self):
@@ -52,10 +52,3 @@ class BandsBaseWorkChain(BaseRestartWorkChain):
         arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
         self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
         self.report(f'Action taken: {action}')
-
-    @process_handler(priority=600)
-    def handle_unrecoverable_failure(self, node):
-        """Handle calculations with an exit status below 400 which are unrecoverable, so abort the work chain."""
-        if node.is_failed and node.exit_status < 400:
-            self.report_error_handled(node, 'unrecoverable error, aborting...')
-            return ProcessHandlerReport(True, self.exit_codes.ERROR_UNRECOVERABLE_FAILURE)

--- a/src/aiida_quantumespresso/workflows/bands/base.py
+++ b/src/aiida_quantumespresso/workflows/bands/base.py
@@ -28,7 +28,7 @@ class BandsBaseWorkChain(BaseRestartWorkChain):
             cls.results,
         )
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
-            message='The calculation failed with an unrecoverable error. [deprecated]')
+            message='[deprecated] The calculation failed with an unrecoverable error.')
         # yapf: enable
 
     def setup(self):

--- a/src/aiida_quantumespresso/workflows/matdyn/base.py
+++ b/src/aiida_quantumespresso/workflows/matdyn/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Workchain to run a Quantum ESPRESSO matdyn.x calculation with automated error handling and restarts."""
 from aiida.common import AttributeDict
-from aiida.engine import BaseRestartWorkChain, ProcessHandlerReport, process_handler, while_
+from aiida.engine import BaseRestartWorkChain, while_
 from aiida.plugins import CalculationFactory
 
 MatdynCalculation = CalculationFactory('quantumespresso.matdyn')

--- a/src/aiida_quantumespresso/workflows/matdyn/base.py
+++ b/src/aiida_quantumespresso/workflows/matdyn/base.py
@@ -28,7 +28,7 @@ class MatdynBaseWorkChain(BaseRestartWorkChain):
             cls.results,
         )
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
-            message='The calculation failed with an unrecoverable error.')
+            message='The calculation failed with an unrecoverable error.[deprecated]')
         # yapf: enable
 
     def setup(self):
@@ -52,10 +52,3 @@ class MatdynBaseWorkChain(BaseRestartWorkChain):
         arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
         self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
         self.report(f'Action taken: {action}')
-
-    @process_handler(priority=600)
-    def handle_unrecoverable_failure(self, node):
-        """Handle calculations with an exit status below 400 which are unrecoverable, so abort the work chain."""
-        if node.is_failed and node.exit_status < 400:
-            self.report_error_handled(node, 'unrecoverable error, aborting...')
-            return ProcessHandlerReport(True, self.exit_codes.ERROR_UNRECOVERABLE_FAILURE)

--- a/src/aiida_quantumespresso/workflows/matdyn/base.py
+++ b/src/aiida_quantumespresso/workflows/matdyn/base.py
@@ -28,7 +28,7 @@ class MatdynBaseWorkChain(BaseRestartWorkChain):
             cls.results,
         )
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
-            message='The calculation failed with an unrecoverable error.[deprecated]')
+            message='[deprecated] The calculation failed with an unrecoverable error.')
         # yapf: enable
 
     def setup(self):

--- a/src/aiida_quantumespresso/workflows/ph/base.py
+++ b/src/aiida_quantumespresso/workflows/ph/base.py
@@ -62,7 +62,7 @@ class PhBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             message='The `metadata.options` did not specify both `resources.num_machines` and `max_wallclock_seconds`. '
                     'This exit status has been deprecated as the check it corresponded to was incorrect.')
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
-            message='The calculation failed with an unrecoverable error.')
+            message='The calculation failed with an unrecoverable error.[deprecated]')
         spec.exit_code(401, 'ERROR_MERGING_QPOINTS',
             message='The work chain failed to merge the q-points data from multiple `PhCalculation`s because not all '
                     'q-points were parsed.')
@@ -271,13 +271,6 @@ class PhBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
         self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
         self.report(f'Action taken: {action}')
-
-    @process_handler(priority=600)
-    def handle_unrecoverable_failure(self, node):
-        """Handle calculations with an exit status below 400 which are unrecoverable, so abort the work chain."""
-        if node.is_failed and node.exit_status < 400:
-            self.report_error_handled(node, 'unrecoverable error, aborting...')
-            return ProcessHandlerReport(True, self.exit_codes.ERROR_UNRECOVERABLE_FAILURE)
 
     @process_handler(priority=610, exit_codes=PhCalculation.exit_codes.ERROR_SCHEDULER_OUT_OF_WALLTIME)
     def handle_scheduler_out_of_walltime(self, node):

--- a/src/aiida_quantumespresso/workflows/ph/base.py
+++ b/src/aiida_quantumespresso/workflows/ph/base.py
@@ -62,7 +62,7 @@ class PhBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             message='The `metadata.options` did not specify both `resources.num_machines` and `max_wallclock_seconds`. '
                     'This exit status has been deprecated as the check it corresponded to was incorrect.')
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
-            message='[deprecated] The calculation failed with an unrecoverable error.')
+            message='The calculation failed with an unrecoverable error.')
         spec.exit_code(401, 'ERROR_MERGING_QPOINTS',
             message='The work chain failed to merge the q-points data from multiple `PhCalculation`s because not all '
                     'q-points were parsed.')

--- a/src/aiida_quantumespresso/workflows/ph/base.py
+++ b/src/aiida_quantumespresso/workflows/ph/base.py
@@ -62,7 +62,7 @@ class PhBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             message='The `metadata.options` did not specify both `resources.num_machines` and `max_wallclock_seconds`. '
                     'This exit status has been deprecated as the check it corresponded to was incorrect.')
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
-            message='The calculation failed with an unrecoverable error.[deprecated]')
+            message='[deprecated] The calculation failed with an unrecoverable error.')
         spec.exit_code(401, 'ERROR_MERGING_QPOINTS',
             message='The work chain failed to merge the q-points data from multiple `PhCalculation`s because not all '
                     'q-points were parsed.')

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -81,10 +81,10 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         spec.exit_code(211, 'ERROR_INVALID_INPUT_AUTOMATIC_PARALLELIZATION_UNRECOGNIZED_KEY',
             message='Unrecognized keys were specified for `automatic_parallelization`.'
                     'This exit status has been deprecated as the automatic parallellization feature was removed.')
-        spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE [deprecated]',
-            message='The calculation failed with an unidentified unrecoverable error.')
+        spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
+            message='[deprecated] The calculation failed with an unidentified unrecoverable error.')
         spec.exit_code(310, 'ERROR_KNOWN_UNRECOVERABLE_FAILURE',
-            message='The calculation failed with a known unrecoverable error. [deprecated]')
+            message='The calculation failed with a known unrecoverable error.')
         spec.exit_code(320, 'ERROR_INITIALIZATION_CALCULATION_FAILED',
             message='The initialization calculation failed.')
         spec.exit_code(501, 'ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF',

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -81,10 +81,10 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         spec.exit_code(211, 'ERROR_INVALID_INPUT_AUTOMATIC_PARALLELIZATION_UNRECOGNIZED_KEY',
             message='Unrecognized keys were specified for `automatic_parallelization`.'
                     'This exit status has been deprecated as the automatic parallellization feature was removed.')
-        spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
+        spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE [deprecated]',
             message='The calculation failed with an unidentified unrecoverable error.')
         spec.exit_code(310, 'ERROR_KNOWN_UNRECOVERABLE_FAILURE',
-            message='The calculation failed with a known unrecoverable error.')
+            message='The calculation failed with a known unrecoverable error. [deprecated]')
         spec.exit_code(320, 'ERROR_INITIALIZATION_CALCULATION_FAILED',
             message='The initialization calculation failed.')
         spec.exit_code(501, 'ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF',
@@ -410,13 +410,6 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             )
 
             return ProcessHandlerReport(True)
-
-    @process_handler(priority=600)
-    def handle_unrecoverable_failure(self, calculation):
-        """Handle calculations with an exit status below 400 which are unrecoverable, so abort the work chain."""
-        if calculation.is_failed and calculation.exit_status < 400:
-            self.report_error_handled(calculation, 'unrecoverable error, aborting...')
-            return ProcessHandlerReport(True, self.exit_codes.ERROR_UNRECOVERABLE_FAILURE)
 
     @process_handler(priority=590, exit_codes=[])
     def handle_known_unrecoverable_failure(self, calculation):

--- a/src/aiida_quantumespresso/workflows/q2r/base.py
+++ b/src/aiida_quantumespresso/workflows/q2r/base.py
@@ -28,7 +28,7 @@ class Q2rBaseWorkChain(BaseRestartWorkChain):
             cls.results,
         )
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
-            message='The calculation failed with an unrecoverable error.')
+            message='The calculation failed with an unrecoverable error.[deprecated]')
         # yapf: enable
 
     def setup(self):
@@ -52,10 +52,3 @@ class Q2rBaseWorkChain(BaseRestartWorkChain):
         arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
         self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
         self.report(f'Action taken: {action}')
-
-    @process_handler(priority=600)
-    def handle_unrecoverable_failure(self, node):
-        """Handle calculations with an exit status below 400 which are unrecoverable, so abort the work chain."""
-        if node.is_failed and node.exit_status < 400:
-            self.report_error_handled(node, 'unrecoverable error, aborting...')
-            return ProcessHandlerReport(True, self.exit_codes.ERROR_UNRECOVERABLE_FAILURE)

--- a/src/aiida_quantumespresso/workflows/q2r/base.py
+++ b/src/aiida_quantumespresso/workflows/q2r/base.py
@@ -28,7 +28,7 @@ class Q2rBaseWorkChain(BaseRestartWorkChain):
             cls.results,
         )
         spec.exit_code(300, 'ERROR_UNRECOVERABLE_FAILURE',
-            message='The calculation failed with an unrecoverable error.[deprecated]')
+            message='[deprecated] The calculation failed with an unrecoverable error.')
         # yapf: enable
 
     def setup(self):

--- a/src/aiida_quantumespresso/workflows/q2r/base.py
+++ b/src/aiida_quantumespresso/workflows/q2r/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Workchain to run a Quantum ESPRESSO q2r.x calculation with automated error handling and restarts."""
 from aiida.common import AttributeDict
-from aiida.engine import BaseRestartWorkChain, ProcessHandlerReport, process_handler, while_
+from aiida.engine import BaseRestartWorkChain, while_
 from aiida.plugins import CalculationFactory
 
 Q2rCalculation = CalculationFactory('quantumespresso.q2r')

--- a/src/aiida_quantumespresso/workflows/xspectra/base.py
+++ b/src/aiida_quantumespresso/workflows/xspectra/base.py
@@ -73,7 +73,7 @@ class XspectraBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         spec.exit_code(
             300,
             'ERROR_UNRECOVERABLE_FAILURE',
-            message='The calculation failed with an unrecoverable error.[deprecated]'
+            message='[deprecated] The calculation failed with an unrecoverable error.'
         )
 
     @classmethod

--- a/src/aiida_quantumespresso/workflows/xspectra/base.py
+++ b/src/aiida_quantumespresso/workflows/xspectra/base.py
@@ -71,7 +71,9 @@ class XspectraBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             message='Neither the `kpoints` nor the `kpoints_distance` input was specified.'
         )
         spec.exit_code(
-            300, 'ERROR_UNRECOVERABLE_FAILURE', message='The calculation failed with an unrecoverable error.'
+            300,
+            'ERROR_UNRECOVERABLE_FAILURE',
+            message='The calculation failed with an unrecoverable error.[deprecated]'
         )
 
     @classmethod
@@ -231,13 +233,6 @@ class XspectraBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
         self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
         self.report(f'Action taken: {action}')
-
-    @process_handler(priority=600)
-    def handle_unrecoverable_failure(self, node):
-        """Handle calculations with an exit status below 400 which are unrecoverable, so abort the work chain."""
-        if node.is_failed and node.exit_status < 400:
-            self.report_error_handled(node, 'unrecoverable error, aborting...')
-            return ProcessHandlerReport(True, self.exit_codes.ERROR_UNRECOVERABLE_FAILURE)
 
     @process_handler(priority=610, exit_codes=XspectraCalculation.exit_codes.ERROR_SCHEDULER_OUT_OF_WALLTIME)
     def handle_scheduler_out_of_walltime(self, node):

--- a/tests/workflows/bands/test_base.py
+++ b/tests/workflows/bands/test_base.py
@@ -2,12 +2,8 @@
 # pylint: disable=no-member,redefined-outer-name
 """Tests for the `BandsBaseWorkChain` class."""
 from aiida.common import AttributeDict
-from aiida.engine import ProcessHandlerReport
 from plumpy import ProcessState
 import pytest
-
-from aiida_quantumespresso.calculations.bands import BandsCalculation
-from aiida_quantumespresso.workflows.bands.base import BandsBaseWorkChain
 
 
 @pytest.fixture

--- a/tests/workflows/bands/test_base.py
+++ b/tests/workflows/bands/test_base.py
@@ -38,17 +38,3 @@ def test_setup(generate_workchain_bands):
 
     assert process.ctx.restart_calc is None
     assert isinstance(process.ctx.inputs, AttributeDict)
-
-
-def test_handle_unrecoverable_failure(generate_workchain_bands):
-    """Test `BandsBaseWorkChain.handle_unrecoverable_failure`."""
-    process = generate_workchain_bands(exit_code=BandsCalculation.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
-    process.setup()
-
-    result = process.handle_unrecoverable_failure(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert result.do_break
-    assert result.exit_code == BandsBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
-
-    result = process.inspect_process()
-    assert result == BandsBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE

--- a/tests/workflows/matdyn/test_base.py
+++ b/tests/workflows/matdyn/test_base.py
@@ -38,17 +38,3 @@ def test_setup(generate_workchain_matdyn):
 
     assert process.ctx.restart_calc is None
     assert isinstance(process.ctx.inputs, AttributeDict)
-
-
-def test_handle_unrecoverable_failure(generate_workchain_matdyn):
-    """Test `MatdynBaseWorkChain.handle_unrecoverable_failure`."""
-    process = generate_workchain_matdyn(exit_code=MatdynCalculation.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
-    process.setup()
-
-    result = process.handle_unrecoverable_failure(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert result.do_break
-    assert result.exit_code == MatdynBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
-
-    result = process.inspect_process()
-    assert result == MatdynBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE

--- a/tests/workflows/matdyn/test_base.py
+++ b/tests/workflows/matdyn/test_base.py
@@ -2,12 +2,8 @@
 # pylint: disable=no-member,redefined-outer-name
 """Tests for the `MatdynBaseWorkChain` class."""
 from aiida.common import AttributeDict
-from aiida.engine import ProcessHandlerReport
 from plumpy import ProcessState
 import pytest
-
-from aiida_quantumespresso.calculations.matdyn import MatdynCalculation
-from aiida_quantumespresso.workflows.matdyn.base import MatdynBaseWorkChain
 
 
 @pytest.fixture

--- a/tests/workflows/ph/test_base.py
+++ b/tests/workflows/ph/test_base.py
@@ -81,20 +81,6 @@ def test_set_qpoints(generate_workchain_ph, generate_inputs_ph, with_output_stru
         assert process.ctx.inputs['qpoints'] == inputs['qpoints']
 
 
-def test_handle_unrecoverable_failure(generate_workchain_ph):
-    """Test `PhBaseWorkChain.handle_unrecoverable_failure`."""
-    process = generate_workchain_ph(exit_code=PhCalculation.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
-    process.setup()
-
-    result = process.handle_unrecoverable_failure(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert result.do_break
-    assert result.exit_code == PhBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
-
-    result = process.inspect_process()
-    assert result == PhBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
-
-
 def test_handle_out_of_walltime(generate_workchain_ph):
     """Test `PhBaseWorkChain.handle_out_of_walltime`."""
     process = generate_workchain_ph(exit_code=PhCalculation.exit_codes.ERROR_OUT_OF_WALLTIME)

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -18,20 +18,6 @@ def test_setup(generate_workchain_pw):
     assert isinstance(process.ctx.inputs, AttributeDict)
 
 
-def test_handle_unrecoverable_failure(generate_workchain_pw):
-    """Test `PwBaseWorkChain.handle_unrecoverable_failure`."""
-    process = generate_workchain_pw(exit_code=PwCalculation.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
-    process.setup()
-
-    result = process.handle_unrecoverable_failure(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert result.do_break
-    assert result.exit_code == PwBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
-
-    result = process.inspect_process()
-    assert result == PwBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
-
-
 @pytest.mark.parametrize('structure_changed', (
     True,
     False,

--- a/tests/workflows/q2r/test_base.py
+++ b/tests/workflows/q2r/test_base.py
@@ -2,12 +2,8 @@
 # pylint: disable=no-member,redefined-outer-name
 """Tests for the `Q2rBaseWorkChain` class."""
 from aiida.common import AttributeDict
-from aiida.engine import ProcessHandlerReport
 from plumpy import ProcessState
 import pytest
-
-from aiida_quantumespresso.calculations.q2r import Q2rCalculation
-from aiida_quantumespresso.workflows.q2r.base import Q2rBaseWorkChain
 
 
 @pytest.fixture

--- a/tests/workflows/q2r/test_base.py
+++ b/tests/workflows/q2r/test_base.py
@@ -38,17 +38,3 @@ def test_setup(generate_workchain_q2r):
 
     assert process.ctx.restart_calc is None
     assert isinstance(process.ctx.inputs, AttributeDict)
-
-
-def test_handle_unrecoverable_failure(generate_workchain_q2r):
-    """Test `Q2rBaseWorkChain.handle_unrecoverable_failure`."""
-    process = generate_workchain_q2r(exit_code=Q2rCalculation.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
-    process.setup()
-
-    result = process.handle_unrecoverable_failure(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert result.do_break
-    assert result.exit_code == Q2rBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
-
-    result = process.inspect_process()
-    assert result == Q2rBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE

--- a/tests/workflows/xspectra/test_base.py
+++ b/tests/workflows/xspectra/test_base.py
@@ -5,7 +5,6 @@ from aiida.common import AttributeDict
 from aiida.engine import ProcessHandlerReport
 
 from aiida_quantumespresso.calculations.xspectra import XspectraCalculation
-from aiida_quantumespresso.workflows.xspectra.base import XspectraBaseWorkChain
 
 
 def test_setup(generate_workchain_xspectra):

--- a/tests/workflows/xspectra/test_base.py
+++ b/tests/workflows/xspectra/test_base.py
@@ -16,20 +16,6 @@ def test_setup(generate_workchain_xspectra):
     assert isinstance(process.ctx.inputs, AttributeDict)
 
 
-def test_handle_unrecoverable_failure(generate_workchain_xspectra):
-    """Test `XspectraBaseWorkChain.handle_unrecoverable_failure`."""
-    process = generate_workchain_xspectra(exit_code=XspectraCalculation.exit_codes.ERROR_NO_RETRIEVED_FOLDER)
-    process.setup()
-
-    result = process.handle_unrecoverable_failure(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert result.do_break
-    assert result.exit_code == XspectraBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
-
-    result = process.inspect_process()
-    assert result == XspectraBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
-
-
 def test_handle_out_of_walltime(generate_workchain_xspectra, fixture_localhost, generate_remote_data):
     """Test `XspectraBaseWorkChain.handle_out_of_walltime`."""
     remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')


### PR DESCRIPTION
Following the conversation with @mbercx , I've decided to create a fresh pull request. This new PR will remove the unrecoverable handler, allowing the BaseRestartWorkChain to attempt a single resubmission in the event of a node failure or an 'unrecoverable' error.