### PR TITLE
👌 `PwRelaxWorkChain`: tolerate Pulay failure in initial relax

### DIFF
--- a/src/aiida_quantumespresso/workflows/pw/relax.py
+++ b/src/aiida_quantumespresso/workflows/pw/relax.py
@@ -246,7 +246,10 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         """Inspect the result of the initial relax `PwBaseWorkChain`."""
         workchain = self.ctx.base_init_relax_workchain
 
-        if not workchain.is_finished_ok:
+        # The following list of `PwBaseWorkChain` exit status should not interrupt the work chain
+        acceptable_statuses = ['ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF']
+
+        if workchain.is_failed and workchain.exit_status not in PwBaseWorkChain.get_exit_statuses(acceptable_statuses):
             self.report(f'initial relax PwBaseWorkChain failed with exit status {workchain.exit_status}')
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_INIT_RELAX
 


### PR DESCRIPTION
The `inspect_init_relax` step previously aborted the work chain on any non-zero exit status of the initial `PwBaseWorkChain`, including `ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF`. That exit code indicates the ionic relaxation converged but the final SCF exceeded stress thresholds (Pulay stress), and the `PwBaseWorkChain` handler already attaches `output_structure` in this case, so the result is usable as the starting point for the subsequent meta-convergence loop.

Treat this exit code as acceptable using the same `acceptable_statuses` + `PwBaseWorkChain.get_exit_statuses()` pattern already used in `inspect_relax`, and switch the failure check from `not is_finished_ok` to `is_failed` for consistency.