### PR TITLE
Revisited the logic for the number of bands determination, in the case of spin-orbit calculations.

### DIFF
--- a/src/aiida_quantumespresso/workflows/pw/bands.py
+++ b/src/aiida_quantumespresso/workflows/pw/bands.py
@@ -267,7 +267,6 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
         inputs.pw.parameters.setdefault('SYSTEM', {})
         inputs.pw.parameters.setdefault('ELECTRONS', {})
 
-        is_soc = inputs.pw.parameters['SYSTEM'].get('lspinorb', False)
         electrons_per_band = 1 if inputs.pw.parameters['SYSTEM'].get('noncolin', False) else 2
         # If `nbands_factor` is defined in the inputs we set the `nbnd` parameter
         if 'nbands_factor' in self.inputs:


### PR DESCRIPTION
In band-structure calculations with spin–orbit coupling, each band can hold only one electron, so the current logic is insufficient. This PR revises the band-counting logic. 