### PR TITLE
🧪 Remove `autouse=True` from `pseudo_family` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,7 @@ def serialize_builder():
     return _serialize_builder
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='session')
 def pseudo_family(generate_upf_data):
     """Create the SSSP pseudo potential families from scratch."""
     from aiida.common.constants import elements


### PR DESCRIPTION
Using `autouse=True` means the `pseudo_family` fixture is used for every test in the suite. This seems unnecessary, and a potential source of nasty bugs. If a test needs the `pseudo_family` fixture, it should use it like any other.