### PR TITLE
Give priority to overrides when setting `FIXED_COORDS` and `cell_dofree`

### DIFF
--- a/src/aiida_quantumespresso/workflows/pw/relax.py
+++ b/src/aiida_quantumespresso/workflows/pw/relax.py
@@ -178,19 +178,20 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
                 namespace.pw.parameters['CELL']['cell_dofree'] = 'shape'
 
             if relax_type in (RelaxType.CELL, RelaxType.POSITIONS_CELL):
-                pbc_cell_dofree_map = {
-                    (True, True, True): 'all',
-                    (True, False, False): 'x',
-                    (False, True, False): 'y',
-                    (False, False, True): 'z',
-                    (True, True, False): '2Dxy',
-                }
-                if structure.pbc in pbc_cell_dofree_map:
-                    namespace.pw.parameters['CELL']['cell_dofree'] = pbc_cell_dofree_map[structure.pbc]
-                else:
-                    raise ValueError(
-                        f'Structures with periodic boundary conditions `{structure.pbc}` are not supported.'
-                    )
+                if 'cell_dofree' not in namespace.pw.parameters.get('CELL', {}):
+                    pbc_cell_dofree_map = {
+                        (True, True, True): 'all',
+                        (True, False, False): 'x',
+                        (False, True, False): 'y',
+                        (False, False, True): 'z',
+                        (True, True, False): '2Dxy',
+                    }
+                    if structure.pbc in pbc_cell_dofree_map:
+                        namespace.pw.parameters['CELL']['cell_dofree'] = pbc_cell_dofree_map[structure.pbc]
+                    else:
+                        raise ValueError(
+                            f'Structures with periodic boundary conditions `{structure.pbc}` are not supported.'
+                        )
 
         builder = cls.get_builder()
         builder.base_relax = base_relax
@@ -405,7 +406,7 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
     def _fix_atomic_positions(structure, settings):
         """Fix the atomic positions, by setting the `FIXED_COORDS` key in the `settings` input node."""
         settings = settings.get_dict() if settings is not None else {}
-
-        settings['FIXED_COORDS'] = [[True, True, True]] * len(structure.sites)
+        if 'FIXED_COORDS' not in settings:
+            settings['FIXED_COORDS'] = [[True, True, True]] * len(structure.sites)
 
         return settings


### PR DESCRIPTION
Ciao!
Now in some cases `FIXED_COORS` and `cell_dofree` parameters passed as overrides to `get_builder_from_protocol` in `PwRelaxWorkChain` got overridden in some cases.
In some cases maybe a good idea to prevent meaningless combination of parameters, on the other side prevents the user to really set the parameter he wants (for example for a 2D system with pbc=TTF now only cell_dofree=2Dxy is allowed, however he may want to set it to x in order to adjust only v1_x component, or maybe he really wants to adjust also z direction because he wants to find out the 3D structure out of the 2D initial one).
In general if the user sets some `overrides` I would leave to him the responsibility of the meaningfulness of parameters unless they  would give rise to critical issues.
