### PR TITLE
❌ `PwBandsWorkChain`: deprecate `relax` namespace

### DIFF
--- a/tests/workflows/protocols/pw/test_bands/test_default.yml
+++ b/tests/workflows/protocols/pw/test_bands/test_default.yml
@@ -36,46 +36,6 @@ bands:
 bands_kpoints_distance: 0.025
 clean_workdir: false
 nbands_factor: 3.0
-relax:
-  base:
-    kpoints_distance: 0.15
-    kpoints_force_parity: false
-    max_iterations: 5
-    pw:
-      code: test.quantumespresso.pw@localhost
-      metadata:
-        options:
-          max_wallclock_seconds: 43200
-          resources:
-            num_machines: 1
-            num_mpiprocs_per_machine: 1
-          withmpi: true
-      parameters:
-        CELL:
-          cell_dofree: all
-          press_conv_thr: 0.5
-        CONTROL:
-          calculation: vc-relax
-          etot_conv_thr: 2.0e-05
-          forc_conv_thr: 0.0001
-          tprnfor: true
-          tstress: true
-        ELECTRONS:
-          conv_thr: 4.0e-10
-          electron_maxstep: 80
-          mixing_beta: 0.4
-        SYSTEM:
-          degauss: 0.02
-          ecutrho: 240.0
-          ecutwfc: 30.0
-          nosym: false
-          occupations: smearing
-          smearing: cold
-      pseudos:
-        Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
-  max_meta_convergence_iterations: 5
-  meta_convergence: true
-  volume_convergence: 0.02
 scf:
   kpoints_distance: 0.15
   kpoints_force_parity: false


### PR DESCRIPTION
The `PwBandsWorkChain` was originally designed to handle both structure optimization and band structure calculations in a single workflow. However, this design conflates two conceptually distinct tasks and creates unnecessary complexity. Users who only want band structures are forced to understand relaxation parameters, while those who need optimization must navigate a nested workflow structure.

From v5.0 onwards, the `PwBandsWorkChain` will focus exclusively on band structure calculations. Users should optimize their structures using the `PwRelaxWorkChain` separately, then pass the relaxed structure to the `PwBandsWorkChain`. This separation provides clearer workflow semantics and better modularity.

The `relax` namespace remains functional during the deprecation period but issues a warning when used. The `get_builder_from_protocol` method no longer sets up relaxation inputs by default, reflecting the future v5.0 behavior.