### PR TITLE
🐛 `NebCalculation`: Fix top-level inputs validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ disable = [
     'too-many-ancestors',
     'too-many-branches',
     'too-many-locals',
+    'too-many-return-statements',
     'use-dict-literal',
 ]
 

--- a/tests/calculations/test_neb.py
+++ b/tests/calculations/test_neb.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Tests for the `NebCalculation` class."""
+import pytest
+
+
+def test_neb_calcjob_validation(fixture_sandbox, generate_calc_job, generate_inputs):
+    """Test that the `NebCalculation` still uses the `CalcJob` top-level input validation."""
+    entry_point_name = 'quantumespresso.neb'
+
+    inputs = generate_inputs(entry_point_name)
+    inputs['metadata'] = {'options': {'resources': {'non-existent': 1}}}
+    with pytest.raises(ValueError, match='input `metadata.options.resources` is not valid for the'):
+        generate_calc_job(fixture_sandbox, entry_point_name, inputs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -584,7 +584,7 @@ def generate_force_constants_data(filepath_tests):
 @pytest.fixture
 def generate_inputs(
     generate_inputs_bands, generate_inputs_cp, generate_inputs_matdyn, generate_inputs_ph, generate_inputs_pw,
-    generate_inputs_q2r
+    generate_inputs_q2r, generate_inputs_neb
 ):
     """Generate the inputs for a process."""
 
@@ -595,6 +595,7 @@ def generate_inputs(
         'quantumespresso.ph': generate_inputs_ph,
         'quantumespresso.matdyn': generate_inputs_matdyn,
         'quantumespresso.q2r': generate_inputs_q2r,
+        'quantumespresso.neb': generate_inputs_neb
     }
 
     def _generate_inputs(entry_point: str):
@@ -786,8 +787,8 @@ def generate_inputs_neb(fixture_code, generate_trajectory, generate_kpoints_mesh
             'code': fixture_code('quantumespresso.neb'),
             'images': trajectory,
             'parameters': neb_parameters,
-            'kpoints': generate_kpoints_mesh(1),
             'pw': {
+                'kpoints': generate_kpoints_mesh(1),
                 'parameters': pw_parameters,
                 'pseudos':
                 {kind: generate_upf_data(kind) for kind in trajectory.get_step_structure(-1).get_kind_names()},
@@ -913,7 +914,7 @@ def generate_workchain_neb(generate_workchain, generate_inputs_neb, generate_cal
 
         if inputs is None:
             neb_inputs = generate_inputs_neb()
-            kpoints = neb_inputs.pop('kpoints')
+            kpoints = neb_inputs['pw'].pop('kpoints')
             inputs = {'neb': neb_inputs, 'kpoints': kpoints}
 
         if return_inputs:


### PR DESCRIPTION
Fixes #1141

In b0b63c1c2493949a8ffe95fe59ae2da98ffe6b62 we added a top-level validator to the `NebCalculation`. This approach is solid, and warns/stops the user before runtime if there are issues with the inputs.

However, in doing so we override the default `CalcJob` validation. To fix this, we take the same approach as is used in the `PwCalculation`: manually apply the `validate_calc_job` validation function on the top-level inputs in the `NebCalculation.validate_inputs` method.

We also change the name of the `inputs` input argument to `value`, to be consistent with other validators.