### PR TITLE
🐛 `PdosWorkChain`: thread `settings` overrides to dos/projwfc

### DIFF
--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -383,9 +383,13 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         builder.dos.code = dos_code
         builder.dos.parameters = orm.Dict(inputs.get('dos', {}).get('parameters'))
         builder.dos.metadata = metadata_dos
+        if inputs.get('dos', {}).get('settings'):
+            builder.dos.settings = orm.Dict(inputs['dos']['settings'])
         builder.projwfc.code = projwfc_code
         builder.projwfc.parameters = orm.Dict(inputs.get('projwfc', {}).get('parameters'))
         builder.projwfc.metadata = metadata_projwfc
+        if inputs.get('projwfc', {}).get('settings'):
+            builder.projwfc.settings = orm.Dict(inputs['projwfc']['settings'])
 
         return builder
 

--- a/tests/workflows/protocols/test_pdos.py
+++ b/tests/workflows/protocols/test_pdos.py
@@ -90,3 +90,15 @@ def test_options(get_pdos_generator_inputs):
         builder.projwfc.metadata,
     ):
         assert subspace['options']['queue_name'] == queue_name, subspace
+
+
+def test_settings_overrides(get_pdos_generator_inputs):
+    """Test that ``settings`` overrides are threaded onto the ``dos`` and ``projwfc`` namespaces."""
+    overrides = {
+        'dos': {'settings': {'CMDLINE': ['-npool', '4']}},
+        'projwfc': {'settings': {'CMDLINE': ['-npool', '4']}},
+    }
+    builder = PdosWorkChain.get_builder_from_protocol(**get_pdos_generator_inputs, overrides=overrides)
+
+    assert builder.dos.settings.get_dict() == {'CMDLINE': ['-npool', '4']}
+    assert builder.projwfc.settings.get_dict() == {'CMDLINE': ['-npool', '4']}


### PR DESCRIPTION
## Problem
`PdosWorkChain.get_builder_from_protocol` never populated the `settings` of the `dos` and `projwfc` namespaces. As a result any `settings` override for those namespaces — for example `overrides={'projwfc': {'settings': {'CMDLINE': ['-npool', '4']}}}` — was silently dropped and never reached the builder, so it had no effect on the launched `DosCalculation` / `ProjwfcCalculation`.

## Changes
Both namespaces had the identical gap, since `DosCalculation` and `ProjwfcCalculation` both derive from `NamelistsCalculation`, which exposes the `settings` port. The fix sets `builder.dos.settings` and `builder.projwfc.settings` from the merged protocol inputs whenever a `settings` override is provided, matching the way the sibling `code`/`parameters`/`metadata` inputs are already threaded.

## Tests
Added `test_settings_overrides` to `tests/workflows/protocols/test_pdos.py`, which passes `settings` overrides for both the `dos` and `projwfc` namespaces and asserts they land on the builder. The test fails on the pre-fix code (the `settings` input is absent) and passes with the fix.