### PR TITLE
Remove ppcg diagonalization method

### DIFF
--- a/src/aiida_quantumespresso/workflows/neb/base.py
+++ b/src/aiida_quantumespresso/workflows/neb/base.py
@@ -243,7 +243,7 @@ class NebBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
 
         if 'diagonalizations' not in self.ctx:
             # Initialize a list to track diagonalisations that haven't been tried in reverse order or preference
-            self.ctx.diagonalizations = [value for value in ['cg', 'paro', 'ppcg', 'david'] if value != current.lower()]
+            self.ctx.diagonalizations = [value for value in ['cg', 'paro', 'david'] if value != current.lower()]
 
         try:
             new = self.ctx.diagonalizations.pop()

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -507,7 +507,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
 
         if 'diagonalizations' not in self.ctx:
             # Initialize a list to track diagonalisations that haven't been tried in reverse order or preference
-            self.ctx.diagonalizations = [value for value in ['cg', 'paro', 'ppcg', 'david'] if value != current.lower()]
+            self.ctx.diagonalizations = [value for value in ['cg', 'paro', 'david'] if value != current.lower()]
 
         try:
             new = self.ctx.diagonalizations.pop()

--- a/tests/workflows/neb/test_base.py
+++ b/tests/workflows/neb/test_base.py
@@ -61,17 +61,12 @@ def test_handle_diagonalization_errors(generate_workchain_neb, exit_code):
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'ppcg'
+    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'cg'
     assert result.do_break
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
     assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'paro'
-    assert result.do_break
-
-    result = process.handle_diagonalization_errors(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'cg'
     assert result.do_break
 
     result = process.inspect_process()
@@ -95,12 +90,7 @@ def test_handle_diagonalization_errors_not_from_david(generate_workchain_neb, ex
     process = generate_workchain_neb(exit_code=exit_code)
     process.setup()
 
-    process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] = 'ppcg'
-
-    result = process.handle_diagonalization_errors(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'david'
-    assert result.do_break
+    process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] = 'cg'
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
@@ -109,7 +99,7 @@ def test_handle_diagonalization_errors_not_from_david(generate_workchain_neb, ex
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'cg'
+    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'david'
     assert result.do_break
 
     result = process.inspect_process()

--- a/tests/workflows/neb/test_base.py
+++ b/tests/workflows/neb/test_base.py
@@ -61,12 +61,12 @@ def test_handle_diagonalization_errors(generate_workchain_neb, exit_code):
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'cg'
+    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'paro'
     assert result.do_break
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'paro'
+    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'cg'
     assert result.do_break
 
     result = process.inspect_process()
@@ -94,12 +94,12 @@ def test_handle_diagonalization_errors_not_from_david(generate_workchain_neb, ex
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'paro'
+    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'david'
     assert result.do_break
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'david'
+    assert process.ctx.inputs.pw.parameters['ELECTRONS']['diagonalization'] == 'paro'
     assert result.do_break
 
     result = process.inspect_process()

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -116,17 +116,12 @@ def test_handle_diagonalization_errors(generate_workchain_pw, exit_code):
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'ppcg'
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'cg'
     assert result.do_break
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
     assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'paro'
-    assert result.do_break
-
-    result = process.handle_diagonalization_errors(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'cg'
     assert result.do_break
 
     result = process.inspect_process()
@@ -150,12 +145,7 @@ def test_handle_diagonalization_errors_not_from_david(generate_workchain_pw, exi
     process = generate_workchain_pw(exit_code=exit_code)
     process.setup()
 
-    process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] = 'ppcg'
-
-    result = process.handle_diagonalization_errors(process.ctx.children[-1])
-    assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'david'
-    assert result.do_break
+    process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] = 'cg'
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
@@ -164,7 +154,7 @@ def test_handle_diagonalization_errors_not_from_david(generate_workchain_pw, exi
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'cg'
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'david'
     assert result.do_break
 
     result = process.inspect_process()

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -116,12 +116,12 @@ def test_handle_diagonalization_errors(generate_workchain_pw, exit_code):
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'cg'
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'paro'
     assert result.do_break
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'paro'
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'cg'
     assert result.do_break
 
     result = process.inspect_process()
@@ -149,12 +149,12 @@ def test_handle_diagonalization_errors_not_from_david(generate_workchain_pw, exi
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'paro'
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'david'
     assert result.do_break
 
     result = process.handle_diagonalization_errors(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
-    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'david'
+    assert process.ctx.inputs.parameters['ELECTRONS']['diagonalization'] == 'paro'
     assert result.do_break
 
     result = process.inspect_process()


### PR DESCRIPTION
Remove ppcg diagonalization method as QE v7.5 no longer supports it, improving error handling for users.#1091