### PR TITLE
Fix : Feature/pdos : allow retrieval of nbands params from finished SCF calc when no SCF is launched internally

### DIFF
--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -451,12 +451,10 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         """
         inputs = AttributeDict(self.exposed_inputs(PwBaseWorkChain, 'nscf'))
 
+        # If no SCF calculation launched, `workchain_scf` is not in ctx
+        # but `nscf.pw.parent_folder` is given if inputs are valid
         if 'scf' in self.inputs:
             inputs.pw.parent_folder = self.ctx.scf_parent_folder
-        else:
-            # No SCF calculation has been launched, `workchain_scf` is not in ctx
-            # but `nscf.pw.parent_folder` is given if inputs are valid
-            self.ctx.scf_parent_folder = inputs.pw.parent_folder
 
         if 'nbands_factor' in self.inputs:
             inputs.pw.parameters = inputs.pw.parameters.get_dict()

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -46,12 +46,11 @@ Related Resources:
     (see `this post <https://lists.quantum-espresso.org/pipermail/users/2017-November/039656.html>`_).
 
 """
+import jsonschema
 from aiida import orm, plugins
 from aiida.common import AttributeDict
 from aiida.engine import ToContext, WorkChain, if_
 from aiida.orm.nodes.data.base import to_aiida_type
-import jsonschema
-
 from aiida_quantumespresso.utils.mapping import prepare_process_inputs
 
 from .protocols.utils import ProtocolMixin
@@ -451,6 +450,9 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
 
         if 'scf' in self.inputs:
             inputs.pw.parent_folder = self.ctx.scf_parent_folder
+        else:
+            # to get the SCF workchain from the remote given in input when no SCF is to be run
+            self.ctx.workchain_scf = inputs.pw.parent_folder.creator.caller
 
         if 'nbands_factor' in self.inputs:
             inputs.pw.parameters = inputs.pw.parameters.get_dict()

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -461,7 +461,7 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         if 'nbands_factor' in self.inputs:
             inputs.pw.parameters = inputs.pw.parameters.get_dict()
             factor = self.inputs.nbands_factor.value
-            parameters = self.ctx.scf_parent_folder.creator.outputs.output_parameters.get_dict()
+            parameters = inputs.pw.parent_folder.creator.outputs.output_parameters.get_dict()
             nbands = int(parameters['number_of_bands'])
             nelectron = int(parameters['number_of_electrons'])
             nbnd = max(int(0.5 * nelectron * factor), int(0.5 * nelectron) + 4, nbands)

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -46,11 +46,12 @@ Related Resources:
     (see `this post <https://lists.quantum-espresso.org/pipermail/users/2017-November/039656.html>`_).
 
 """
-import jsonschema
 from aiida import orm, plugins
 from aiida.common import AttributeDict
 from aiida.engine import ToContext, WorkChain, if_
 from aiida.orm.nodes.data.base import to_aiida_type
+import jsonschema
+
 from aiida_quantumespresso.utils.mapping import prepare_process_inputs
 
 from .protocols.utils import ProtocolMixin

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -262,7 +262,7 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         spec.expose_inputs(
             PwBaseWorkChain,
             namespace='nscf',
-            exclude=('clean_workdir', 'pw.structure', 'pw.parent_folder'),
+            exclude=('clean_workdir', 'pw.structure'),
             namespace_options={
                 'help': 'Inputs for the `PwBaseWorkChain` of the `nscf` calculation.',
                 'validator': validate_nscf


### PR DESCRIPTION
This pull request reopens #1079. 
The problem was the following: 
In the case where no SCF workchain is explicitly launched, workchain_scf is not in self.ctx so an error occurs when trying to get the output_parameters of the SCF workchain and retrieve the number of bands used when launching NSCF WorkChain.

The PR introduces several improvements and fixes to the `PdosWorkChain` workflow in `src/aiida_quantumespresso/workflows/pdos.py`, focusing on handling of the SCF calculation folders, and logic to retrieve nbands parameter for NSCF calculation.

To answer the last question on the closed PR, yes the use case consisting of performing an SCF calculation internally with `serial_clean=True` is still valid.
But a `serial_clean` can also be used with an external SCF calculation and in that case we do not want to erase mistakenly the remote folder of that external calculation. So I modified the cleaning logic accordingly.


**Calculation folder handling:**
* In `run_nscf`, clarified assignment of `scf_parent_folder` in the absence of an SCF calculation, ensuring correct context setup when only `nscf.pw.parent_folder` is provided.
* In `inspect_nscf`, improved logic for cleaning SCF remote folders, only cleaning if the SCF was run in this workchain, and preserving user-supplied folders otherwise.

**Band calculation logic:**
* Updated logic in `run_nscf` to fetch output parameters from the correct source (`scf_parent_folder.creator.outputs.output_parameters`) when calculating the number of bands, ensuring compatibility with both workchain-run and user-supplied SCF folders through a `PwCalculation`.

**Interface and usability improvements:**
* Modified input exposure for the NSCF namespace to no longer exclude `pw.parent_folder`, allowing users to supply this input directly when skipping the SCF step. Otherwise one cannot add a `pw.parent_folder` to the builder and the corresponding input validation is useless.