### PR TITLE
Fix issues with `aiida-core` 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -183,6 +183,7 @@ nitpick_ignore_regex = [
     (r'py:class', r'Annotated(\[.*\])?'),
     (r'py:class', r'Field(\[.*\])?'),
     (r'py:.*', r'aiida_quantumespresso.*'),
+    (r'py:.*', r'aiida.*'),
 ]
 nitpick_ignore = [
     ('py:class', 't.IO'),


### PR DESCRIPTION
A recent PR build on RTD failed:

https://app.readthedocs.org/api/v2/build/30047260.txt

Because the AutoAPI docs have been removed from `aiida-core` in https://github.com/aiidateam/aiida-core/pull/7056.

Here we fix our RTD build by ignoring the missing autoAPI references via `nitpick_ignore_regex`. 