### PR TITLE
🐛 `ProjwfcParser`: convert `bands` array into floats

### DIFF
--- a/src/aiida_quantumespresso/parsers/projwfc.py
+++ b/src/aiida_quantumespresso/parsers/projwfc.py
@@ -285,7 +285,7 @@ class ProjwfcParser(BaseParser):
 
         # Parse the bands energies
         energy_pattern = re.compile(r'====\se\(\s*\d+\)\s=\s*(\S+)\seV\s====')
-        bands = np.array([energy_pattern.findall(block) for block in kpoint_blocks])
+        bands = np.array([energy_pattern.findall(block) for block in kpoint_blocks], dtype=float)
 
         # Parse the projection arrays
         energy_pattern = re.compile(r'\n====.+==== \n')

--- a/tests/parsers/test_projwfc.py
+++ b/tests/parsers/test_projwfc.py
@@ -30,7 +30,7 @@ def generate_projwfc_node(generate_calc_job_node, fixture_localhost, tmpdir):
 
 @pytest.mark.parametrize('test_name', ['nonpolarised', 'noncollinear', 'spinorbit', 'numbered_kinds'])
 def test_projwfc(generate_projwfc_node, generate_parser, data_regression, tmpdir, test_name):
-    """Test ``ProjwfcParser`` on the results of a non-polarised ``projwfc.x`` calculation."""
+    """Test `ProjwfcParser` for various spin types."""
     node = generate_projwfc_node(test_name)
     parser = generate_parser('quantumespresso.projwfc')
     results, calcfunction = parser.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=tmpdir)
@@ -46,6 +46,7 @@ def test_projwfc(generate_projwfc_node, generate_parser, data_regression, tmpdir
             'Dos': results['Dos'].base.attributes.all,
             'Pdos': results['Pdos'].base.attributes.all,
             'bands': results['bands'].base.attributes.all,
+            'bands_values': results['bands'].get_array('bands')[:, :5].tolist(),
             'projections': {
                 k: v
                 for k, v in results['projections'].base.attributes.all.items()

--- a/tests/parsers/test_projwfc/test_projwfc_noncollinear_.yml
+++ b/tests/parsers/test_projwfc/test_projwfc_noncollinear_.yml
@@ -45,6 +45,17 @@ bands:
   pbc2: true
   pbc3: true
   units: eV
+bands_values:
+- - -68.36512
+  - -68.21967
+  - -64.93267
+  - -64.7721
+  - -34.55293
+- - -68.28706
+  - -68.28673
+  - -64.84624
+  - -64.84593
+  - -34.46613
 projections:
   array|energy_array_0:
   - 50

--- a/tests/parsers/test_projwfc/test_projwfc_nonpolarised_.yml
+++ b/tests/parsers/test_projwfc/test_projwfc_nonpolarised_.yml
@@ -45,6 +45,17 @@ bands:
   pbc2: true
   pbc3: true
   units: eV
+bands_values:
+- - -5.79862
+  - 6.02858
+  - 6.02858
+  - 6.02858
+  - 8.56508
+- - -3.51752
+  - -0.85516
+  - 4.84298
+  - 4.84299
+  - 7.4854
 projections:
   array|energy_array_0:
   - 11

--- a/tests/parsers/test_projwfc/test_projwfc_numbered_kinds_.yml
+++ b/tests/parsers/test_projwfc/test_projwfc_numbered_kinds_.yml
@@ -45,6 +45,12 @@ bands:
   pbc2: true
   pbc3: true
   units: eV
+bands_values:
+- - -5.79865
+  - 6.02855
+  - 6.02855
+  - 6.02855
+  - 8.56504
 projections:
   array|energy_array_0:
   - 6

--- a/tests/parsers/test_projwfc/test_projwfc_spinorbit_.yml
+++ b/tests/parsers/test_projwfc/test_projwfc_spinorbit_.yml
@@ -45,6 +45,17 @@ bands:
   pbc2: true
   pbc3: true
   units: eV
+bands_values:
+- - -68.36512
+  - -68.21967
+  - -64.93267
+  - -64.7721
+  - -34.55293
+- - -68.28706
+  - -68.28673
+  - -64.84624
+  - -64.84593
+  - -34.46613
 projections:
   array|energy_array_0:
   - 50


### PR DESCRIPTION
The 'bands' array in the `bands` `BandsData` output (phew) is obtained using a regex pattern in combination with the `findall` method. However, by default the `findall` method will simply return the extracted values as strings.

Here we correctly case the 'bands' array data type as float when constructing the numpy array.