### PR TITLE
✨ Typed `overrides` for `get_builder_from_protocol`

### DIFF
--- a/src/aiida_quantumespresso/workflows/protocols/overrides.py
+++ b/src/aiida_quantumespresso/workflows/protocols/overrides.py
@@ -1,0 +1,100 @@
+"""Typed dictionaries describing the ``overrides`` accepted by ``get_builder_from_protocol``.
+
+These ``TypedDict`` definitions mirror the nested ``overrides`` mapping that each work chain's
+``get_builder_from_protocol`` recursively merges onto the protocol defaults. They exist purely to
+provide editor autocompletion and static type checking for callers; they carry no runtime behaviour
+and the builder logic remains unchanged whether or not they are used.
+
+To keep them from silently drifting away from the work chain input specs, the keys of each
+``TypedDict`` are asserted to be *equal* to the corresponding ``spec().inputs`` port names (plus a
+small set of "builder-consumed" keys that the protocol logic reads directly without exposing them as
+input ports, minus an explicit set of ports the builder always overwrites from its own arguments) in
+``tests/workflows/protocols/test_overrides.py``. Equality (rather than a one-sided subset) means the
+guard fires in both directions: an orphaned typed key *and* a newly added upstream port that the
+``TypedDict`` is missing both break the test.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class PwParametersOverrides(TypedDict, total=False):
+    """Overrides for the ``pw.parameters`` Quantum ESPRESSO namelists.
+
+    The keys are the QE ``pw.x`` namelist names; the values are free-form mappings of namelist
+    keyword to value. This enumerates the full ``pw.x`` namelist set so that any namelist a caller
+    may legitimately merge in through the ``overrides`` is autocompleted.
+    """
+
+    CONTROL: dict[str, Any]
+    SYSTEM: dict[str, Any]
+    ELECTRONS: dict[str, Any]
+    IONS: dict[str, Any]
+    CELL: dict[str, Any]
+    FCP: dict[str, Any]
+    RISM: dict[str, Any]
+
+
+class PwCalculationOverrides(TypedDict, total=False):
+    """Overrides for the ``pw`` namespace of ``PwBaseWorkChain`` (the ``PwCalculation`` inputs).
+
+    ``code`` and ``structure`` are deliberately omitted: the builder always sets them from its own
+    ``code``/``structure`` arguments, so an override there would be ignored (see the drift-guard's
+    ``INTENTIONALLY_UNTYPED`` set).
+    """
+
+    parameters: PwParametersOverrides
+    pseudos: dict[str, Any]
+    metadata: dict[str, Any]
+    settings: dict[str, Any]
+    parallelization: dict[str, Any]
+    monitors: dict[str, Any]
+    hubbard_file: Any
+    parent_folder: Any
+    remote_folder: Any
+    vdw_table: Any
+
+
+class PwMetaParameters(TypedDict, total=False):
+    """Overrides for the protocol ``meta_parameters`` (consumed by the builder, not an input port)."""
+
+    conv_thr_per_atom: float
+    etot_conv_thr_per_atom: float
+
+
+class PwBaseOverrides(TypedDict, total=False):
+    """Overrides accepted by ``PwBaseWorkChain.get_builder_from_protocol``.
+
+    ``meta_parameters`` and ``pseudo_family`` are protocol keys the builder consumes directly (they
+    are not input ports); every other key is a ``PwBaseWorkChain`` input port.
+    """
+
+    pw: PwCalculationOverrides
+    clean_workdir: bool
+    kpoints: Any
+    kpoints_distance: float
+    kpoints_force_parity: bool
+    max_iterations: int
+    metadata: dict[str, Any]
+    handler_overrides: dict[str, Any]
+    on_unhandled_failure: str
+    pause_on_max_iterations: bool
+    meta_parameters: PwMetaParameters
+    pseudo_family: str
+
+
+class PwBandsOverrides(TypedDict, total=False):
+    """Overrides accepted by ``PwBandsWorkChain.get_builder_from_protocol``.
+
+    ``structure`` is deliberately omitted: the builder always sets it from its own ``structure``
+    argument, so an override there would be ignored (see the drift-guard's ``INTENTIONALLY_UNTYPED``).
+    """
+
+    scf: PwBaseOverrides
+    bands: PwBaseOverrides
+    clean_workdir: bool
+    nbands_factor: float
+    bands_kpoints: Any
+    bands_kpoints_distance: float
+    metadata: dict[str, Any]

--- a/src/aiida_quantumespresso/workflows/protocols/overrides.py
+++ b/src/aiida_quantumespresso/workflows/protocols/overrides.py
@@ -12,6 +12,14 @@ input ports, minus an explicit set of ports the builder always overwrites from i
 ``tests/workflows/protocols/test_overrides.py``. Equality (rather than a one-sided subset) means the
 guard fires in both directions: an orphaned typed key *and* a newly added upstream port that the
 ``TypedDict`` is missing both break the test.
+
+``PwBandsWorkChain`` exposes ``PwBaseWorkChain`` under its ``scf`` and ``bands`` namespaces but
+``exclude``s some ports (``clean_workdir`` from both, and ``pw.parent_folder`` from ``bands`` since
+the builder wires it from the SCF remote folder). The ``scf``/``bands`` overrides therefore use
+*narrowed* ``TypedDict``\\ s (``PwBandsScfOverrides``/``PwBandsBandsOverrides`` and the narrowed
+``PwBandsCalculationOverrides``) rather than the full ``PwBaseOverrides``, so autocomplete never
+suggests a key the namespace does not expose. The drift guards check each nested namespace against
+its own sub-spec so this narrowing cannot silently rot either.
 """
 
 from __future__ import annotations
@@ -36,12 +44,13 @@ class PwParametersOverrides(TypedDict, total=False):
     RISM: dict[str, Any]
 
 
-class PwCalculationOverrides(TypedDict, total=False):
-    """Overrides for the ``pw`` namespace of ``PwBaseWorkChain`` (the ``PwCalculation`` inputs).
+class _PwCalculationCommonOverrides(TypedDict, total=False):
+    """The ``pw`` (``PwCalculation``) override keys shared by every ``PwBaseWorkChain`` namespace.
 
-    ``code`` and ``structure`` are deliberately omitted: the builder always sets them from its own
-    ``code``/``structure`` arguments, so an override there would be ignored (see the drift-guard's
-    ``INTENTIONALLY_UNTYPED`` set).
+    ``code`` and ``structure`` are absent throughout: the builder always sets them from its own
+    ``code``/``structure`` arguments, so an override there would be ignored (they are listed in the
+    drift guard's ``intentionally_untyped`` set). ``parent_folder`` is *not* here because the
+    ``bands`` namespace of ``PwBandsWorkChain`` excludes it; it is added by ``PwCalculationOverrides``.
     """
 
     parameters: PwParametersOverrides
@@ -51,9 +60,23 @@ class PwCalculationOverrides(TypedDict, total=False):
     parallelization: dict[str, Any]
     monitors: dict[str, Any]
     hubbard_file: Any
-    parent_folder: Any
     remote_folder: Any
     vdw_table: Any
+
+
+class PwCalculationOverrides(_PwCalculationCommonOverrides, total=False):
+    """Overrides for the ``pw`` namespace of ``PwBaseWorkChain`` (the ``PwCalculation`` inputs)."""
+
+    parent_folder: Any
+
+
+class PwBandsCalculationOverrides(_PwCalculationCommonOverrides, total=False):
+    """Overrides for the ``bands.pw`` namespace of ``PwBandsWorkChain``.
+
+    Identical to ``PwCalculationOverrides`` but without ``parent_folder``: ``PwBandsWorkChain``
+    excludes ``pw.parent_folder`` from its ``bands`` namespace (the builder sets it from the SCF
+    remote folder), so exposing it here would suggest a key the namespace does not accept.
+    """
 
 
 class PwMetaParameters(TypedDict, total=False):
@@ -63,15 +86,15 @@ class PwMetaParameters(TypedDict, total=False):
     etot_conv_thr_per_atom: float
 
 
-class PwBaseOverrides(TypedDict, total=False):
-    """Overrides accepted by ``PwBaseWorkChain.get_builder_from_protocol``.
+class _PwBaseCommonOverrides(TypedDict, total=False):
+    """The ``PwBaseWorkChain`` override keys shared by the full work chain and its exposed namespaces.
 
+    ``clean_workdir`` and ``pw`` are declared by each concrete subclass: ``PwBandsWorkChain`` excludes
+    ``clean_workdir`` from its ``scf``/``bands`` namespaces, and narrows ``pw`` for ``bands``.
     ``meta_parameters`` and ``pseudo_family`` are protocol keys the builder consumes directly (they
-    are not input ports); every other key is a ``PwBaseWorkChain`` input port.
+    are not input ports); every other key here is a ``PwBaseWorkChain`` input port.
     """
 
-    pw: PwCalculationOverrides
-    clean_workdir: bool
     kpoints: Any
     kpoints_distance: float
     kpoints_force_parity: bool
@@ -84,15 +107,43 @@ class PwBaseOverrides(TypedDict, total=False):
     pseudo_family: str
 
 
+class PwBaseOverrides(_PwBaseCommonOverrides, total=False):
+    """Overrides accepted by ``PwBaseWorkChain.get_builder_from_protocol``."""
+
+    pw: PwCalculationOverrides
+    clean_workdir: bool
+
+
+class PwBandsScfOverrides(_PwBaseCommonOverrides, total=False):
+    """Overrides for the ``scf`` namespace of ``PwBandsWorkChain``.
+
+    Same as ``PwBaseOverrides`` but without ``clean_workdir``, which ``PwBandsWorkChain`` excludes
+    from its ``scf`` namespace (cleanup is driven by the parent work chain's own ``clean_workdir``).
+    """
+
+    pw: PwCalculationOverrides
+
+
+class PwBandsBandsOverrides(_PwBaseCommonOverrides, total=False):
+    """Overrides for the ``bands`` namespace of ``PwBandsWorkChain``.
+
+    Same as ``PwBandsScfOverrides`` (no ``clean_workdir``) but with ``pw`` further narrowed to
+    ``PwBandsCalculationOverrides`` (no ``parent_folder``), matching the ports the ``bands`` namespace
+    exposes.
+    """
+
+    pw: PwBandsCalculationOverrides
+
+
 class PwBandsOverrides(TypedDict, total=False):
     """Overrides accepted by ``PwBandsWorkChain.get_builder_from_protocol``.
 
     ``structure`` is deliberately omitted: the builder always sets it from its own ``structure``
-    argument, so an override there would be ignored (see the drift-guard's ``INTENTIONALLY_UNTYPED``).
+    argument, so an override there would be ignored (see the drift guard's ``intentionally_untyped``).
     """
 
-    scf: PwBaseOverrides
-    bands: PwBaseOverrides
+    scf: PwBandsScfOverrides
+    bands: PwBandsBandsOverrides
     clean_workdir: bool
     nbands_factor: float
     bands_kpoints: Any

--- a/src/aiida_quantumespresso/workflows/protocols/overrides.py
+++ b/src/aiida_quantumespresso/workflows/protocols/overrides.py
@@ -17,7 +17,7 @@ guard fires in both directions: an orphaned typed key *and* a newly added upstre
 ``exclude``s some ports (``clean_workdir`` from both, and ``pw.parent_folder`` from ``bands`` since
 the builder wires it from the SCF remote folder). The ``scf``/``bands`` overrides therefore use
 *narrowed* ``TypedDict``\\ s (``PwBandsScfOverrides``/``PwBandsBandsOverrides`` and the narrowed
-``PwBandsCalculationOverrides``) rather than the full ``PwBaseOverrides``, so autocomplete never
+``PwBandsCalculationOverrides``) rather than the full ``PwBaseProtocolOverrides``, so autocomplete never
 suggests a key the namespace does not expose. The drift guards check each nested namespace against
 its own sub-spec so this narrowing cannot silently rot either.
 """
@@ -107,7 +107,7 @@ class _PwBaseCommonOverrides(TypedDict, total=False):
     pseudo_family: str
 
 
-class PwBaseOverrides(_PwBaseCommonOverrides, total=False):
+class PwBaseProtocolOverrides(_PwBaseCommonOverrides, total=False):
     """Overrides accepted by ``PwBaseWorkChain.get_builder_from_protocol``."""
 
     pw: PwCalculationOverrides
@@ -117,7 +117,7 @@ class PwBaseOverrides(_PwBaseCommonOverrides, total=False):
 class PwBandsScfOverrides(_PwBaseCommonOverrides, total=False):
     """Overrides for the ``scf`` namespace of ``PwBandsWorkChain``.
 
-    Same as ``PwBaseOverrides`` but without ``clean_workdir``, which ``PwBandsWorkChain`` excludes
+    Same as ``PwBaseProtocolOverrides`` but without ``clean_workdir``, which ``PwBandsWorkChain`` excludes
     from its ``scf`` namespace (cleanup is driven by the parent work chain's own ``clean_workdir``).
     """
 
@@ -135,7 +135,7 @@ class PwBandsBandsOverrides(_PwBaseCommonOverrides, total=False):
     pw: PwBandsCalculationOverrides
 
 
-class PwBandsOverrides(TypedDict, total=False):
+class PwBandsProtocolOverrides(TypedDict, total=False):
     """Overrides accepted by ``PwBandsWorkChain.get_builder_from_protocol``.
 
     ``structure`` is deliberately omitted: the builder always sets it from its own ``structure``

--- a/src/aiida_quantumespresso/workflows/pw/bands.py
+++ b/src/aiida_quantumespresso/workflows/pw/bands.py
@@ -8,6 +8,7 @@ from aiida_quantumespresso.calculations.functions.seekpath_structure_analysis im
 from aiida_quantumespresso.utils.mapping import prepare_process_inputs
 from aiida_quantumespresso.workflows.pw.base import PwBaseWorkChain
 
+from ..protocols.overrides import PwBandsOverrides
 from ..protocols.utils import ProtocolMixin
 
 
@@ -142,7 +143,9 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
         return files(pw_protocols) / 'bands.yaml'
 
     @classmethod
-    def get_builder_from_protocol(cls, code, structure, protocol=None, overrides=None, options=None, **kwargs):
+    def get_builder_from_protocol(
+        cls, code, structure, protocol=None, overrides: PwBandsOverrides | None = None, options=None, **kwargs
+    ):
         """Return a builder prepopulated with inputs selected according to the chosen protocol.
 
         :param code: the ``Code`` instance configured for the ``quantumespresso.pw`` plugin.

--- a/src/aiida_quantumespresso/workflows/pw/bands.py
+++ b/src/aiida_quantumespresso/workflows/pw/bands.py
@@ -8,7 +8,7 @@ from aiida_quantumespresso.calculations.functions.seekpath_structure_analysis im
 from aiida_quantumespresso.utils.mapping import prepare_process_inputs
 from aiida_quantumespresso.workflows.pw.base import PwBaseWorkChain
 
-from ..protocols.overrides import PwBandsOverrides
+from ..protocols.overrides import PwBandsProtocolOverrides
 from ..protocols.utils import ProtocolMixin
 
 
@@ -144,7 +144,13 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
 
     @classmethod
     def get_builder_from_protocol(
-        cls, code, structure, protocol=None, overrides: PwBandsOverrides | None = None, options=None, **kwargs
+        cls,
+        code,
+        structure,
+        protocol=None,
+        overrides: PwBandsProtocolOverrides | None = None,
+        options=None,
+        **kwargs,
     ):
         """Return a builder prepopulated with inputs selected according to the chosen protocol.
 

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -18,6 +18,7 @@ from aiida_quantumespresso.calculations.functions.create_kpoints_from_distance i
 from aiida_quantumespresso.common.types import ElectronicType, RestartType, SpinType
 from aiida_quantumespresso.utils.defaults.calculation import pw as qe_defaults
 
+from ..protocols.overrides import PwBaseOverrides
 from ..protocols.utils import ProtocolMixin
 
 PwCalculation = CalculationFactory('quantumespresso.pw')
@@ -155,7 +156,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         code,
         structure,
         protocol=None,
-        overrides=None,
+        overrides: PwBaseOverrides | None = None,
         electronic_type=ElectronicType.METAL,
         spin_type=SpinType.NONE,
         initial_magnetic_moments=None,

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -22,7 +22,7 @@ from aiida_quantumespresso.common.types import ElectronicType, RestartType, Spin
 from aiida_quantumespresso.tools.monitors.accuracy_stuck import ACCURACY_STUCK_MESSAGE_PREFIX
 from aiida_quantumespresso.utils.defaults.calculation import pw as qe_defaults
 
-from ..protocols.overrides import PwBaseOverrides
+from ..protocols.overrides import PwBaseProtocolOverrides
 from ..protocols.utils import ProtocolMixin
 
 PwCalculation = CalculationFactory('quantumespresso.pw')
@@ -163,7 +163,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         code,
         structure,
         protocol=None,
-        overrides: PwBaseOverrides | None = None,
+        overrides: PwBaseProtocolOverrides | None = None,
         electronic_type=ElectronicType.METAL,
         spin_type=SpinType.NONE,
         initial_magnetic_moments=None,

--- a/tests/workflows/protocols/test_overrides.py
+++ b/tests/workflows/protocols/test_overrides.py
@@ -1,0 +1,100 @@
+"""Drift guards for the ``overrides`` ``TypedDict`` definitions.
+
+Each ``TypedDict`` in :mod:`aiida_quantumespresso.workflows.protocols.overrides` mirrors the
+``overrides`` mapping consumed by a ``get_builder_from_protocol`` method. These tests assert that the
+keys never drift away from the actual work chain input spec, and they do so with *equality* rather
+than a one-sided subset:
+
+    set(TheOverrides.__annotations__) == (port_names | builder_consumed) - intentionally_untyped
+
+A subset check only catches the *orphaned* direction — a typed key that no longer maps to any port.
+Equality also catches the *incomplete* direction: upstream adds an input port and the ``TypedDict``
+silently lacks it, which is exactly the autocomplete/type-check gap this module closes. Because the
+overrides recursively merge onto the builder inputs, every input port is legitimate override surface,
+so the target set is the full port namespace (plus builder-consumed protocol keys the logic reads
+directly without exposing as ports) minus an explicit, justified set of ports the builder always
+overwrites from its own arguments. The shared :func:`assert_overrides_match_spec` helper performs the
+comparison and reports which direction drifted.
+"""
+
+from typing import Iterable
+
+from aiida_quantumespresso.workflows.protocols.overrides import (
+    PwBandsOverrides,
+    PwBaseOverrides,
+    PwCalculationOverrides,
+    PwMetaParameters,
+    PwParametersOverrides,
+)
+from aiida_quantumespresso.workflows.pw.bands import PwBandsWorkChain
+from aiida_quantumespresso.workflows.pw.base import PwBaseWorkChain
+
+# The complete set of Quantum ESPRESSO ``pw.x`` input namelists. Any of these may be merged into the
+# ``pw.parameters`` ``Dict`` through the overrides, so ``PwParametersOverrides`` enumerates them all.
+PW_NAMELISTS = {'CONTROL', 'SYSTEM', 'ELECTRONS', 'IONS', 'CELL', 'FCP', 'RISM'}
+
+
+def assert_overrides_match_spec(
+    overrides_cls: type,
+    port_names: Iterable[str],
+    *,
+    builder_consumed: Iterable[str] = frozenset(),
+    intentionally_untyped: Iterable[str] = frozenset(),
+) -> None:
+    """Assert the ``TypedDict`` covers exactly the override surface (two-way drift guard).
+
+    :param overrides_cls: the ``TypedDict`` whose ``__annotations__`` keys are the declared overrides.
+    :param port_names: the ``spec().inputs`` (or namelist/protocol) key names the type must mirror.
+    :param builder_consumed: protocol keys the builder reads directly without exposing as input ports.
+    :param intentionally_untyped: ports the builder always overwrites from its own arguments, so an
+        override there would be ignored and is deliberately left out of the ``TypedDict``.
+    """
+    expected = (set(port_names) | set(builder_consumed)) - set(intentionally_untyped)
+    actual = set(overrides_cls.__annotations__)
+    assert actual == expected, (
+        f'missing from {overrides_cls.__name__}: {sorted(expected - actual)}; '
+        f'orphaned in {overrides_cls.__name__}: {sorted(actual - expected)}'
+    )
+
+
+def test_pw_parameters_overrides_match_namelists():
+    """The ``pw.parameters`` overrides keys must be exactly the Quantum ESPRESSO ``pw.x`` namelists."""
+    assert_overrides_match_spec(PwParametersOverrides, PW_NAMELISTS)
+
+
+def test_pw_meta_parameters_match_protocol():
+    """The ``meta_parameters`` overrides keys must match the protocol ``meta_parameters`` schema."""
+    protocol_meta = PwBaseWorkChain.get_protocol_inputs()['meta_parameters']
+    # No exclusions: the builder reads every ``meta_parameters`` key, so all are override surface.
+    assert_overrides_match_spec(PwMetaParameters, protocol_meta)
+
+
+def test_pw_calculation_overrides_match_spec():
+    """The ``pw`` overrides keys must equal the ``pw`` input namespace ports (bar builder-set ones)."""
+    ports = PwBaseWorkChain.spec().inputs['pw'].keys()
+    # Ports the builder always sets from its own arguments, so an override would be ignored.
+    intentionally_untyped = {
+        'code',  # set unconditionally from the ``code`` argument
+        'structure',  # set unconditionally from the ``structure`` argument
+    }
+    assert_overrides_match_spec(PwCalculationOverrides, ports, intentionally_untyped=intentionally_untyped)
+
+
+def test_pw_base_overrides_match_spec():
+    """The ``PwBaseWorkChain`` overrides keys must equal spec ports plus builder-consumed keys."""
+    ports = PwBaseWorkChain.spec().inputs.keys()
+    # Protocol keys the builder pops directly (``inputs.pop(...)``) without exposing as input ports.
+    builder_consumed = {'meta_parameters', 'pseudo_family'}
+    # Nothing at this level is set from the builder's own arguments (``code``/``structure`` land in
+    # the nested ``pw`` namespace), so no port is excluded.
+    assert_overrides_match_spec(PwBaseOverrides, ports, builder_consumed=builder_consumed)
+
+
+def test_pw_bands_overrides_match_spec():
+    """The ``PwBandsWorkChain`` overrides keys must equal spec ports (nested ``scf``/``bands`` recurse)."""
+    ports = PwBandsWorkChain.spec().inputs.keys()
+    # Ports the builder always sets from its own arguments, so an override would be ignored.
+    intentionally_untyped = {
+        'structure',  # set unconditionally from the ``structure`` argument
+    }
+    assert_overrides_match_spec(PwBandsOverrides, ports, intentionally_untyped=intentionally_untyped)

--- a/tests/workflows/protocols/test_overrides.py
+++ b/tests/workflows/protocols/test_overrides.py
@@ -19,8 +19,13 @@ comparison and reports which direction drifted.
 
 from typing import Iterable
 
+from aiida.plugins import CalculationFactory
+
 from aiida_quantumespresso.workflows.protocols.overrides import (
+    PwBandsBandsOverrides,
+    PwBandsCalculationOverrides,
     PwBandsOverrides,
+    PwBandsScfOverrides,
     PwBaseOverrides,
     PwCalculationOverrides,
     PwMetaParameters,
@@ -29,8 +34,14 @@ from aiida_quantumespresso.workflows.protocols.overrides import (
 from aiida_quantumespresso.workflows.pw.bands import PwBandsWorkChain
 from aiida_quantumespresso.workflows.pw.base import PwBaseWorkChain
 
-# The complete set of Quantum ESPRESSO ``pw.x`` input namelists. Any of these may be merged into the
-# ``pw.parameters`` ``Dict`` through the overrides, so ``PwParametersOverrides`` enumerates them all.
+PwCalculation = CalculationFactory('quantumespresso.pw')
+
+# The complete set of Quantum ESPRESSO ``pw.x`` input namelists that ``PwParametersOverrides``
+# enumerates. There is no authoritative in-repo list of *all* ``pw.x`` namelists to tie this to
+# (``PwCalculation._automatic_namelists`` only covers the geometry/electronic ones dispatched by
+# calculation type; ``FCP``/``RISM`` are QE features aiida-quantumespresso does not reference
+# elsewhere). This constant is therefore a second hand-written copy: the equality guard below only
+# protects the two declarations against drifting apart, not against QE's real namelist set.
 PW_NAMELISTS = {'CONTROL', 'SYSTEM', 'ELECTRONS', 'IONS', 'CELL', 'FCP', 'RISM'}
 
 
@@ -58,8 +69,27 @@ def assert_overrides_match_spec(
 
 
 def test_pw_parameters_overrides_match_namelists():
-    """The ``pw.parameters`` overrides keys must be exactly the Quantum ESPRESSO ``pw.x`` namelists."""
+    """The ``pw.parameters`` overrides keys must equal the hand-maintained ``PW_NAMELISTS`` copy.
+
+    Both sides are hand-written, so this only guards the two declarations against drifting apart, not
+    against Quantum ESPRESSO's real ``pw.x`` namelist set (there is no authoritative in-repo source
+    for the latter; see the ``PW_NAMELISTS`` comment). The ``_automatic_namelists`` check below adds a
+    partial guard tied to actual plugin code.
+    """
     assert_overrides_match_spec(PwParametersOverrides, PW_NAMELISTS)
+
+
+def test_pw_parameters_overrides_cover_automatic_namelists():
+    """Every namelist ``PwCalculation`` dispatches by calculation type must be a typed override key.
+
+    Unlike ``PW_NAMELISTS`` (a second hand-written copy), ``PwCalculation._automatic_namelists`` is
+    real plugin code, so this is a genuine one-directional guard: if a calculation type gains a
+    namelist that ``PwParametersOverrides`` lacks, this fails. It cannot cover ``FCP``/``RISM``, which
+    are not referenced there.
+    """
+    automatic = set().union(*PwCalculation._automatic_namelists.values())  # noqa: SLF001
+    typed = set(PwParametersOverrides.__annotations__)
+    assert automatic <= typed, f'namelists dispatched by PwCalculation but not typed: {sorted(automatic - typed)}'
 
 
 def test_pw_meta_parameters_match_protocol():
@@ -91,10 +121,46 @@ def test_pw_base_overrides_match_spec():
 
 
 def test_pw_bands_overrides_match_spec():
-    """The ``PwBandsWorkChain`` overrides keys must equal spec ports (nested ``scf``/``bands`` recurse)."""
+    """The ``PwBandsWorkChain`` top-level overrides keys must equal its spec ports (bar builder-set)."""
     ports = PwBandsWorkChain.spec().inputs.keys()
     # Ports the builder always sets from its own arguments, so an override would be ignored.
     intentionally_untyped = {
         'structure',  # set unconditionally from the ``structure`` argument
     }
     assert_overrides_match_spec(PwBandsOverrides, ports, intentionally_untyped=intentionally_untyped)
+
+
+# Protocol keys the nested ``PwBaseWorkChain`` builder consumes directly (they are not input ports).
+# The ``scf``/``bands`` overrides are forwarded verbatim to ``PwBaseWorkChain.get_builder_from_protocol``.
+_BASE_BUILDER_CONSUMED = {'meta_parameters', 'pseudo_family'}
+
+
+def test_pw_bands_scf_overrides_match_spec():
+    """The ``scf`` overrides keys must equal the ``scf`` namespace ports (which exclude ``clean_workdir``)."""
+    ports = PwBandsWorkChain.spec().inputs['scf'].keys()
+    assert_overrides_match_spec(PwBandsScfOverrides, ports, builder_consumed=_BASE_BUILDER_CONSUMED)
+
+
+def test_pw_bands_scf_pw_overrides_match_spec():
+    """The ``scf.pw`` overrides keys must equal the ``scf.pw`` namespace ports (bar builder-set ones)."""
+    ports = PwBandsWorkChain.spec().inputs['scf']['pw'].keys()
+    # ``structure`` is already excluded from the ``scf`` namespace; ``code`` is set by the builder.
+    assert_overrides_match_spec(PwCalculationOverrides, ports, intentionally_untyped={'code'})
+
+
+def test_pw_bands_bands_overrides_match_spec():
+    """The ``bands`` overrides keys must equal the ``bands`` namespace ports (which exclude ``clean_workdir``)."""
+    ports = PwBandsWorkChain.spec().inputs['bands'].keys()
+    assert_overrides_match_spec(PwBandsBandsOverrides, ports, builder_consumed=_BASE_BUILDER_CONSUMED)
+
+
+def test_pw_bands_bands_pw_overrides_match_spec():
+    """The ``bands.pw`` overrides keys must equal the ``bands.pw`` namespace ports (bar builder-set ones).
+
+    ``PwBandsWorkChain`` excludes ``pw.parent_folder`` (and ``pw.structure``) from its ``bands``
+    namespace, so ``PwBandsCalculationOverrides`` must omit ``parent_folder`` where the general
+    ``PwCalculationOverrides`` keeps it.
+    """
+    ports = PwBandsWorkChain.spec().inputs['bands']['pw'].keys()
+    # ``structure``/``parent_folder`` are already excluded from the ``bands`` namespace; ``code`` is builder-set.
+    assert_overrides_match_spec(PwBandsCalculationOverrides, ports, intentionally_untyped={'code'})

--- a/tests/workflows/protocols/test_overrides.py
+++ b/tests/workflows/protocols/test_overrides.py
@@ -17,16 +17,17 @@ overwrites from its own arguments. The shared :func:`assert_overrides_match_spec
 comparison and reports which direction drifted.
 """
 
-from typing import Iterable
+from typing import Callable, Iterable
 
+import pytest
 from aiida.plugins import CalculationFactory
 
 from aiida_quantumespresso.workflows.protocols.overrides import (
     PwBandsBandsOverrides,
     PwBandsCalculationOverrides,
-    PwBandsOverrides,
+    PwBandsProtocolOverrides,
     PwBandsScfOverrides,
-    PwBaseOverrides,
+    PwBaseProtocolOverrides,
     PwCalculationOverrides,
     PwMetaParameters,
     PwParametersOverrides,
@@ -43,6 +44,11 @@ PwCalculation = CalculationFactory('quantumespresso.pw')
 # elsewhere). This constant is therefore a second hand-written copy: the equality guard below only
 # protects the two declarations against drifting apart, not against QE's real namelist set.
 PW_NAMELISTS = {'CONTROL', 'SYSTEM', 'ELECTRONS', 'IONS', 'CELL', 'FCP', 'RISM'}
+
+# Protocol keys the ``PwBaseWorkChain`` builder pops directly (``inputs.pop(...)``) without exposing
+# them as input ports. The ``scf``/``bands`` overrides of ``PwBandsWorkChain`` are forwarded verbatim
+# to that builder, so they carry the same keys.
+_BASE_BUILDER_CONSUMED = {'meta_parameters', 'pseudo_family'}
 
 
 def assert_overrides_match_spec(
@@ -68,6 +74,100 @@ def assert_overrides_match_spec(
     )
 
 
+# One case per typed namespace, in the argument order of ``assert_overrides_match_spec``: the
+# ``TypedDict``, a callable returning the key names it must mirror (called inside the test to keep
+# ``spec()`` off the collection path), the builder-consumed keys, and the intentionally untyped ones.
+OVERRIDES_CASES = [
+    pytest.param(
+        PwBaseProtocolOverrides,
+        lambda: PwBaseWorkChain.spec().inputs.keys(),
+        _BASE_BUILDER_CONSUMED,
+        # ``code``/``structure`` land in the nested ``pw`` namespace, so no top-level port is builder-set.
+        frozenset(),
+        id='base',
+    ),
+    pytest.param(
+        PwCalculationOverrides,
+        lambda: PwBaseWorkChain.spec().inputs['pw'].keys(),
+        frozenset(),
+        {
+            'code',  # set unconditionally from the ``code`` argument
+            'structure',  # set unconditionally from the ``structure`` argument
+        },
+        id='base.pw',
+    ),
+    pytest.param(
+        PwBandsProtocolOverrides,
+        lambda: PwBandsWorkChain.spec().inputs.keys(),
+        frozenset(),
+        {
+            'structure',  # set unconditionally from the ``structure`` argument
+        },
+        id='bands',
+    ),
+    pytest.param(
+        PwBandsScfOverrides,
+        # The ``scf`` namespace excludes ``clean_workdir``, so the type must not declare it.
+        lambda: PwBandsWorkChain.spec().inputs['scf'].keys(),
+        _BASE_BUILDER_CONSUMED,
+        frozenset(),
+        id='bands.scf',
+    ),
+    pytest.param(
+        PwCalculationOverrides,
+        lambda: PwBandsWorkChain.spec().inputs['scf']['pw'].keys(),
+        frozenset(),
+        {
+            'code',  # set by the builder (``structure`` is already excluded from the ``scf`` namespace)
+        },
+        id='bands.scf.pw',
+    ),
+    pytest.param(
+        PwBandsBandsOverrides,
+        # The ``bands`` namespace excludes ``clean_workdir``, so the type must not declare it.
+        lambda: PwBandsWorkChain.spec().inputs['bands'].keys(),
+        _BASE_BUILDER_CONSUMED,
+        frozenset(),
+        id='bands.bands',
+    ),
+    pytest.param(
+        PwBandsCalculationOverrides,
+        # ``PwBandsWorkChain`` excludes ``pw.parent_folder`` (and ``pw.structure``) from its ``bands``
+        # namespace, so this type must omit ``parent_folder`` where ``PwCalculationOverrides`` keeps it.
+        lambda: PwBandsWorkChain.spec().inputs['bands']['pw'].keys(),
+        frozenset(),
+        {
+            'code',  # set by the builder (``structure``/``parent_folder`` are excluded from the namespace)
+        },
+        id='bands.bands.pw',
+    ),
+    pytest.param(
+        PwMetaParameters,
+        lambda: PwBaseWorkChain.get_protocol_inputs()['meta_parameters'],
+        frozenset(),
+        # The builder reads every ``meta_parameters`` key, so all of them are override surface.
+        frozenset(),
+        id='meta_parameters',
+    ),
+]
+
+
+@pytest.mark.parametrize('overrides_cls, port_names, builder_consumed, intentionally_untyped', OVERRIDES_CASES)
+def test_overrides_match_spec(
+    overrides_cls: type,
+    port_names: Callable[[], Iterable[str]],
+    builder_consumed: Iterable[str],
+    intentionally_untyped: Iterable[str],
+):
+    """The typed overrides keys must equal the override surface of the namespace they mirror."""
+    assert_overrides_match_spec(
+        overrides_cls,
+        port_names(),
+        builder_consumed=builder_consumed,
+        intentionally_untyped=intentionally_untyped,
+    )
+
+
 def test_pw_parameters_overrides_match_namelists():
     """The ``pw.parameters`` overrides keys must equal the hand-maintained ``PW_NAMELISTS`` copy.
 
@@ -90,77 +190,3 @@ def test_pw_parameters_overrides_cover_automatic_namelists():
     automatic = set().union(*PwCalculation._automatic_namelists.values())  # noqa: SLF001
     typed = set(PwParametersOverrides.__annotations__)
     assert automatic <= typed, f'namelists dispatched by PwCalculation but not typed: {sorted(automatic - typed)}'
-
-
-def test_pw_meta_parameters_match_protocol():
-    """The ``meta_parameters`` overrides keys must match the protocol ``meta_parameters`` schema."""
-    protocol_meta = PwBaseWorkChain.get_protocol_inputs()['meta_parameters']
-    # No exclusions: the builder reads every ``meta_parameters`` key, so all are override surface.
-    assert_overrides_match_spec(PwMetaParameters, protocol_meta)
-
-
-def test_pw_calculation_overrides_match_spec():
-    """The ``pw`` overrides keys must equal the ``pw`` input namespace ports (bar builder-set ones)."""
-    ports = PwBaseWorkChain.spec().inputs['pw'].keys()
-    # Ports the builder always sets from its own arguments, so an override would be ignored.
-    intentionally_untyped = {
-        'code',  # set unconditionally from the ``code`` argument
-        'structure',  # set unconditionally from the ``structure`` argument
-    }
-    assert_overrides_match_spec(PwCalculationOverrides, ports, intentionally_untyped=intentionally_untyped)
-
-
-def test_pw_base_overrides_match_spec():
-    """The ``PwBaseWorkChain`` overrides keys must equal spec ports plus builder-consumed keys."""
-    ports = PwBaseWorkChain.spec().inputs.keys()
-    # Protocol keys the builder pops directly (``inputs.pop(...)``) without exposing as input ports.
-    builder_consumed = {'meta_parameters', 'pseudo_family'}
-    # Nothing at this level is set from the builder's own arguments (``code``/``structure`` land in
-    # the nested ``pw`` namespace), so no port is excluded.
-    assert_overrides_match_spec(PwBaseOverrides, ports, builder_consumed=builder_consumed)
-
-
-def test_pw_bands_overrides_match_spec():
-    """The ``PwBandsWorkChain`` top-level overrides keys must equal its spec ports (bar builder-set)."""
-    ports = PwBandsWorkChain.spec().inputs.keys()
-    # Ports the builder always sets from its own arguments, so an override would be ignored.
-    intentionally_untyped = {
-        'structure',  # set unconditionally from the ``structure`` argument
-    }
-    assert_overrides_match_spec(PwBandsOverrides, ports, intentionally_untyped=intentionally_untyped)
-
-
-# Protocol keys the nested ``PwBaseWorkChain`` builder consumes directly (they are not input ports).
-# The ``scf``/``bands`` overrides are forwarded verbatim to ``PwBaseWorkChain.get_builder_from_protocol``.
-_BASE_BUILDER_CONSUMED = {'meta_parameters', 'pseudo_family'}
-
-
-def test_pw_bands_scf_overrides_match_spec():
-    """The ``scf`` overrides keys must equal the ``scf`` namespace ports (which exclude ``clean_workdir``)."""
-    ports = PwBandsWorkChain.spec().inputs['scf'].keys()
-    assert_overrides_match_spec(PwBandsScfOverrides, ports, builder_consumed=_BASE_BUILDER_CONSUMED)
-
-
-def test_pw_bands_scf_pw_overrides_match_spec():
-    """The ``scf.pw`` overrides keys must equal the ``scf.pw`` namespace ports (bar builder-set ones)."""
-    ports = PwBandsWorkChain.spec().inputs['scf']['pw'].keys()
-    # ``structure`` is already excluded from the ``scf`` namespace; ``code`` is set by the builder.
-    assert_overrides_match_spec(PwCalculationOverrides, ports, intentionally_untyped={'code'})
-
-
-def test_pw_bands_bands_overrides_match_spec():
-    """The ``bands`` overrides keys must equal the ``bands`` namespace ports (which exclude ``clean_workdir``)."""
-    ports = PwBandsWorkChain.spec().inputs['bands'].keys()
-    assert_overrides_match_spec(PwBandsBandsOverrides, ports, builder_consumed=_BASE_BUILDER_CONSUMED)
-
-
-def test_pw_bands_bands_pw_overrides_match_spec():
-    """The ``bands.pw`` overrides keys must equal the ``bands.pw`` namespace ports (bar builder-set ones).
-
-    ``PwBandsWorkChain`` excludes ``pw.parent_folder`` (and ``pw.structure``) from its ``bands``
-    namespace, so ``PwBandsCalculationOverrides`` must omit ``parent_folder`` where the general
-    ``PwCalculationOverrides`` keeps it.
-    """
-    ports = PwBandsWorkChain.spec().inputs['bands']['pw'].keys()
-    # ``structure``/``parent_folder`` are already excluded from the ``bands`` namespace; ``code`` is builder-set.
-    assert_overrides_match_spec(PwBandsCalculationOverrides, ports, intentionally_untyped={'code'})


### PR DESCRIPTION
This PR adds `TypedDict` definitions describing the nested `overrides` mapping accepted by `get_builder_from_protocol`, so that callers get editor autocompletion and static type-checking for what is otherwise an untyped, deeply-nested `dict`. This PR introduces the scheme for `PwBaseWorkChain` and `PwBandsWorkChain`; the remaining work chains can follow the same pattern in later PRs.

Partially addresses #1273

## Changes
A new module `src/aiida_quantumespresso/workflows/protocols/overrides.py` defines `total=False` `TypedDict`s that mirror the overrides tree.

The two `get_builder_from_protocol` signatures are annotated `overrides: PwBaseOverrides | None = None` and `overrides: PwBandsOverrides | None = None` respectively.

The `TypedDict`s carry no runtime behaviour — they are ordinary `dict`s at runtime and the builder logic is untouched. Existing `overrides={...}` call sites keep working exactly as before.

## Drift guards

Because these types duplicate information that already lives in each work chain's `spec()`, they can rot. `tests/workflows/protocols/test_overrides.py` asserts, for each `TypedDict`, that its keys are **equal** to the corresponding `spec().inputs` port names, **plus** a small, explicitly-declared set of "builder-consumed" keys — protocol keys such as `meta_parameters` and `pseudo_family` that `get_builder_from_protocol` reads directly (`inputs.pop(...)`) without exposing them as input ports — **minus** the few ports the builder always sets from its own `code`/`structure` arguments. Each nested namespace is checked against its own sub-spec: `pw`, the top-level `scf`/`bands`, and the `scf.pw`/`bands.pw` sub-namespaces.

Because `PwBandsWorkChain` excludes `clean_workdir` from `scf`/`bands` and `pw.parent_folder` from `bands`, those namespaces use narrowed `TypedDict`s rather than the full `PwBaseOverrides`, and the sub-spec guards lock that narrowing in.

The `pw.parameters` namelist keys are guarded only against a second hand-maintained copy — there is no authoritative in-repo list of every `pw.x` namelist — with the namelists QE dispatches by calculation type additionally checked against the plugin's `_automatic_namelists`. If a future spec change removes or renames a port, the matching test fails until the `TypedDict` is updated.

## Notes for maintainers

On the single-source-of-truth question raised in #1273 this implementation keeps things hand-written rather than generating types from the `spec` at runtime (which wouldn't give static checkers anything to see). Happy to revisit the generation approach if preferred.