### PR TITLE
❌ `parameters`: deprecate inconsistent casing

### DIFF
--- a/src/aiida_quantumespresso/calculations/__init__.py
+++ b/src/aiida_quantumespresso/calculations/__init__.py
@@ -18,6 +18,7 @@ from qe_tools.converters import get_parameters_from_cell
 from aiida_quantumespresso.data.hubbard_structure import HubbardStructureData
 from aiida_quantumespresso.utils.convert import convert_input_to_namelist_entry
 from aiida_quantumespresso.utils.hubbard import HubbardUtils
+from aiida_quantumespresso.utils.validation.parameters import validate_parameters
 
 from .base import CalcJob
 from .helpers import QEInputValidationError
@@ -119,6 +120,7 @@ class BasePwCpInputGenerator(CalcJob):
             'parameters',
             valid_type=orm.Dict,
             help='The input parameters that are to be used to construct the input file.',
+            validator=validate_parameters,
         )
         spec.input(
             'settings',

--- a/src/aiida_quantumespresso/calculations/matdyn.py
+++ b/src/aiida_quantumespresso/calculations/matdyn.py
@@ -77,10 +77,12 @@ class MatdynCalculation(NamelistsCalculation):
                 'There is no need to specify this input, and its value will be overridden.'
             )
 
-        if 'parent_folder' in value and not parameters['INPUT'].get('la2F', False):
+        # Support both la2f (new) and la2F (deprecated) during deprecation period
+        la2f_value = parameters['INPUT'].get('la2f', False) or parameters['INPUT'].get('la2F', False)
+        if 'parent_folder' in value and not la2f_value:
             return (
-                'The `parent_folder` input is only used to calculate the el-ph coefficients but `la2F` is not set '
-                'to `.true.` in input `parameters`'
+                'The `parent_folder` input is only used to calculate the el-ph coefficients but `la2f` is not set '
+                'to true in input `parameters`'
             )
 
     def generate_input_file(self, parameters):
@@ -126,7 +128,7 @@ class MatdynCalculation(NamelistsCalculation):
         lists that are to be retrieved after job completion.
 
         After calling the method of the parent `NamelistsCalculation` class, the input parameters are checked to see
-        if the `la2F` tag is set to true. In this case the remote symlink or copy list is set to the electron-phonon
+        if the `la2f` tag is set to true. In this case the remote symlink or copy list is set to the electron-phonon
         directory, depending on the settings.
 
         :param folder: a sandbox folder to temporarily write files on disk.
@@ -143,13 +145,15 @@ class MatdynCalculation(NamelistsCalculation):
             settings = {}
 
         if 'parameters' in self.inputs:
-            parameters = _uppercase_dict(self.inputs.parameters.get_dict(), dict_name='parameters')
+            parameters = self.inputs.parameters.get_dict()
         else:
             parameters = {'INPUT': {}}
 
         source = self.inputs.get('parent_folder', None)
 
-        if source is not None and parameters['INPUT'].get('la2F', False):
+        # Support both la2f (new) and la2F (deprecated) during deprecation period
+        la2f_value = parameters['INPUT'].get('la2f', False) or parameters['INPUT'].get('la2F', False)
+        if source is not None and la2f_value:
             dirpath = Path(source.get_remote_path()) / PhCalculation._FOLDER_ELECTRON_PHONON  # noqa: SLF001
             remote_list = [(source.computer.uuid, str(dirpath), PhCalculation._FOLDER_ELECTRON_PHONON)]  # noqa: SLF001
 

--- a/src/aiida_quantumespresso/calculations/namelists.py
+++ b/src/aiida_quantumespresso/calculations/namelists.py
@@ -12,6 +12,7 @@ from aiida.orm import Dict, FolderData, RemoteData, SinglefileData
 
 from aiida_quantumespresso.calculations import _lowercase_dict, _pop_parser_options, _uppercase_dict
 from aiida_quantumespresso.utils.convert import convert_input_to_namelist_entry
+from aiida_quantumespresso.utils.validation.parameters import validate_parameters
 
 from .base import CalcJob
 
