### PR TITLE
🔧 CI: use Hatch for nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,22 +41,18 @@ jobs:
             with:
                 python-version: ${{ matrix.python-version }}
 
-        - name: Setup uv
-          uses: astral-sh/setup-uv@v6
-          with:
-              activate-environment: true
-              python-version: ${{ matrix.python-version }}
+        -   name: Install Hatch
+            run: python -m pip install hatch
 
-        -   name: Install Python dependencies
+        -   name: Install aiida-core main branch
             id: install
-            run: |
-                uv pip install -e .[tests] aiida-core[atomic_tools]@git+https://github.com/aiidateam/aiida-core@main
+            run: hatch run uv pip install aiida-core[atomic_tools]@git+https://github.com/aiidateam/aiida-core@main
 
         -   name: Run pytest
             id: tests
             env:
                 AIIDA_WARN_v3: 1
-            run: pytest -sv tests
+            run: hatch run pytest -sv tests
 
         -   name: Slack notification
             if: always() && (steps.install.outcome == 'failure' || steps.tests.outcome == 'failure') && env.SLACK_WEBHOOK != null


### PR DESCRIPTION
In cddf25a97b116769f43c582ac52984ccefe26a42 we switched to Hatch for our build system and adding environments/scrips for running various devops tasks in separate Python environments. The regular CI was updated correctly, but the nightly build also relied on the `tests` optional dependencies that were removed.

Here we adapt the nightly build to also rely on the Hatch environments.