### PR TITLE
🔧 Hatch: clean up `pre-commit` environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,9 +140,7 @@ scripts.view = 'make -C docs view'
 
 [tool.hatch.envs.pre-commit]
 dependencies = [
-    'pre-commit',
-    'pylint==2.15.10',
-    'pylint-aiida==0.1.1'
+    'pre-commit>=4.3.0',
 ]
 scripts.install = 'pre-commit install'
 scripts.run = 'pre-commit run {args}'


### PR DESCRIPTION
In cb8a5445aedfc12270556875089090f57cd2d0c7 we decided to move to the Ruff linter, after removing `pylint` from the pre-commit in cddf25a97b116769f43c582ac52984ccefe26a42. However, we forgot to remove `pylint` and the AiiDA plugin as dependencies of the corresponding Hatch environment. This is corrected here.