@@ -55,7 +56,11 @@ class NamelistsCalculation(CalcJob):
         if cls._default_parser is not None:
             spec.input('metadata.options.parser_name', valid_type=str, default=cls._default_parser)
         spec.input(
-            'parameters', valid_type=Dict, required=False, help='Parameters for the namelists in the input file.'
+            'parameters',
+            valid_type=Dict,
+            required=False,
+            help='Parameters for the namelists in the input file.',
+            validator=validate_parameters,
         )
         spec.input('settings', valid_type=Dict, required=False, help='Use an additional node for special settings')
         spec.input(

--- a/src/aiida_quantumespresso/calculations/neb.py
+++ b/src/aiida_quantumespresso/calculations/neb.py
@@ -17,6 +17,7 @@ from aiida_quantumespresso.calculations import (
 )
 from aiida_quantumespresso.calculations.pw import PwCalculation
 from aiida_quantumespresso.utils.convert import convert_input_to_namelist_entry
+from aiida_quantumespresso.utils.validation.parameters import validate_parameters
 
 from .base import CalcJob
 
@@ -79,7 +80,9 @@ class NebCalculation(CalcJob):
             help='Ordered trajectory of all NEB images along the reaction path, including'
             'initial, intermediate, and final configurations.',
         )
-        spec.input('parameters', valid_type=orm.Dict, help='NEB-specific input parameters')
+        spec.input(
+            'parameters', valid_type=orm.Dict, help='NEB-specific input parameters', validator=validate_parameters
+        )
         spec.input(
             'settings',
             valid_type=orm.Dict,

--- a/src/aiida_quantumespresso/calculations/ph.py
+++ b/src/aiida_quantumespresso/calculations/ph.py
@@ -11,6 +11,7 @@ from aiida.common.warnings import AiidaDeprecationWarning
 from aiida_quantumespresso.calculations import _lowercase_dict, _uppercase_dict
 from aiida_quantumespresso.calculations.pw import PwCalculation
 from aiida_quantumespresso.utils.convert import convert_input_to_namelist_entry
+from aiida_quantumespresso.utils.validation.parameters import validate_parameters
 
 from .base import CalcJob
 
@@ -63,7 +64,7 @@ class PhCalculation(CalcJob):
         spec.input('metadata.options.parser_name', valid_type=str, default='quantumespresso.ph')
         spec.input('metadata.options.withmpi', valid_type=bool, default=True)
         spec.input('qpoints', valid_type=orm.KpointsData, help='qpoint mesh')
-        spec.input('parameters', valid_type=orm.Dict, help='')
+        spec.input('parameters', valid_type=orm.Dict, help='', validator=validate_parameters)
         spec.input('settings', valid_type=orm.Dict, required=False, help='')
         spec.input('parent_folder', valid_type=orm.RemoteData, help='the folder of a completed `PwCalculation`')
         spec.output('output_parameters', valid_type=orm.Dict)

--- a/src/aiida_quantumespresso/calculations/pp.py
+++ b/src/aiida_quantumespresso/calculations/pp.py
@@ -9,12 +9,20 @@ from aiida.common.warnings import AiidaDeprecationWarning
 
 from aiida_quantumespresso.calculations import _lowercase_dict, _uppercase_dict
 from aiida_quantumespresso.utils.convert import convert_input_to_namelist_entry
+from aiida_quantumespresso.utils.validation.parameters import validate_parameters as validate_parameters_base
 
 from .base import CalcJob
 
 
 def validate_parameters(value, _):
-    """Validate 'parameters' dict."""
+    """Validate 'parameters' dict.
+
+    First does basic validation, then checks pp.x-specific requirements.
+    """
+    error = validate_parameters_base(value, _)
+    if error:
+        return error
+
     parameters = value.get_dict()
 
     try:

--- a/src/aiida_quantumespresso/calculations/q2r.py
+++ b/src/aiida_quantumespresso/calculations/q2r.py
@@ -45,7 +45,7 @@ class Q2rCalculation(NamelistsCalculation):
         lists that are to be retrieved after job completion.
 
         After calling the method of the parent `NamelistsCalculation` class, the input parameters are checked to see
-        if the `la2F` tag is set to true. In this case the electron-phonon directory is added to the remote symlink or
+        if the `la2f` tag is set to true. In this case the electron-phonon directory is added to the remote symlink or
         copy list, depending on the settings.
 
         :param folder: a sandbox folder to temporarily write files on disk.
@@ -65,7 +65,9 @@ class Q2rCalculation(NamelistsCalculation):
 
         parent_folder = self.inputs.get('parent_folder', None)
 
-        if parent_folder is not None and 'parameters' in self.inputs and parameters.get('INPUT').get('la2F', False):
+        # Support both la2f (new) and la2F (deprecated) for deprecation
+        la2f_value = parameters.get('INPUT', {}).get('la2f', False) or parameters.get('INPUT', {}).get('la2F', False)
+        if parent_folder is not None and 'parameters' in self.inputs and la2f_value:
             symlink = settings.pop('PARENT_FOLDER_SYMLINK', False)
             remote_list = calcinfo.remote_symlink_list if symlink else calcinfo.remote_copy_list
 

--- a/src/aiida_quantumespresso/utils/validation/parameters.py
+++ b/src/aiida_quantumespresso/utils/validation/parameters.py
@@ -1,0 +1,43 @@
+"""Validation functions for calculation parameters."""
+
+import warnings
+
+from aiida import orm
+from aiida.common.warnings import AiidaDeprecationWarning
+
+
+def validate_parameters(node: orm.Dict, _) -> str | None:
+    """Validate the `parameters` input.
+
+    Checks that the `parameters` input adheres to the following conventions:
+
+    1. Namelist keys should be UPPERCASE, and their values must be a dictionary of
+       parameters.
+    2. Parameter keys should be lowercase.
+
+    Emits deprecation warnings for incorrect casing. In v5.0, unstored nodes will be
+    auto-corrected and stored nodes will be rejected.
+
+    :param node: Dict node containing the namelists/parameters.
+    :return: Error message if validation fails, None otherwise.
+    """
+    for namelist_key, namelist_value in node.items():
+        if namelist_key != namelist_key.upper():
+            warnings.warn(
+                f"Namelist '{namelist_key}' should be UPPERCASE. "
+                f"In v5.0, this will be auto-corrected to '{namelist_key.upper()}' for unstored nodes "
+                'and enforced for stored nodes. Please update your code to use UPPERCASE namelist names.',
+                AiidaDeprecationWarning,
+            )
+
+        if not isinstance(namelist_value, dict):
+            return f"Namelist '{namelist_key}' should contain a dictionary of parameters, got {type(namelist_value).__name__}"
+
+        for param_key, param_value in namelist_value.items():
+            if param_key != param_key.lower():
+                warnings.warn(
+                    f"Parameter '{param_key}' in namelist '{namelist_key}' should be lowercase. "
+                    f"In v5.0, this will be auto-corrected to '{param_key.lower()}' for unstored nodes "
+                    'and enforced for stored nodes. Please update your code to use lowercase parameter names.',
+                    AiidaDeprecationWarning,
+                )

--- a/src/aiida_quantumespresso/workflows/protocols/pdos.yaml
+++ b/src/aiida_quantumespresso/workflows/protocols/pdos.yaml
@@ -18,7 +18,7 @@ default_inputs:
     dos:
         parameters:
             DOS:
-                DeltaE: 0.01
+                deltae: 0.01
         metadata:
             options:
                 max_wallclock_seconds: 43200  # Twelve hours
@@ -26,7 +26,7 @@ default_inputs:
     projwfc:
         parameters:
             PROJWFC:
-                DeltaE: 0.01
+                deltae: 0.01
         metadata:
             options:
                 max_wallclock_seconds: 43200  # Twelve hours
@@ -40,11 +40,11 @@ protocols:
         dos:
             parameters:
                 DOS:
-                    DeltaE: 0.01
+                    deltae: 0.01
         projwfc:
             parameters:
                 PROJWFC:
-                    DeltaE: 0.01
+                    deltae: 0.01
         nscf:
             kpoints_distance: 0.05
     fast:
@@ -52,10 +52,10 @@ protocols:
         dos:
             parameters:
                 DOS:
-                    DeltaE: 0.1
+                    deltae: 0.1
         projwfc:
             parameters:
                 PROJWFC:
-                    DeltaE: 0.1
+                    deltae: 0.1
         nscf:
             kpoints_distance: 0.5

--- a/tests/calculations/test_matdyn.py
+++ b/tests/calculations/test_matdyn.py
@@ -38,7 +38,7 @@ def test_matdyn_elph(fixture_sandbox, generate_calc_job, generate_inputs_matdyn,
     entry_point_name = 'quantumespresso.matdyn'
 
     inputs = generate_inputs_matdyn(parent_folder=True)
-    inputs['parameters'] = orm.Dict({'INPUT': {'la2F': True, 'dos': True}})
+    inputs['parameters'] = orm.Dict({'INPUT': {'la2f': True, 'dos': True}})
     kpoints = orm.KpointsData()
     kpoints.set_kpoints_mesh([2, 2, 2])
     inputs['kpoints'] = kpoints

--- a/tests/calculations/test_pw2gw.py
+++ b/tests/calculations/test_pw2gw.py
@@ -20,9 +20,9 @@ def generate_inputs(tmp_path, fixture_localhost, fixture_code, generate_remote_d
                     'qplda': False,
                     'vxcdiag': False,
                     'vkb': False,
-                    'Emin': 0.0,
-                    'Emax': 15.0,
-                    'DeltaE': 0.001,
+                    'emin': 0.0,
+                    'emax': 15.0,
+                    'deltae': 0.001,
                 }
             }
 

--- a/tests/calculations/test_q2r.py
+++ b/tests/calculations/test_q2r.py
@@ -44,11 +44,11 @@ def test_q2r_default(fixture_sandbox, generate_calc_job, generate_inputs_q2r, fi
 @pytest.mark.parametrize(
     ('key', 'value'),
     [
-        ('la2F', True),
+        ('la2f', True),
         ('zasr', 'simple'),
     ],
 )
-def test_q2r_parameters(fixture_sandbox, generate_calc_job, generate_inputs_q2r, file_regression, key, value):
+def test_parameters(fixture_sandbox, generate_calc_job, generate_inputs_q2r, file_regression, key, value):
     """Test the ``parameters`` input for the ``Q2rCalculation`` plugin."""
     entry_point_name = 'quantumespresso.q2r'
 
@@ -68,7 +68,7 @@ def test_q2r_parameters(fixture_sandbox, generate_calc_job, generate_inputs_q2r,
     retrieve_list = [Q2rCalculation._DEFAULT_OUTPUT_FILE] + Q2rCalculation._internal_retrieve_list
 
     # Test that `elph_dir` is added properly to the remote_copy_list
-    if inputs['parameters']['INPUT'].get('la2F', None) is True:
+    if inputs['parameters']['INPUT'].get('la2f', None) is True:
         dirpath = Path(parent_folder.get_remote_path()) / PhCalculation._FOLDER_ELECTRON_PHONON
         remote_copy_list.append(
             (

--- a/tests/calculations/test_q2r/test_parameters_la2f_True_.in
+++ b/tests/calculations/test_q2r/test_parameters_la2f_True_.in
@@ -1,0 +1,5 @@
+&INPUT
+  fildyn = 'DYN_MAT/dynamical-matrix-'
+  flfrc = 'real_space_force_constants.dat'
+  la2f = .true.
+/

--- a/tests/calculations/test_q2r/test_parameters_zasr_simple_.in
+++ b/tests/calculations/test_q2r/test_parameters_zasr_simple_.in
@@ -1,0 +1,5 @@
+&INPUT
+  fildyn = 'DYN_MAT/dynamical-matrix-'
+  flfrc = 'real_space_force_constants.dat'
+  zasr = 'simple'
+/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1018,14 +1018,14 @@ def generate_workchain_pdos(generate_workchain, generate_inputs_pw, fixture_code
 
         dos_params = {
             'DOS': {
-                'DeltaE': 0.01,
+                'deltae': 0.01,
             }
         }
-        projwfc_params = {'PROJWFC': {'DeltaE': 0.01, 'ngauss': 0, 'degauss': 0.01}}
+        projwfc_params = {'PROJWFC': {'deltae': 0.01, 'ngauss': 0, 'degauss': 0.01}}
 
         if emin and emax:
-            dos_params['DOS'].update({'Emin': emin, 'Emax': emax})
-            projwfc_params['PROJWFC'].update({'Emin': emin, 'Emax': emax})
+            dos_params['DOS'].update({'emin': emin, 'emax': emax})
+            projwfc_params['PROJWFC'].update({'emin': emin, 'emax': emax})
 
         dos = {
             'code': fixture_code('quantumespresso.dos'),

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -266,7 +266,7 @@ def test_parallelization_overrides(fixture_code, generate_structure):
         ({'pw': {'parameters': {'CONTROL': {'calculation': 'relax'}}}}, None),
         # CORRECT overrides for `Dict` node with incorrect keys
         # The key check should _not_ validate the inputs, that is the job of the port validator
-        ({'pw': {'parameters': {'NON-EXISTENT': 1}}}, None),
+        ({'pw': {'parameters': {'NON-EXISTENT': {'param': 1}}}}, None),
         # WRONG overrides with typo
         ({'clean_wokdir': True}, UserWarning),
         # WRONG overrides with process input at incorrect level

--- a/tests/workflows/protocols/test_pdos/test_default.yml
+++ b/tests/workflows/protocols/test_pdos/test_default.yml
@@ -9,7 +9,7 @@ dos:
       withmpi: true
   parameters:
     DOS:
-      DeltaE: 0.01
+      deltae: 0.01
 nscf:
   kpoints_distance: 0.1
   kpoints_force_parity: false
@@ -52,7 +52,7 @@ projwfc:
       withmpi: true
   parameters:
     PROJWFC:
-      DeltaE: 0.01
+      deltae: 0.01
 scf:
   kpoints_distance: 0.15
   kpoints_force_parity: false

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -300,8 +300,8 @@ def test_handle_vcrelax_recoverable_fft_significant_volume_contraction_error(gen
 def test_handle_electronic_convergence_warning(generate_workchain_pw, generate_structure):
     """Test `PwBaseWorkChain.handle_electronic_convergence_warning`."""
     inputs = generate_workchain_pw(return_inputs=True)
-    inputs['pw']['parameters']['scf_maxstep'] = 0
-    inputs['pw']['parameters']['scf_must_converge'] = False
+    inputs['pw']['parameters']['ELECTRONS']['electron_maxstep'] = 0
+    inputs['pw']['parameters']['ELECTRONS']['scf_must_converge'] = False
 
     structure = generate_structure()
 

--- a/tests/workflows/test_pdos.py
+++ b/tests/workflows/test_pdos.py
@@ -31,10 +31,10 @@ def check_pdos_energy_range(dos_inputs, projwfc_inputs, expected_p_dos_inputs):
     dos_params = dos_inputs.parameters.get_dict()
     projwfc_params = projwfc_inputs.parameters.get_dict()
 
-    assert np.isclose(dos_params['DOS']['Emin'], expected_p_dos_inputs[0])
-    assert np.isclose(dos_params['DOS']['Emax'], expected_p_dos_inputs[1])
-    assert np.isclose(projwfc_params['PROJWFC']['Emin'], expected_p_dos_inputs[0])
-    assert np.isclose(projwfc_params['PROJWFC']['Emax'], expected_p_dos_inputs[1])
+    assert np.isclose(dos_params['DOS']['emin'], expected_p_dos_inputs[0])
+    assert np.isclose(dos_params['DOS']['emax'], expected_p_dos_inputs[1])
+    assert np.isclose(projwfc_params['PROJWFC']['emin'], expected_p_dos_inputs[0])
+    assert np.isclose(projwfc_params['PROJWFC']['emax'], expected_p_dos_inputs[1])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Deprecation PR of https://github.com/aiidateam/aiida-quantumespresso/pull/1204

>[!NOTE] 
> Reposting [this comment](https://github.com/aiidateam/aiida-quantumespresso/pull/1204#issuecomment-3520235796) on the deprecation pathway below

@t-reents I was also working on adding a deprecation path, but realised this is not so simple. I was thinking of only raising a deprecation warning and not fixing the case. But then we should still adapt the case in the protocols for DeltaE, Emin and Emax, else our protocols raise warnings. But then we should also fix the validation/logic in e.g. the PdosWorkChain, else that will break. But then using the old DeltaE will break, so we're making breaking changes. We can add logic to be lenient and accept both cases here. But we'll be making the code more messy, which is what we're trying to avoid.

We can also decide not to merge this PR in the end: I think by updating on the fly with a warning we are helping to avoid any issues for most users. Also: the deprecation may be more annoying because it doesn't fix things on the fly. 😅 Have a look and let me know what you think!