### PR TITLE
🐛 `PwBaseWorkChain`: only build magnetization for spin cases

### DIFF
--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -259,23 +259,25 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             parameters['SYSTEM'].pop('degauss')
             parameters['SYSTEM'].pop('smearing')
 
-        magnetization = get_magnetization(
-            structure=structure,
-            z_valences={kind.name: pseudos[kind.name].z_valence for kind in structure.kinds},
-            initial_magnetic_moments=initial_magnetic_moments,
-            spin_type=spin_type,
-        )
-        if spin_type is SpinType.COLLINEAR:
+        if spin_type in [SpinType.COLLINEAR, SpinType.SPIN_ORBIT, SpinType.NON_COLLINEAR]:
+            magnetization = get_magnetization(
+                structure=structure,
+                z_valences={kind.name: pseudos[kind.name].z_valence for kind in structure.kinds},
+                initial_magnetic_moments=initial_magnetic_moments,
+                spin_type=spin_type,
+            )
             parameters['SYSTEM']['starting_magnetization'] = magnetization['starting_magnetization']
-            parameters['SYSTEM']['nspin'] = 2
 
-        if spin_type in [SpinType.SPIN_ORBIT, SpinType.NON_COLLINEAR]:
-            parameters['SYSTEM']['starting_magnetization'] = magnetization['starting_magnetization']
-            parameters['SYSTEM']['angle1'] = magnetization['angle1']
-            parameters['SYSTEM']['angle2'] = magnetization['angle2']
-            parameters['SYSTEM']['noncolin'] = True
-            parameters['SYSTEM']['nspin'] = 4
-            if spin_type == SpinType.SPIN_ORBIT:
+            if spin_type is SpinType.COLLINEAR:
+                parameters['SYSTEM']['nspin'] = 2
+
+            if spin_type in [SpinType.SPIN_ORBIT, SpinType.NON_COLLINEAR]:
+                parameters['SYSTEM']['angle1'] = magnetization['angle1']
+                parameters['SYSTEM']['angle2'] = magnetization['angle2']
+                parameters['SYSTEM']['noncolin'] = True
+                parameters['SYSTEM']['nspin'] = 4
+
+            if spin_type is SpinType.SPIN_ORBIT:
                 parameters['SYSTEM']['lspinorb'] = True
 
         # If overrides are provided, they are considered absolute


### PR DESCRIPTION
When building protocol inputs with `spin_type=SpinType.NONE`, the `get_magnetization` helper was still being called, even though its result is only consumed by the `COLLINEAR`, `NON_COLLINEAR`, and `SPIN_ORBIT` branches. This was unnecessary and could lead to issues in some cases for `SpinType.NONE`, however the exact failure mode escapes memory.

Wrap the call and the related `SYSTEM` updates in a single `spin_type in [COLLINEAR, SPIN_ORBIT, NON_COLLINEAR]` guard so non-magnetic protocols no longer trigger the computation (and any associated validation it does on pseudos / kinds). The inner branches are simplified accordingly: `starting_magnetization` is now set once from the computed `magnetization` dict, and the SO/NC branch only adds the extra `angle1`/`angle2`/`noncolin`/ `nspin` keys on top.