### PR TITLE
🧪 `test_matdyn.py`: strip `pbc{1,2,3}` in `default` to fix nightly

### DIFF
--- a/tests/parsers/test_matdyn.py
+++ b/tests/parsers/test_matdyn.py
@@ -30,10 +30,19 @@ def test_matdyn_default(fixture_localhost, generate_calc_job_node, generate_pars
     assert not orm.Log.collection.get_logs_for(node)
     assert 'output_parameters' in results
     assert 'output_phonon_bands' in results
+
+    # Pop `pbc{1,2,3}` attributes that aiida-core >=2.9 adds to `BandsData.base.attributes.all`
+    # (see aiida-core commit f4560285, unreleased at the time of writing). Assert they are
+    # `False`/`None` so both aiida-core versions pass.
+    bands_attrs = dict(results['output_phonon_bands'].base.attributes.all)
+
+    for key in ('pbc1', 'pbc2', 'pbc3'):
+        assert bands_attrs.pop(key, None) in (False, None)
+
     data_regression.check(
         {
             'output_parameters': results['output_parameters'].get_dict(),
-            'output_phonon_bands': results['output_phonon_bands'].base.attributes.all,
+            'output_phonon_bands': bands_attrs,
         }
     )
 


### PR DESCRIPTION
The `BandsData.base.attributes.all` data regression test used in `tests/parsers/test_matdyn.py::test_matdyn_default` started failing in the nightly build because aiida-core commit

https://github.com/aiidateam/aiida-core/commit/f4560285d611bbf4f2b702338ea466da4e210f4c

reworks the Pydantic model layer for `KpointsData` so that `pbc1`/`pbc2`/`pbc3` are now exposed as node attributes via `orm_to_model=lambda node: node.pbc[i]`. The data regression YAML was captured against an aiida-core that did not emit these keys, so any install of aiida-core past that commit (e.g. in the nightly build) would break the test.

Rather than regenerate the fixture and lock the test to the unreleased behaviour, here we copy `attributes.all` into a plain dict, pop `pbc{1,2,3}` and assert each popped value is `False` or `None` before handing the dict to `data_regression.check`. Both aiida-core variants now pass against the same checked-in fixture; the assertion still catches a stray `True` from a wrongly-propagated `pbc` setting on the parsed `BandsData`.