### PR TITLE
🔧 Diversify and document our devops tools

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,7 +74,7 @@ jobs:
         -   name: Run pytest
             env:
                 AIIDA_WARN_v3: 1
-            run: hatch run pytest -sv tests
+            run: hatch test -v -- -s
 
 
     publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
         -   name: Run pytest
             env:
                 AIIDA_WARN_v3: 1
-            run: hatch run pytest -sv tests
+            run: hatch test -v -- -s

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
             id: tests
             env:
                 AIIDA_WARN_v3: 1
-            run: hatch run pytest -sv tests
+            run: hatch test -v -- -s
 
         -   name: Slack notification
             if: always() && (steps.install.outcome == 'failure' || steps.tests.outcome == 'failure') && env.SLACK_WEBHOOK != null

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,11 @@
 repos:
-- repo: local
-  hooks:
-  - id: format
-    name: Format with Ruff
-    entry: hatch fmt -f
-    language: system
-    types: [python]
-  - id: lint
-    name: Lint with Ruff
-    entry: hatch fmt -l
-    language: system
-    types: [python]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.2
+    hooks:
+      - id: ruff-check
+        name: Lint with Ruff
+        types_or: [ python, pyi ]
+        args: [ --fix ]
+      - id: ruff-format
+        name: Format with Ruff
+        types_or: [ python, pyi ]

--- a/docs/source/developer.md
+++ b/docs/source/developer.md
@@ -1,5 +1,245 @@
 # Developer Guide
 
