### PR TITLE
👌 Protocols: Add validation on `overrides` keys

### DIFF
--- a/src/aiida_quantumespresso/workflows/protocols/utils.py
+++ b/src/aiida_quantumespresso/workflows/protocols/utils.py
@@ -17,10 +17,6 @@ from aiida_quantumespresso.common.types import SpinType
 class ProtocolMixin:
     """Utility class for processes to build input mappings for a given protocol based on a YAML configuration file."""
 
-    # Mapping of "protocol inputs": keys allowed in `overrides` that are not part of the process spec.
-    # Used during validation to catch typos or misplaced override keys.
-    _protocol_input_mapping = {}
-
     @classmethod
     def get_protocol_filepath(cls) -> pathlib.Path:
         """Return the ``pathlib.Path`` to the ``.yaml`` file that defines the protocols."""
@@ -149,7 +145,7 @@ class ProtocolMixin:
                 if isinstance(value, dict) and isinstance(inputs_mapping.get(key), dict):
                     recursive_key_check(inputs_mapping[key], value, full_key)
 
-        inputs_mapping = recursive_merge(port_namespace_to_dict(cls.spec().inputs), cls._protocol_input_mapping)
+        inputs_mapping = recursive_merge(cls.get_protocol_inputs(), port_namespace_to_dict(cls.spec().inputs))
         recursive_key_check(inputs_mapping, overrides)
 
 

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -24,13 +24,6 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
     # pylint: disable=too-many-public-methods, too-many-statements
 
     _process_class = PwCalculation
-    _protocol_input_mapping = {
-        'pseudo_family': None,
-        'meta_parameters': {
-            'conv_thr_per_atom': None,
-            'etot_conv_thr_per_atom': None,
-        }
-    }
 
     defaults = AttributeDict({
         'qe': qe_defaults,

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -24,6 +24,13 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
     # pylint: disable=too-many-public-methods, too-many-statements
 
     _process_class = PwCalculation
+    _protocol_input_mapping = {
+        'pseudo_family': None,
+        'meta_parameters': {
+            'conv_thr_per_atom': None,
+            'etot_conv_thr_per_atom': None,
+        }
+    }
 
     defaults = AttributeDict({
         'qe': qe_defaults,

--- a/tests/workflows/protocols/pw/test_relax.py
+++ b/tests/workflows/protocols/pw/test_relax.py
@@ -151,3 +151,49 @@ def test_pbc_cell(fixture_code, generate_structure, struc_name, cell_dofree):
 
     builder = PwRelaxWorkChain.get_builder_from_protocol(code, structure)
     assert builder.base_relax.pw.parameters['CELL'].get('cell_dofree', None) == cell_dofree
+
+
+@pytest.mark.parametrize(
+    'overrides,warning',
+    (
+        # CORRECT overrides for top-level process input
+        ({
+            'clean_workdir': True
+        }, None),
+        # CORRECT overrides for nested process input
+        ({
+            'base_relax': {
+                'kpoints_force_parity': True
+            }
+        }, None),
+        # CORRECT overrides for nested protocol input
+        ({
+            'base_relax': {
+                'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'
+            }
+        }, None),
+        # WRONG overrides with typo
+        ({
+            'clean_wokdir': True
+        }, UserWarning),
+        # WRONG overrides with process input at incorrect level
+        ({
+            'base_relax': {
+                'clean_workdir': True
+            }
+        }, UserWarning),
+        # WRONG overrides with protocol input at incorrect level
+        ({
+            'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'
+        }, UserWarning),
+    )
+)
+def test_overrides_key_check(fixture_code, generate_structure, overrides, warning):
+    """Test that the `get_builder_from_protocol()` method warns for erroneous keys in the `overrides`."""
+
+    with pytest.warns(warning):
+        PwRelaxWorkChain.get_builder_from_protocol(
+            fixture_code('quantumespresso.pw'),
+            generate_structure('silicon'),
+            overrides=overrides,
+        )


### PR DESCRIPTION
Fixes #1134

When using the `overrides` input of the `get_builder_from_protocol()` method, it is easy to make a mistake by e.g. having a typo or setting an input at the wrong level. Currently these overrides are silently ignored, which can lead to hard to debug issues and potentially incorrect results, potentially unknown to the user. The nested inputs of many work chains can be quite complex, which makes the issue even more problematic.

Here we add the `_validate_override_keys()` method to the `ProtocolMixin` that checks for erroneous keys in the `overrides` input and warns the user in case they are present. In order to be able to check for both

* "process inputs": inputs defined as ports on the process e.g. `clean_workdir`.
* "protocol inputs": inputs used by the protocol method e.g. `pseudo_family`.

We convert the `inputs` `PortNamespace` into a dictionary and merge it with a `_protocol_input_mapping` class variable that a developer can specify on their process class. This means that in case a class uses such protocol inputs, it needs to set `_protocol_input_mapping` to avoid raising warning for correct usage of "protocol inputs" in the `overrides`.

Finally, we recursively check the `overrides` dictionary keys against the combined `inputs_mapping`.

Note that the `_validate_override_keys()` method does _not_ validate the final inputs provided. This is the job of either the input port validator for "process inputs" or the `get_builder_from_protocol()` method for "protocol inputs".