### PR TITLE
👌 Fix entry point of `realhydrogen` to `core.realhydrogen`

### DIFF
--- a/src/aiida_quantumespresso/parsers/projwfc.py
+++ b/src/aiida_quantumespresso/parsers/projwfc.py
@@ -212,7 +212,7 @@ class ProjwfcParser(BaseParser):
         elif non_collinear:
             orbital_class = OrbitalFactory('noncollinearhydrogen')
         else:
-            orbital_class = OrbitalFactory('realhydrogen')
+            orbital_class = OrbitalFactory('core.realhydrogen')
         for new_orbital_dict in orbital_dicts:
             orbitals.append(orbital_class(**new_orbital_dict))
 


### PR DESCRIPTION
The `RealhydrogenOrbital` class was still loaded with the old entry point, here add the `core.` prepend to remove deprecation warnings.

Note that the `spinorbithydrogen` and `noncollinearhydrogen` entry points are defined in this repository, so they don't need the `core.` prefix. In principle we should add the `quantumespresso.` prefix, but frankly I think we should move these to `aiida-atomistic`.