+## Quick start
+
+Thanks for contributing! 🙏
+Below you can find an overview of the commands to get you up and running quickly, depending on your preferred development tools.
+
+First clone the repository from GitHub and install the package locally in **editable** mode (`-e`):
+
+```
+$ git clone https://github.com/aiidateam/aiida-quantumespresso
+$ cd aiida-quantumespresso
+$ pip install -e .
+```
+
+::::{tab-set}
+
+:::{tab-item} Default
+
+The "default" approach to developing is to install the development extras in your current environment:
+
+```console
+$ pip install -e .[pre-commit,tests,docs]
+```
+
+````{tip}
+You can also install the development dependencies using the new [dependency groups](https://packaging.python.org/en/latest/specifications/dependency-groups/), [available from `pip` v25.1](https://ichard26.github.io/blog/2025/04/whats-new-in-pip-25.1/):
+
+```console
+$ pip install -e . --group dev
+```
+
+In the future the development extras will most likely be removed.
+
+````
+
+**Pre-commit**
+
+To make sure your changes adhere to our formatting/linting preferences, install the pre-commit hooks:
+
+```console
+$ pre-commit install
+```
+
+They will then run on every `git commit`.
+You can also run them on e.g. all files using:
+
+```console
+$ pre-commit run -a
+```
+
+Drop the `-a` option in case you only want to run on staged files.
+
+**Tests**
+
+You can run all tests in the `tests` directory with `pytest`:
+
+```console
+$ pytest
+```
+
+Or select the test module:
+
+```console
+$ pytest tests/parsers/test_pw.py
+```
+
+See the [`pytest` documentation](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run) for more information.
+
+**Documentation**
+
+The current documentation build relies on a [Sphinx](https://www.sphinx-doc.org/en/master/index.html)-generated [Makefile](https://www.gnu.org/software/make/manual/make.html).
+Build the documentation with:
+
+```console
+$ make -C docs html
+```
+
+Once complete, you can open the documentation in your browser using:
+
+```console
+$ make -C docs view
+```
+
+Or clean the documentation files:
+
+```console
+$ make -C docs clean
+```
+
+See the [documentation](#developer-documentation) section for more information on how we write our documentation.
+
+:::
+
+:::{tab-item} uv
+
+`uv` is a Python package and project manager.
+See [the documentation](https://docs.astral.sh/uv/getting-started/installation/) on how to install `uv`.
+
+**Pre-commit**
+
+To make sure your changes adhere to our formatting/linting preferences, install the pre-commit hooks:
+
+```console
+$ uvx pre-commit install
+```
+
+They will then run on every `git commit`.
+You can also run them on e.g. all files using:
+
+```console
+$ uvx pre-commit run -a
+```
+
+Drop the `-a` option in case you only want to run on staged files.
+
+```{note}
+Here we use the [`uvx` command](https://docs.astral.sh/uv/guides/tools/#running-tools) to run the `pre-commit` tool without installing it.
+Alternatively you can also install [`pre-commit` as a tool](https://docs.astral.sh/uv/guides/tools/#installing-tools) and omit `uvx`.
+```
+
+**Tests**
+
+You can run all tests in the `tests` directory with `pytest`:
+
+```console
+$ uv run pytest
+```
+
+Or select the test module:
+
+```console
+$ uv run pytest tests/parsers/test_pw.py
+```
+
+See the [`pytest` documentation](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run) for more information.
+
+**Documentation**
+
+The current documentation build relies on a [Sphinx](https://www.sphinx-doc.org/en/master/index.html)-generated [Makefile](https://www.gnu.org/software/make/manual/make.html).
+Build the documentation with:
+
+```console
+$ uv run make -C docs html
+```
+
+Once complete, you can open the documentation in your browser using:
+
+```console
+$ uv run make -C docs view
+```
+
+Or clean the documentation files:
+
+```console
+$ uv run make -C docs clean
+```
+
+See the [documentation](#developer-documentation) section for more information on how we write our documentation.
+
+:::
+
+:::{tab-item} Hatch
+
+You can use [Hatch](https://hatch.pypa.io/1.9/install/) to run development tools in isolated environments.
+
+**Pre-commit**
+
+To make sure your changes adhere to our formatting/linting preferences, install the pre-commit hooks:
+
+```console
+$ hatch run pre-commit:install
+```
+
+They will then run on every `git commit`.
+You can also run them on e.g. all files using:
+
+```console
+$ hatch run pre-commit:run -a
+```
+
+Drop the `-a` option in case you only want to run on staged files.
+
+**Tests**
+
+You can run all tests in the `tests` directory using:
+
+```console
+$ hatch test
+```
+
+Or select the test module:
+
+```console
+$ hatch test tests/parsers/test_pw.py
+```
+
+You can also run the tests for a specific Python version with the `-py` option:
+
+```
+$ hatch test -py 3.11
+```
+
+Or all supported Python `versions` with `--all`:
+
+```
+$ hatch test --all
+```
+
+See the [Hatch documentation](https://hatch.pypa.io/1.12/tutorials/testing/overview/) for more information.
+
+**Documentation**
+
+The current documentation build relies on a [Sphinx](https://www.sphinx-doc.org/en/master/index.html)-generated [Makefile](https://www.gnu.org/software/make/manual/make.html).
+Build the documentation with Hatch in the `docs` environment using:
+
+```console
+$ hatch run docs:build
+```
+
+This runs `make` under the hood.
+Once complete, you can open the documentation in your browser using:
+
+```console
+$ hatch run docs:view
+```
+
+Or clean the documentation files:
+
+```console
+$ hatch run docs:clean
+```
+
+See the [documentation](#developer-documentation) section for more information on how we write our documentation.
+
+:::
+
+::::
+
+
+(developer-documentation)=
+
 ## Documentation
 
 We use the [Diátaxis](https://diataxis.fr/) approach for organising the documentation in four sections:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ path = 'src/aiida_quantumespresso/__init__.py'
 installer = 'uv'
 dependencies = [
     'pgtest~=1.3',
-    'pytest~=6.0',
+    'pytest~=8.4',
     'pytest-regressions~=2.3'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,19 @@ docs = [
     'sphinx-autoapi~=3.0.0',
     'myst-parser~=3.0.0',
 ]
+tests = [
+    'pgtest~=1.3',
+    'pytest~=8.4',
+    'pytest-regressions~=2.8',
+]
+pre-commit = [
+    'pre-commit>=4.3.0',
+]
+
+[dependency-groups]
+dev = [
+  "aiida-quantumespresso[docs,tests,pre-commit]",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ['src/aiida_quantumespresso']
@@ -126,24 +139,26 @@ path = 'src/aiida_quantumespresso/__init__.py'
 
 [tool.hatch.envs.default]
 installer = 'uv'
-dependencies = [
-    'pgtest~=1.3',
-    'pytest~=8.4',
-    'pytest-regressions~=2.3'
-]
+
+[tool.hatch.envs.pre-commit]
+features = ["pre-commit"]
+scripts.install = 'pre-commit install'
+scripts.run = 'pre-commit run {args}'
+
+[tool.hatch.envs.hatch-test]
+features = ["tests"]
+randomize = false
+parallel = false
+run = "pytest {args}"
+
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.docs]
 features = ["docs"]
 scripts.clean = 'make -C docs clean'
 scripts.build = 'make -C docs html'
 scripts.view = 'make -C docs view'
-
-[tool.hatch.envs.pre-commit]
-dependencies = [
-    'pre-commit>=4.3.0',
-]
-scripts.install = 'pre-commit install'
-scripts.run = 'pre-commit run {args}'
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ scripts.install = 'pre-commit install'
 scripts.run = 'pre-commit run {args}'
 
 [tool.ruff]
+line-length = 120
 lint.ignore = [
     "ARG002",  # https://docs.astral.sh/ruff/rules/unused-method-argument/
     "ARG004",  # https://docs.astral.sh/ruff/rules/unused-static-method-argument/

--- a/src/aiida_quantumespresso/calculations/__init__.py
+++ b/src/aiida_quantumespresso/calculations/__init__.py
@@ -443,7 +443,7 @@ class BasePwCpInputGenerator(CalcJob):
             if aliases_in_cmdline:
                 if len(aliases_in_cmdline) > 1:
                     raise exceptions.InputValidationError(
-                        f'Conflicting parallelization flags {aliases_in_cmdline} ' "in settings['CMDLINE']"
+                        f"Conflicting parallelization flags {aliases_in_cmdline} in settings['CMDLINE']"
                     )
                 if flag_name in parallelization_dict:
                     raise exceptions.InputValidationError(
@@ -718,7 +718,7 @@ class BasePwCpInputGenerator(CalcJob):
 
                 elif len(kpoints_list) != 1 or tuple(kpoints_list[0]) != tuple(0.0, 0.0, 0.0):
                     raise exceptions.InputValidationError(
-                        'If a gamma_only calculation is requested, the ' 'kpoints coordinates must only be (0.,0.,0.)'
+                        'If a gamma_only calculation is requested, the kpoints coordinates must only be (0.,0.,0.)'
                     )
 
                 kpoints_type = 'gamma'
@@ -761,7 +761,7 @@ class BasePwCpInputGenerator(CalcJob):
             namelists_toprint = settings.pop('NAMELISTS')
             if not isinstance(namelists_toprint, list):
                 raise exceptions.InputValidationError(
-                    "The 'NAMELISTS' value, if specified in the settings input " 'node, must be a list of strings'
+                    "The 'NAMELISTS' value, if specified in the settings input node, must be a list of strings"
                 )
         except KeyError:  # list of namelists not specified; do automatic detection
             try:
@@ -808,7 +808,7 @@ class BasePwCpInputGenerator(CalcJob):
         if input_params:
             raise exceptions.InputValidationError(
                 'The following namelists are specified in input_params, but are not valid namelists for the current '
-                f"type of calculation: {', '.join(list(input_params.keys()))}"
+                f'type of calculation: {", ".join(list(input_params.keys()))}'
             )
 
         return inputfile, local_copy_list_to_append

--- a/src/aiida_quantumespresso/calculations/cp.py
+++ b/src/aiida_quantumespresso/calculations/cp.py
@@ -154,7 +154,7 @@ class CpCalculation(BasePwCpInputGenerator):
                 if isinstance(event['newvalue'], str):
                     autopilot_card += f"ON_STEP = {event['onstep']} : '{event['what']}' = {event['newvalue']}\n"
                 else:
-                    autopilot_card += f"ON_STEP = {event['onstep']} : {event['what']} = {event['newvalue']}\n"
+                    autopilot_card += f'ON_STEP = {event["onstep"]} : {event["what"]} = {event["newvalue"]}\n'
         except KeyError as exception:
             raise exceptions.InputValidationError(
                 f"""AUTOPILOT input: you must specify a list of dictionaries like the following:

--- a/src/aiida_quantumespresso/calculations/helpers/__init__.py
+++ b/src/aiida_quantumespresso/calculations/helpers/__init__.py
@@ -203,7 +203,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
         else:
             add_str = f' (the older, closest version you can use is {strictversions[pos - 1]})'
         raise QEInputValidationError(
-            f"Unknown Quantum Espresso version: {version}. Available versions: {', '.join(versions)};{add_str}"
+            f'Unknown Quantum Espresso version: {version}. Available versions: {", ".join(versions)};{add_str}'
         ) from exception
 
     # ========== List of known PW variables (from XML file) ===============
@@ -337,7 +337,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
     except KeyError as exception:
         raise QEInputValidationError(
             'Error, you need to specify at least the calculation type (among '
-            f"{', '.join(list(valid_calculations_and_opt_namelists.keys()))})"
+            f'{", ".join(list(valid_calculations_and_opt_namelists.keys()))})'
         ) from exception
 
     try:
@@ -345,7 +345,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
     except KeyError as exception:
         raise QEInputValidationError(
             f'Error, {calculation_type} is not a valid value for '
-            f"the calculation type (valid values: {', '.join(list(valid_calculations_and_opt_namelists.keys()))}"
+            f'the calculation type (valid values: {", ".join(list(valid_calculations_and_opt_namelists.keys()))}'
         ) from exception
 
     internal_dict = {i: {} for i in compulsory_namelists + opt_namelists}
@@ -586,7 +586,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
             if len(similar_kws) == 1:
                 err_str += f'Maybe you wanted to specify {similar_kws[0]}?'
             elif len(similar_kws) > 1:
-                err_str += f"Maybe you wanted to specify one of these: {', '.join(similar_kws)}?"
+                err_str += f'Maybe you wanted to specify one of these: {", ".join(similar_kws)}?'
             else:
                 err_str += '(No similar keywords found...)'
             if stop_at_first_error:
@@ -600,7 +600,7 @@ def pw_input_helper(input_params, structure, stop_at_first_error=False, flat_mod
     # ============== I check here compulsory variables ===========
     missing_kws = compulsory_kws - set(inserted_kws)
     if missing_kws:
-        err_str = f"Missing compulsory variables: {', '.join(missing_kws)}."
+        err_str = f'Missing compulsory variables: {", ".join(missing_kws)}.'
         if stop_at_first_error:
             raise QEInputValidationError(err_str)
 

--- a/src/aiida_quantumespresso/calculations/neb.py
+++ b/src/aiida_quantumespresso/calculations/neb.py
@@ -190,15 +190,15 @@ class NebCalculation(CalcJob):
         for image_idx, structure in enumerate(structure_list[1:]):
             # Check that all images have the same cell
             if abs(np.array(structure_list[0].cell) - np.array(structure.cell)).max() > 1.0e-4:
-                return f'Different cell in the first and image {image_idx+1}'
+                return f'Different cell in the first and image {image_idx + 1}'
 
             # Check that all images have the same number of sites
             if len(structure_list[0].sites) != len(structure.sites):
-                return f'Different number of sites in the first and image {image_idx+1}'
+                return f'Different number of sites in the first and image {image_idx + 1}'
 
             # Check that all images have the same kinds
             if structure_list[0].get_site_kindnames() != structure.get_site_kindnames():
-                return f'Mismatch between the kind names and/or order between the first and image {image_idx+1}'
+                return f'Mismatch between the kind names and/or order between the first and image {image_idx + 1}'
 
             # Check that a pseudo potential was specified for each kind present in the `StructureData`
             # self.inputs.pw.pseudos is a plumpy.utils.AttributesFrozendict
@@ -254,7 +254,7 @@ class NebCalculation(CalcJob):
             num_of_images = input_params['PATH'].get('num_of_images', 2)
             if any((i < 2 or i >= num_of_images) for i in climbing_image_list):
                 raise InputValidationError(
-                    'The climbing images should be in the range between the first ' 'and the last image (excluded).'
+                    'The climbing images should be in the range between the first and the last image (excluded).'
                 )
             climbing_image_card = 'CLIMBING_IMAGES\n'
             climbing_image_card += ', '.join([str(_) for _ in climbing_image_list]) + '\n'
@@ -277,7 +277,7 @@ class NebCalculation(CalcJob):
         if input_params:
             raise InputValidationError(
                 'The following namelists are specified in input_params, but are not valid namelists for the current '
-                f"type of calculation: {', '.join(list(input_params.keys()))}"
+                f'type of calculation: {", ".join(list(input_params.keys()))}'
             )
 
         return input_data, namelist

--- a/src/aiida_quantumespresso/calculations/ph.py
+++ b/src/aiida_quantumespresso/calculations/ph.py
@@ -256,7 +256,7 @@ class PhCalculation(CalcJob):
             namelists_toprint = settings.pop('NAMELISTS')
             if not isinstance(namelists_toprint, list):
                 raise exceptions.InputValidationError(
-                    "The 'NAMELISTS' value, if specified in the settings input " 'node, must be a list of strings'
+                    "The 'NAMELISTS' value, if specified in the settings input node, must be a list of strings"
                 )
         except KeyError:  # list of namelists not specified in the settings; do automatic detection
             namelists_toprint = self._compulsory_namelists
@@ -281,7 +281,7 @@ class PhCalculation(CalcJob):
         if parameters:
             raise exceptions.InputValidationError(
                 'The following namelists are specified in parameters, but are not valid namelists for the current type '
-                f"of calculation: {', '.join(list(parameters.keys()))}"
+                f'of calculation: {", ".join(list(parameters.keys()))}'
             )
 
         # copy the parent scratch

--- a/src/aiida_quantumespresso/calculations/pp.py
+++ b/src/aiida_quantumespresso/calculations/pp.py
@@ -218,7 +218,7 @@ class PpCalculation(CalcJob):
         if parameters:
             raise exceptions.InputValidationError(
                 'The following namelists are specified in parameters, but are not valid namelists for the current type '
-                f"of calculation: {', '.join(list(parameters.keys()))}"
+                f'of calculation: {", ".join(list(parameters.keys()))}'
             )
 
         remote_copy_list = []

--- a/src/aiida_quantumespresso/calculations/pw.py
+++ b/src/aiida_quantumespresso/calculations/pw.py
@@ -66,7 +66,7 @@ class PwCalculation(BasePwCpInputGenerator):
             'metadata.options.without_xml',
             valid_type=bool,
             required=False,
-            help='If set to `True` the parser ' 'will not fail if the XML file is missing in the retrieved folder.',
+            help='If set to `True` the parser will not fail if the XML file is missing in the retrieved folder.',
         )
         spec.input('kpoints', valid_type=orm.KpointsData, help='kpoint mesh or kpoint path')
         spec.input(

--- a/src/aiida_quantumespresso/calculations/pwimmigrant.py
+++ b/src/aiida_quantumespresso/calculations/pwimmigrant.py
@@ -237,7 +237,7 @@ class PwimmigrantCalculation(PwCalculation):
             # else.
             if pwinputfile.namelists['SYSTEM']['ibrav'] != 0:
                 raise FeatureNotAvailable(
-                    'Found ibrav !=0 while parsing the input file. ' 'Currently, AiiDa only supports ibrav = 0.'
+                    'Found ibrav !=0 while parsing the input file. Currently, AiiDa only supports ibrav = 0.'
                 )
 
             # Create Dict node based on the namelist and link as input.
@@ -364,7 +364,7 @@ class PwimmigrantCalculation(PwCalculation):
         # Check that the create_input_nodes method has run successfully.
         if not self.get_attr('input_nodes_created', False):
             raise InvalidOperation(
-                'You must run the create_input_nodes method before calling ' 'prepare_for_retrieval_and_parsing!'
+                'You must run the create_input_nodes method before calling prepare_for_retrieval_and_parsing!'
             )
 
         # Check that open_transport is the correct transport type.

--- a/src/aiida_quantumespresso/cli/setup/codes.py
+++ b/src/aiida_quantumespresso/cli/setup/codes.py
@@ -112,7 +112,7 @@ def setup_codes_cmd(
             label=label,
             computer=computer,
             filepath_executable=exec_path,
-            default_calc_job_plugin=f"quantumespresso.{executable.split('.')[0]}",
+            default_calc_job_plugin=f'quantumespresso.{executable.split(".")[0]}',
             prepend_text=prepend_text,
             append_text=append_text,
         )

--- a/src/aiida_quantumespresso/cli/utils/display.py
+++ b/src/aiida_quantumespresso/cli/utils/display.py
@@ -35,8 +35,8 @@ def echo_process_results(node):
         click.echo(f'{class_name}<{node.pk}> registered no outputs')
         return
 
-    click.echo(f"\n{'Output link':25s} Node pk and type")
-    click.echo(f"{'-' * 60}")
+    click.echo(f'\n{"Output link":25s} Node pk and type')
+    click.echo(f'{"-" * 60}')
 
     for triple in sorted(outputs, key=lambda triple: triple.link_label):
         click.echo(f'{triple.link_label:25s} {triple.node.__class__.__name__}<{triple.node.pk}> ')

--- a/src/aiida_quantumespresso/cli/utils/validate.py
+++ b/src/aiida_quantumespresso/cli/utils/validate.py
@@ -122,7 +122,7 @@ def validate_smearing(parameters, smearing=None):
             break
     else:
         raise ValueError(
-            f"the smearing type `{smearing[0]}` is invalid, choose from {', '.join(list(valid_smearing_types.keys()))}"
+            f'the smearing type `{smearing[0]}` is invalid, choose from {", ".join(list(valid_smearing_types.keys()))}'
         )
 
     if not isinstance(smearing[1], float):

--- a/src/aiida_quantumespresso/parsers/parse_raw/ph.py
+++ b/src/aiida_quantumespresso/parsers/parse_raw/ph.py
@@ -290,7 +290,7 @@ def parse_ph_dynmat(data, logs, lattice_parameter=None, also_eigenvectors=False,
                 alat = header_dict['celldm'][0] * CONSTANTS.bohr_to_ang
                 if abs(alat) < 1.0e-5:
                     raise QEOutputParsingError(
-                        'Lattice constant=0! Probably you are using an ' 'old Quantum ESPRESSO version?'
+                        'Lattice constant=0! Probably you are using an old Quantum ESPRESSO version?'
                     )
                 header_dict['alat'] = alat
                 header_dict['alat_units'] = 'angstrom'

--- a/src/aiida_quantumespresso/parsers/parse_xml/pw/legacy.py
+++ b/src/aiida_quantumespresso/parsers/parse_xml/pw/legacy.py
@@ -212,7 +212,7 @@ def parse_pw_xml_pre_6_2(xml_file, dir_with_bands):
     attrname = 'UNITS'
     units = parse_xml_child_attribute_str(tagname, attrname, target_tags)
     if units not in ['hartree']:
-        raise QEOutputParsingError(f"Expected energy units in Hartree. Got instead {parsed_data['energy_units']}")
+        raise QEOutputParsingError(f'Expected energy units in Hartree. Got instead {parsed_data["energy_units"]}')
 
     try:
         tagname = 'TWO_FERMI_ENERGIES'

--- a/src/aiida_quantumespresso/parsers/parse_xml/versions.py
+++ b/src/aiida_quantumespresso/parsers/parse_xml/versions.py
@@ -28,7 +28,7 @@ def get_xml_file_version(xml):
 
     raise XMLUnsupportedFormatError(
         f'unrecognized XML file version: cannot find schema {get_schema_filename(xml)} in '
-        f"{os.path.join(os.path.dirname(os.path.abspath(__file__)), 'schemas')}. "
+        f'{os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas")}. '
         'You can look for it in https://github.com/QEF/qeschemas'
     )
 

--- a/src/aiida_quantumespresso/tools/data/orbital/noncollinearhydrogen.py
+++ b/src/aiida_quantumespresso/tools/data/orbital/noncollinearhydrogen.py
@@ -53,8 +53,8 @@ class NoncollinearHydrogenOrbital(RealhydrogenOrbital):
             )
             pos = orb_dict['position']
             pos_string = f'{pos[0]:.4f},{pos[1]:.4f},{pos[2]:.4f}'
-            orb = f"for kind {orb_dict['kind_name']}" if orb_dict['kind_name'] else ''
-            out_string = f"r{orb_dict['radial_nodes']} {orb_name} (s_z={orb_dict['spin']}) orbital {orb} @ {pos_string}"
+            orb = f'for kind {orb_dict["kind_name"]}' if orb_dict['kind_name'] else ''
+            out_string = f'r{orb_dict["radial_nodes"]} {orb_name} (s_z={orb_dict["spin"]}) orbital {orb} @ {pos_string}'
         except KeyError:
             # Should not happen, but we want it not to crash in __str__
             out_string = '(not all parameters properly set)'

--- a/src/aiida_quantumespresso/tools/data/orbital/spinorbithydrogen.py
+++ b/src/aiida_quantumespresso/tools/data/orbital/spinorbithydrogen.py
@@ -102,10 +102,10 @@ class SpinorbitHydrogenOrbital(Orbital):
         """Printable representation of the orbital."""
         orb = self.get_orbital_dict()
         try:
-            orb_name = f"j={orb['total_angular_momentum']},l={orb['angular_momentum']},m_j={orb['magnetic_number']}"
-            position_string = f"{orb['position'][0]:.4f},{orb['position'][1]:.4f},{orb['position'][2]:.4f}"
-            orbital = f"for kind {orb['kind_name']}" if orb['kind_name'] else ''
-            out_string = f"r{orb['radial_nodes']} {orb_name} orbital {orbital} @ {position_string}"
+            orb_name = f'j={orb["total_angular_momentum"]},l={orb["angular_momentum"]},m_j={orb["magnetic_number"]}'
+            position_string = f'{orb["position"][0]:.4f},{orb["position"][1]:.4f},{orb["position"][2]:.4f}'
+            orbital = f'for kind {orb["kind_name"]}' if orb['kind_name'] else ''
+            out_string = f'r{orb["radial_nodes"]} {orb_name} orbital {orbital} @ {position_string}'
         except KeyError:
             # Should not happen, but we want it not to crash in __str__
             out_string = '(not all parameters properly set)'

--- a/src/aiida_quantumespresso/tools/pwinputparser.py
+++ b/src/aiida_quantumespresso/tools/pwinputparser.py
@@ -56,7 +56,7 @@ class PwInputFile(StructureParseMixin, BasePwInputFile):
         elif self.k_points['type'] == 'gamma':
             kpoints.set_kpoints_mesh([1, 1, 1])
         else:
-            raise NotImplementedError(f"support for units {self.k_points['type']} not yet implemented")
+            raise NotImplementedError(f'support for units {self.k_points["type"]} not yet implemented')
 
         return kpoints
 

--- a/src/aiida_quantumespresso/tools/setup.py
+++ b/src/aiida_quantumespresso/tools/setup.py
@@ -65,7 +65,7 @@ def setup_codes(
             label=label,
             computer=computer,
             filepath_executable=exec_path,
-            default_calc_job_plugin=f"quantumespresso.{executable.split('.')[0]}",
+            default_calc_job_plugin=f'quantumespresso.{executable.split(".")[0]}',
             prepend_text=prepend_text,
             append_text=append_text,
         )
@@ -160,6 +160,6 @@ def get_code_label(
 
     if n_existing_codes > 0:
         existing_label = label
-        label = f'{label}-{n_existing_codes+1}'
+        label = f'{label}-{n_existing_codes + 1}'
 
     return existing_label, label

--- a/src/aiida_quantumespresso/utils/protocols/pw.py
+++ b/src/aiida_quantumespresso/utils/protocols/pw.py
@@ -139,7 +139,7 @@ class ProtocolManager:
 
         # Check that there are no unknown modifiers
         if modifiers_copy:
-            raise ValueError(f"Unknown modifiers specified: {','.join(sorted(modifiers_copy))}")
+            raise ValueError(f'Unknown modifiers specified: {",".join(sorted(modifiers_copy))}')
 
         retdata = self.get_parameters_data(parameters_modifier_name)
         retdata['pseudo_data'] = pseudo_data

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -490,7 +490,7 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
             # as it was not generated in this workchain and might be used for other calculations
             cleaned_calcs = clean_workchain_calcs(self.ctx.workchain_scf)
             if cleaned_calcs:
-                self.report(f"cleaned remote folders of SCF calculations: {' '.join(map(str, cleaned_calcs))}")
+                self.report(f'cleaned remote folders of SCF calculations: {" ".join(map(str, cleaned_calcs))}')
 
         self.ctx.nscf_emin = workchain.outputs.output_band.get_array('bands').min()
         self.ctx.nscf_emax = workchain.outputs.output_band.get_array('bands').max()
@@ -637,4 +637,4 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         cleaned_calcs = clean_workchain_calcs(self.node)
 
         if cleaned_calcs:
-            self.report(f"cleaned remote folders of calculations: {' '.join(map(str, cleaned_calcs))}")
+            self.report(f'cleaned remote folders of calculations: {" ".join(map(str, cleaned_calcs))}')

--- a/src/aiida_quantumespresso/workflows/protocols/utils.py
+++ b/src/aiida_quantumespresso/workflows/protocols/utils.py
@@ -310,7 +310,7 @@ def get_starting_magnetization(
     :returns: dictionary of starting magnetizations.
     """
     warnings.warn(
-        '`get_starting_magnetization` is deprecated, ' 'use `get_magnetization` instead.',
+        '`get_starting_magnetization` is deprecated, use `get_magnetization` instead.',
         AiidaDeprecationWarning,
     )
 

--- a/src/aiida_quantumespresso/workflows/pw/bands.py
+++ b/src/aiida_quantumespresso/workflows/pw/bands.py
@@ -355,4 +355,4 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
                     pass
 
         if cleaned_calcs:
-            self.report(f"cleaned remote folders of calculations: {' '.join(map(str, cleaned_calcs))}")
+            self.report(f'cleaned remote folders of calculations: {" ".join(map(str, cleaned_calcs))}')

--- a/src/aiida_quantumespresso/workflows/pw/relax.py
+++ b/src/aiida_quantumespresso/workflows/pw/relax.py
@@ -399,7 +399,7 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
                     pass
 
         if cleaned_calcs:
-            self.report(f"cleaned remote folders of calculations: {' '.join(map(str, cleaned_calcs))}")
+            self.report(f'cleaned remote folders of calculations: {" ".join(map(str, cleaned_calcs))}')
 
     @staticmethod
     def _fix_atomic_positions(structure, settings):

--- a/tests/calculations/functions/test_seekpath_analysis.py
+++ b/tests/calculations/functions/test_seekpath_analysis.py
@@ -31,12 +31,12 @@ def test_seekpath_analysis(data_regression):
     assert isinstance(prim_structure, HubbardStructureData), 'Primitive structure should be a HubbardStructureData'
     assert isinstance(conv_structure, HubbardStructureData), 'Conventional structure should be a HubbardStructureData'
 
-    assert (
-        prim_structure.hubbard.parameters != orig_structure.hubbard.parameters
-    ), 'Primitive parameters should be different'
-    assert len(prim_structure.hubbard.parameters) == len(
-        orig_structure.hubbard.parameters
-    ), 'Primitive parameters should have the same length as original parameters'
+    assert prim_structure.hubbard.parameters != orig_structure.hubbard.parameters, (
+        'Primitive parameters should be different'
+    )
+    assert len(prim_structure.hubbard.parameters) == len(orig_structure.hubbard.parameters), (
+        'Primitive parameters should have the same length as original parameters'
+    )
     assert all(
         prim_param.atom_manifold == orig_param.atom_manifold
         for prim_param, orig_param in zip(prim_structure.hubbard.parameters, orig_structure.hubbard.parameters)

--- a/tests/calculations/test_pw.py
+++ b/tests/calculations/test_pw.py
@@ -328,6 +328,7 @@ def test_pw_validate_pseudos_incorrect_kinds(fixture_sandbox, generate_calc_job,
 
 @pytest.mark.parametrize('calculation', ['scf', 'relax', 'vc-relax'])
 def test_pw_validate_inputs_restart_base(
+    recwarn,
     fixture_sandbox,
     generate_calc_job,
     generate_inputs_pw,
@@ -351,18 +352,18 @@ def test_pw_validate_inputs_restart_base(
     # Set `restart_mode` to `'restart'` -> no warning
     parameters['CONTROL']['restart_mode'] = 'restart'
     inputs['parameters'] = orm.Dict(parameters)
-    with pytest.warns(None) as warnings:
-        generate_calc_job(fixture_sandbox, entry_point_name, inputs)
-    assert len([w for w in warnings.list if w.category is UserWarning]) == 0, [w.message for w in warnings.list]
+    recwarn.clear  # noqa: B018
+    generate_calc_job(fixture_sandbox, entry_point_name, inputs)
+    assert len([w for w in recwarn.list if w.category is UserWarning]) == 0, [w.message for w in recwarn.list]
     parameters['CONTROL'].pop('restart_mode')
 
     # Set `startingwfc` or `startingpot` to `'file'` -> no warning
     for restart_setting in ('startingpot', 'startingwfc'):
         parameters['ELECTRONS'][restart_setting] = 'file'
         inputs['parameters'] = orm.Dict(parameters)
-        with pytest.warns(None) as warnings:
-            generate_calc_job(fixture_sandbox, entry_point_name, inputs)
-        assert len([w for w in warnings.list if w.category is UserWarning]) == 0
+        recwarn.clear  # noqa: B018
+        generate_calc_job(fixture_sandbox, entry_point_name, inputs)
+        assert len([w for w in recwarn.list if w.category is UserWarning]) == 0, [w.message for w in recwarn.list]
         parameters['ELECTRONS'].pop(restart_setting)
 
 

--- a/tests/parsers/test_pw.py
+++ b/tests/parsers/test_pw.py
@@ -615,7 +615,7 @@ def test_fixed_coords(
 
     The output files of this test were generated for a calculation of a FCC Si supercell where
     """
-    name = f"fixed_coords_{calculation.replace('-', '')}"
+    name = f'fixed_coords_{calculation.replace("-", "")}'
     entry_point_calc_job = 'quantumespresso.pw'
     entry_point_parser = 'quantumespresso.pw'
 

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -1,5 +1,7 @@
 """Tests for the ``PwBaseWorkChain.get_builder_from_protocol`` method."""
 
+from contextlib import nullcontext
+
 import pytest
 from aiida.engine import ProcessBuilder
 
@@ -276,7 +278,9 @@ def test_parallelization_overrides(fixture_code, generate_structure):
 def test_overrides_key_check(fixture_code, generate_structure, overrides, warning):
     """Test that the `get_builder_from_protocol()` method warns for erroneous keys in the `overrides`."""
 
-    with pytest.warns(warning):
+    context = pytest.warns(UserWarning) if warning else nullcontext()
+
+    with context:
         PwBaseWorkChain.get_builder_from_protocol(
             fixture_code('quantumespresso.pw'),
             generate_structure('silicon'),

--- a/tests/workflows/protocols/pw/test_relax.py
+++ b/tests/workflows/protocols/pw/test_relax.py
@@ -1,5 +1,7 @@
 """Tests for the ``PwRelaxWorkChain.get_builder_from_protocol`` method."""
 
+from contextlib import nullcontext
+
 import pytest
 from aiida.engine import ProcessBuilder
 
@@ -172,7 +174,9 @@ def test_pbc_cell(fixture_code, generate_structure, struc_name, cell_dofree):
 def test_overrides_key_check(fixture_code, generate_structure, overrides, warning):
     """Test that the `get_builder_from_protocol()` method warns for erroneous keys in the `overrides`."""
 
-    with pytest.warns(warning):
+    context = pytest.warns(UserWarning) if warning else nullcontext()
+
+    with context:
         PwRelaxWorkChain.get_builder_from_protocol(
             fixture_code('quantumespresso.pw'),
             generate_structure('silicon'),

--- a/tests/workflows/test_workflows.py
+++ b/tests/workflows/test_workflows.py
@@ -40,6 +40,6 @@ def test_base_unrecoverable_failure(generate_workchain, generate_calc_job_node, 
     process.ctx.children.append(node)
     process.ctx.iteration = 2
 
-    assert (
-        process.inspect_process() == process.exit_codes.ERROR_SECOND_CONSECUTIVE_UNHANDLED_FAILURE
-    ), 'The second inspection should return the proper exit code, i.e. the `BaseRestartWorkChain` should stop'
+    assert process.inspect_process() == process.exit_codes.ERROR_SECOND_CONSECUTIVE_UNHANDLED_FAILURE, (
+        'The second inspection should return the proper exit code, i.e. the `BaseRestartWorkChain` should stop'
+    )


### PR DESCRIPTION
This PR makes a bunch of related changes that makes it possible for contributors to work with the tools they prefer:

1. Installing all "extras" in their development environment: easy, straightforward.
2. Using `uv` environments via the `dev` dependency group. This one can also be used for [1] via `--group` for `pip>=25.1`.
3. Hatch environments and scripts.

In [4e2662a](https://github.com/aiidateam/aiida-quantumespresso/pull/1175/commits/4e2662a0ea8d0016f3be0c5a45d201f5fbb097c2) we mainly update `pytest` and fix some incorrect testing with regard to warnings. This was believed necessary to use `hatch test`, but in hindsight that is probably not the case. always good to update packages though!

In https://github.com/aiidateam/aiida-quantumespresso/pull/1175/commits/0a98d60b23987ed570b7853a4aec4d826f09090a we switch to using the Ruff commit hook directly. This means developers won't need to install Hatch.

Finally, in [cda3518](https://github.com/aiidateam/aiida-quantumespresso/pull/1175/commits/cda3518f965b3712004c54af6d9945272cf66a52) we reintroduce the original extras and the new dependency group, and adapt the Hatch environments.

The various options are now also documented, see

https://aiida-quantumespresso--1175.org.readthedocs.build/en/1175/developer.html