### PR TITLE
🔧 Nightly: adapt code fixtures for change in aiida-core

### DIFF
--- a/tests/calculations/test_ph/test_serialize_builder.yml
+++ b/tests/calculations/test_ph/test_serialize_builder.yml
@@ -1,4 +1,4 @@
-code: test.quantumespresso.ph@localhost
+code: test.quantumespresso.ph
 metadata:
   options:
     max_wallclock_seconds: 1800

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ def serialize_builder():
             return data.value
 
         if isinstance(data, AbstractCode):
-            return data.full_label
+            return data.label
 
         if isinstance(data, Dict):
             return data.get_dict()

--- a/tests/workflows/protocols/ph/test_base/test_default.yml
+++ b/tests/workflows/protocols/ph/test_base/test_default.yml
@@ -1,7 +1,7 @@
 clean_workdir: false
 max_iterations: 5
 ph:
-  code: test.quantumespresso.ph@localhost
+  code: test.quantumespresso.ph
   metadata:
     options:
       max_wallclock_seconds: 43200

--- a/tests/workflows/protocols/ph/test_base/test_qpoints_list.yml
+++ b/tests/workflows/protocols/ph/test_base/test_qpoints_list.yml
@@ -1,7 +1,7 @@
 clean_workdir: false
 max_iterations: 5
 ph:
-  code: test.quantumespresso.ph@localhost
+  code: test.quantumespresso.ph
   metadata:
     options:
       max_wallclock_seconds: 43200

--- a/tests/workflows/protocols/pw/test_bands/test_default.yml
+++ b/tests/workflows/protocols/pw/test_bands/test_default.yml
@@ -1,7 +1,7 @@
 bands:
   max_iterations: 5
   pw:
-    code: test.quantumespresso.pw@localhost
+    code: test.quantumespresso.pw
     metadata:
       options:
         max_wallclock_seconds: 43200
@@ -41,7 +41,7 @@ scf:
   kpoints_force_parity: false
   max_iterations: 5
   pw:
-    code: test.quantumespresso.pw@localhost
+    code: test.quantumespresso.pw
     metadata:
       options:
         max_wallclock_seconds: 43200

--- a/tests/workflows/protocols/pw/test_base/test_default.yml
+++ b/tests/workflows/protocols/pw/test_base/test_default.yml
@@ -3,7 +3,7 @@ kpoints_distance: 0.15
 kpoints_force_parity: false
 max_iterations: 5
 pw:
-  code: test.quantumespresso.pw@localhost
+  code: test.quantumespresso.pw
   metadata:
     options:
       max_wallclock_seconds: 43200

--- a/tests/workflows/protocols/pw/test_relax/test_default.yml
+++ b/tests/workflows/protocols/pw/test_relax/test_default.yml
@@ -3,7 +3,7 @@ base_init_relax:
   kpoints_force_parity: false
   max_iterations: 5
   pw:
-    code: test.quantumespresso.pw@localhost
+    code: test.quantumespresso.pw
     metadata:
       options:
         max_wallclock_seconds: 43200
@@ -39,7 +39,7 @@ base_relax:
   kpoints_force_parity: false
   max_iterations: 5
   pw:
-    code: test.quantumespresso.pw@localhost
+    code: test.quantumespresso.pw
     metadata:
       options:
         max_wallclock_seconds: 43200

--- a/tests/workflows/protocols/test_pdos/test_default.yml
+++ b/tests/workflows/protocols/test_pdos/test_default.yml
@@ -1,6 +1,6 @@
 clean_workdir: false
 dos:
-  code: test.quantumespresso.dos@localhost
+  code: test.quantumespresso.dos
   metadata:
     options:
       max_wallclock_seconds: 43200
@@ -15,7 +15,7 @@ nscf:
   kpoints_force_parity: false
   max_iterations: 5
   pw:
-    code: test.quantumespresso.pw@localhost
+    code: test.quantumespresso.pw
     metadata:
       options:
         max_wallclock_seconds: 43200
@@ -43,7 +43,7 @@ nscf:
     pseudos:
       Si: Si<md5=57fa15d98af99972c7b7aa5c179b0bb8>
 projwfc:
-  code: test.quantumespresso.projwfc@localhost
+  code: test.quantumespresso.projwfc
   metadata:
     options:
       max_wallclock_seconds: 43200
@@ -58,7 +58,7 @@ scf:
   kpoints_force_parity: false
   max_iterations: 5
   pw:
-    code: test.quantumespresso.pw@localhost
+    code: test.quantumespresso.pw
     metadata:
       options:
         max_wallclock_seconds: 43200


### PR DESCRIPTION
In the following commit:

https://github.com/aiidateam/aiida-core/commit/2068a7d73142006c6729d3fbcfb12d9c65f48d65

The `localhost` test fixture's label was suffixed to make the tests less flaky. However, that in turn makes our protocol tests fail since the data regression captures the computer label through the full code labels.

Since updating the regression fixtures would mean the tests would fail when _not_ running against `aiida-core@main`, we first adapt the `serialize_builder` to take the code part of the label only; not the full label. Then we update the data regression files to reflect this change.