### PR TITLE
Feature: Add D3hessCalculation for d3hess.x in Quantum ESPRESSO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ aiida-quantumespresso = 'aiida_quantumespresso.cli:cmd_root'
 'quantumespresso.seekpath_structure_analysis' = 'aiida_quantumespresso.calculations.functions.seekpath_structure_analysis:seekpath_structure_analysis'
 'quantumespresso.open_grid' = 'aiida_quantumespresso.calculations.open_grid:OpenGridCalculation'
 'quantumespresso.bands' = 'aiida_quantumespresso.calculations.bands:BandsCalculation'
+'quantumespresso.d3hess' = 'aiida_quantumespresso.calculations.d3hess:D3hessCalculation'
 
 [project.entry-points.'aiida.data']
 'quantumespresso.force_constants' = 'aiida_quantumespresso.data.force_constants:ForceConstantsData'

--- a/src/aiida_quantumespresso/calculations/d3hess.py
+++ b/src/aiida_quantumespresso/calculations/d3hess.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""`CalcJob` implementation for the d3hess.x code of Quantum ESPRESSO."""
+
+from aiida import orm
+
+from aiida_quantumespresso.calculations.namelists import NamelistsCalculation
+
+
+class D3hessCalculation(NamelistsCalculation):
+    """`CalcJob` implementation for the d3hess.x code of Quantum ESPRESSO.
+
+    d3hess.x code of the Quantum ESPRESSO distribution computes the Hessian matrix of the DFT-D3 dispersion
+    after an SCF calculation.
+    """
+
+    _default_namelists = ['INPUT']
+    _blocked_keywords = [
+        ('INPUT', 'outdir', NamelistsCalculation._OUTPUT_SUBFOLDER),  # pylint: disable=protected-access
+        ('INPUT', 'prefix', NamelistsCalculation._PREFIX),  # pylint: disable=protected-access
+    ]
+
+    _internal_retrieve_list = []
+
+    _DEFAULT_INPUT_FILE = 'd3hess.in'
+    _DEFAULT_OUTPUT_FILE = 'd3hess.out'
+
+    @classmethod
+    def define(cls, spec):
+        """Define the process specification."""
+        # yapf: disable
+        super().define(spec)
+        spec.input('parent_folder', valid_type=(orm.RemoteData, orm.FolderData), required=True)
+        # With symlinking, the file `aiida.hess` produced in ./out/ will also be created in the parent folder.
+        # This allows to reuse the remote folder of the SCF calculation (instead of the newly created one for d3hess)
+        # for post-processings which require the `aiida.hess` file (e.g. ph.x with dft-d3 correction)
+        # This prevents the eventual unintended killing of the logic of post-processing workflows which can depend on
+        # the parenthood of the remote folder to an actual SCF calculation
+        spec.input('settings', valid_type=orm.Dict, default=lambda: orm.Dict(dict={'PARENT_FOLDER_SYMLINK': True}))
+        spec.input('metadata.options.withmpi', valid_type=bool, default=False)  # Usually takes less than a sec
+        # yapf: enable


### PR DESCRIPTION
This PR will add a simple implementation of a `D3hessCalculation` class in `d3hess.py` to support the `d3hess.x` code.
It inherits from `NamelistsCalculation` and has a unique input : a remote_folder of a finished SCF calculation.

The code computes the Hessian matrix of DFT-D3 dispersion (reminder: `dftd3_threebody` must be deactivated in the SCF calculation cf. corresponding input description on QE website) and adds it to the remote folder of the SCF calculation.

I used parent folder symlinking by default so that the produced `aiida.hess` file is added to the parent SCF folder to allow for further (post-)processing directly from the SCF calculation.
This means that a phonon WorkChain can be done as usual, taking the remote folder of an SCF calculation and not the D3hess calculation's.

Updated `pyproject.toml` to include an entry point for `d3hess`.