### PR TITLE
🐛 `PwBaseWorkChain`: use FR pseudo family for `SPIN_ORBIT` without overrides

### DIFF
--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -201,7 +201,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         meta_parameters = inputs.pop('meta_parameters')
         pseudo_family = inputs.pop('pseudo_family')
 
-        if spin_type is SpinType.SPIN_ORBIT and overrides is not None and 'pseudo_family' not in overrides:
+        if spin_type is SpinType.SPIN_ORBIT and 'pseudo_family' not in (overrides or {}):
             pseudo_family = 'PseudoDojo/0.4/PBEsol/FR/standard/upf'
 
         natoms = len(structure.sites)

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -433,3 +433,28 @@ def test_default_resources(
 
     builder = PwBaseWorkChain.get_builder_from_protocol(code, structure)
     assert builder.pw.metadata.options['resources'] == expected_resources
+
+
+def test_spin_orbit_pseudo_family(fixture_code, generate_structure):
+    """Test that ``SpinType.SPIN_ORBIT`` selects the fully-relativistic pseudo family by default."""
+    code = fixture_code('quantumespresso.pw')
+    structure = generate_structure('silicon')
+
+    # No overrides at all -> FR family cutoffs
+    builder = PwBaseWorkChain.get_builder_from_protocol(code, structure, spin_type=SpinType.SPIN_ORBIT)
+    assert builder.pw.parameters['SYSTEM']['ecutwfc'] == 60.0
+    assert builder.pw.parameters['SYSTEM']['ecutrho'] == 400.0
+
+    # Overrides present but without ``pseudo_family`` -> FR family
+    builder = PwBaseWorkChain.get_builder_from_protocol(
+        code, structure, spin_type=SpinType.SPIN_ORBIT, overrides={'clean_workdir': True}
+    )
+    assert builder.pw.parameters['SYSTEM']['ecutwfc'] == 60.0
+    assert builder.pw.parameters['SYSTEM']['ecutrho'] == 400.0
+
+    # Explicit ``pseudo_family`` in overrides always wins
+    builder = PwBaseWorkChain.get_builder_from_protocol(
+        code, structure, spin_type=SpinType.SPIN_ORBIT, overrides={'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'}
+    )
+    assert builder.pw.parameters['SYSTEM']['ecutwfc'] == 30.0
+    assert builder.pw.parameters['SYSTEM']['ecutrho'] == 240.0


### PR DESCRIPTION
The fully-relativistic PseudoDojo default for `spin_type == SpinType.SPIN_ORBIT` was only applied when `overrides` was not `None`. A builder created without any overrides therefore silently received the SSSP pseudopotentials. The default is now applied whenever no explicit `pseudo_family` is provided, and a test is added.