### PR TITLE
Fix matdyn parser column offset and ph.py parameter handling

### DIFF
--- a/src/aiida_quantumespresso/calculations/ph.py
+++ b/src/aiida_quantumespresso/calculations/ph.py
@@ -8,10 +8,9 @@ from aiida import orm
 from aiida.common import datastructures, exceptions
 from aiida.common.warnings import AiidaDeprecationWarning
 
-from aiida_quantumespresso.calculations import _uppercase_dict
+from aiida_quantumespresso.calculations import _lowercase_dict, _uppercase_dict
 from aiida_quantumespresso.calculations.pw import PwCalculation
 from aiida_quantumespresso.utils.convert import convert_input_to_namelist_entry
-from aiida_quantumespresso.utils.validation.parameters import validate_parameters
 
 from .base import CalcJob
 
@@ -64,7 +63,7 @@ class PhCalculation(CalcJob):
         spec.input('metadata.options.parser_name', valid_type=str, default='quantumespresso.ph')
         spec.input('metadata.options.withmpi', valid_type=bool, default=True)
         spec.input('qpoints', valid_type=orm.KpointsData, help='qpoint mesh')
-        spec.input('parameters', valid_type=orm.Dict, help='', validator=validate_parameters)
+        spec.input('parameters', valid_type=orm.Dict, help='')
         spec.input('settings', valid_type=orm.Dict, required=False, help='')
         spec.input('parent_folder', valid_type=orm.RemoteData, help='the folder of a completed `PwCalculation`')
         spec.output('output_parameters', valid_type=orm.Dict)
@@ -169,7 +168,8 @@ class PhCalculation(CalcJob):
                 raise exceptions.InputValidationError(msg) from exception
         parent_calc_out_subfolder = settings.pop('PARENT_CALC_OUT_SUBFOLDER', default_parent_output_folder)
 
-        parameters = self.inputs.parameters.get_dict()
+        parameters = _uppercase_dict(self.inputs.parameters.get_dict(), dict_name='parameters')
+        parameters = {k: _lowercase_dict(v, dict_name=k) for k, v in parameters.items()}
 
         prepare_for_d3 = settings.pop('PREPARE_FOR_D3', False)
         if prepare_for_d3:
@@ -337,7 +337,7 @@ class PhCalculation(CalcJob):
                         self._FOLDER_DYNAMICAL_MATRIX,
                     )
                 )
-                if parameters['INPUTPH'].get('electron_phonon', None) is not None:
+                if parameters.get('INPUTPH', {}).get('electron_phonon', None) is not None:
                     remote_symlink_list.append(
                         (
                             parent_folder.computer.uuid,
@@ -361,7 +361,7 @@ class PhCalculation(CalcJob):
                         '.',
                     )
                 )
-                if parameters['INPUTPH'].get('electron_phonon', None) is not None:
+                if parameters.get('INPUTPH', {}).get('electron_phonon', None) is not None:
                     remote_copy_list.append(
                         (
                             parent_folder.computer.uuid,

--- a/src/aiida_quantumespresso/parsers/matdyn.py
+++ b/src/aiida_quantumespresso/parsers/matdyn.py
@@ -137,7 +137,7 @@ def parse_raw_matdyn_phonon_file(phonon_frequencies):
                 parsed_data['warnings'].append('Bad formatting of frequencies')
                 return parsed_data
 
-    counter = 3
+    counter = 4
     for i in range(num_kpoints):
         for j in range(num_bands):
             try:
@@ -148,7 +148,7 @@ def parse_raw_matdyn_phonon_file(phonon_frequencies):
                 parsed_data['warnings'].append('Error while parsing the frequencies, dimension exceeded')
                 return parsed_data
             counter += 1
-        counter += 3  # move past the kpoint coordinates
+        counter += 4
 
     parsed_data['phonon_bands'] = freq_matrix
 


### PR DESCRIPTION
1, The parser assumed 3 values per k-point line but matdyn.x outputs 4 (kx, ky, kz, weight), causing all phonon frequencies to be incorrectly parsed with a cumulative offset.
Fix: Correct k-point stride from 3 to 4 for proper frequency parsing in parse_raw_matdyn_phonon_file() in matdyn.py

2. PhCalculation: Missing parameter normalization and unsafe INPUTPH access.
Fix: 
1) Restored parameter case normalization (_uppercase_dict / _lowercase_dict)
2) Changed to safe dict access: parameters.get('INPUTPH', {}).get('electron_phonon')
