### PR TITLE
Adding efficient restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### 🐛 Bug fixes
+
+* `PwBaseWorkChain`: add `handle_electronic_convergence_stuck` to recover from `STOPPED_BY_MONITOR` failures in `relax` calculations by reducing `IONS.upscale`, and rattle the structure once in `handle_relax_recoverable_ionic_convergence_bfgs_history_error` for `relax` calculations with few symmetries
+
 ## v5.0.0
 
 > [!WARNING]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 
-### 🐛 Bug fixes
+### 👌 Improvements
 
 * `PwBaseWorkChain`: add `handle_electronic_convergence_stuck` to recover from `STOPPED_BY_MONITOR` failures in `relax` calculations by reducing `IONS.upscale`, and rattle the structure once in `handle_relax_recoverable_ionic_convergence_bfgs_history_error` for `relax` calculations with few symmetries
 

--- a/docs/source/topics/workflow_logic.md
+++ b/docs/source/topics/workflow_logic.md
@@ -66,7 +66,8 @@ This information is then used by the `PwRelaxWorkChain`, whose job is to remove 
   - `ERROR_IONIC_CYCLE_BFGS_HISTORY_AND_FINAL_SCF_FAILURE` (521)
 
 Handles failures in the BFGS ionic minimization where the history is reset twice consecutively.
-For `relax` calculations, switches to `damp` dynamics; for `vc-relax`, either reduces `trust_radius_min` by 90% (if above 1.0e-4) or switches to `damp`/`damp-w` dynamics.
+For `relax` calculations, if the output structure has few symmetries, the structure is rattled once (with a 0.01 Angstrom standard deviation) to escape from a possible hard local minimum, and a second occurrence of the same failure is considered unrecoverable.
+Otherwise, it switches to `damp` dynamics; for `vc-relax`, it either reduces `trust_radius_min` by 90% (if above 1.0e-4) or switches to `damp`/`damp-w` dynamics.
 All cases restart from the previous charge density using the output structure.
 
 ### Ionic convergence failures
@@ -117,6 +118,16 @@ Reduces `mixing_beta` by 20% and performs a full restart from the previous calcu
 
 Handles cases where electronic convergence was not reached but the input parameters indicate this is acceptable (e.g., `scf_must_converge = False` or `electron_maxstep = 0`).
 Marks the workchain as finished and returns the outputs with a warning exit code.
+
+### Electronic convergence stuck in relaxations
+
+- **Handler:** `handle_electronic_convergence_stuck`
+- **Exit codes handled:**
+  - `STOPPED_BY_MONITOR` (150)
+
+Handles cases where the electronic convergence is stuck during a `relax` calculation, i.e. when the algorithm in Quantum ESPRESSO tries to decrease the `conv_thr` during the ionic minimization to ensure that forces are small enough.
+Reduces the `IONS.upscale` parameter by 70% (with a minimum of 1) and performs a full restart from the last calculation.
+If `upscale` is already at its minimum of 1, or if the exit message does not correspond to the expected one, the failure is considered unrecoverable.
 
 
 ## `PwRelaxWorkChain`

--- a/docs/source/topics/workflow_logic.md
+++ b/docs/source/topics/workflow_logic.md
@@ -127,7 +127,8 @@ Marks the workchain as finished and returns the outputs with a warning exit code
 
 Handles cases where the electronic convergence is stuck during a `relax` calculation, i.e. when the algorithm in Quantum ESPRESSO tries to decrease the `conv_thr` during the ionic minimization to ensure that forces are small enough.
 Reduces the `IONS.upscale` parameter by 70% (with a minimum of 1) and performs a full restart from the last calculation.
-If `upscale` is already at its minimum of 1, or if the exit message does not correspond to the expected one, the failure is considered unrecoverable.
+If `upscale` is already at its minimum of 1, the failure is considered unrecoverable.
+Since the `STOPPED_BY_MONITOR` exit code is shared by all monitors, the handler identifies the relevant condition through the exit message: if the message does not match, the handler does not intervene and the failure is treated as unhandled by the work chain.
 
 
 ## `PwRelaxWorkChain`

--- a/src/aiida_quantumespresso/calculations/functions/rattle_structure.py
+++ b/src/aiida_quantumespresso/calculations/functions/rattle_structure.py
@@ -1,17 +1,22 @@
 """Calculation function to apply random displacements to the atomic positions of a structure."""
 
-from aiida import orm
+import numpy as np
 from aiida.engine import calcfunction
 
 
 @calcfunction
 def rattle_structure(structure, stdev):
-    """Return a copy of the structure with normally distributed random displacements applied to all positions.
+    """Return a clone of the structure with normally distributed random displacements applied to all positions.
+
+    The node is cloned rather than reconstructed, so any ``StructureData`` subclass (e.g.
+    ``HubbardStructureData``) keeps its type, kind names and additional attributes.
 
     :param structure: the ``StructureData`` instance to rattle.
     :param stdev: ``Float`` with the standard deviation of the displacements in Angstrom.
-    :returns: the rattled ``StructureData`` instance.
+    :returns: the rattled structure node.
     """
-    atoms = structure.get_ase()
-    atoms.rattle(stdev=stdev.value)
-    return orm.StructureData(ase=atoms)
+    rattled = structure.clone()
+    positions = np.array([site.position for site in structure.sites])
+    rng = np.random.RandomState(seed=42)  # same default seed as ``ase.Atoms.rattle``
+    rattled.reset_sites_positions((positions + rng.normal(scale=stdev.value, size=positions.shape)).tolist())
+    return rattled

--- a/src/aiida_quantumespresso/calculations/functions/rattle_structure.py
+++ b/src/aiida_quantumespresso/calculations/functions/rattle_structure.py
@@ -1,0 +1,17 @@
+"""Calculation function to apply random displacements to the atomic positions of a structure."""
+
+from aiida import orm
+from aiida.engine import calcfunction
+
+
+@calcfunction
+def rattle_structure(structure, stdev):
+    """Return a copy of the structure with normally distributed random displacements applied to all positions.
+
+    :param structure: the ``StructureData`` instance to rattle.
+    :param stdev: ``Float`` with the standard deviation of the displacements in Angstrom.
+    :returns: the rattled ``StructureData`` instance.
+    """
+    atoms = structure.get_ase()
+    atoms.rattle(stdev=stdev.value)
+    return orm.StructureData(ase=atoms)

--- a/src/aiida_quantumespresso/tools/monitors/accuracy_stuck.py
+++ b/src/aiida_quantumespresso/tools/monitors/accuracy_stuck.py
@@ -7,6 +7,11 @@ from aiida.transports import Transport
 
 from .utils import parse_accuracy_lines, is_stuck
 
+# Message prefix identifying this monitor as the cause of a `STOPPED_BY_MONITOR` exit code, since that exit code is
+# shared by all monitors. Error handlers (e.g. in `PwBaseWorkChain`) match on this prefix, as the full message
+# depends on the configurable `min_repeats`.
+ACCURACY_STUCK_MESSAGE_PREFIX = 'Job appears stuck: accuracy has not improved'
+
 
 def _fetch_output_content(node: CalcJobNode, transport: Transport) -> Optional[str]:
     """Fetch the output file of a running calculation and return its text content.
@@ -49,6 +54,6 @@ def monitor(node: CalcJobNode, transport: Transport, min_repeats: int = 5) -> Op
 
     nums = parse_accuracy_lines(content)
     if nums is not None and is_stuck(nums, min_repeats=min_repeats):
-        return f'Job appears stuck: accuracy has not improved in the last {min_repeats} occurrences.'
+        return f'{ACCURACY_STUCK_MESSAGE_PREFIX} in the last {min_repeats} occurrences.'
 
     return None

--- a/src/aiida_quantumespresso/utils/defaults/calculation/__init__.py
+++ b/src/aiida_quantumespresso/utils/defaults/calculation/__init__.py
@@ -23,5 +23,6 @@ pw = AttributeDict(
         'wf_collect': True,
         'trust_radius_min': 1.0e-3,
         'ion_dynamics': 'bfgs',
+        'upscale': 100,
     }
 )

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -1,4 +1,5 @@
 """Workchain to run a Quantum ESPRESSO pw.x calculation with automated error handling and restarts."""
+
 import warnings
 
 from aiida import orm
@@ -257,9 +258,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         if structure.pbc != (True, True, True):
             # 0D, 1D, or 2D
             if structure.pbc.count(True) == 2 and structure.pbc not in pbc_parameter_overrides:
-                raise ValueError(
-                    f'2D-periodic structures must be periodic in the x-y plane, got `{structure.pbc}`.'
-                )
+                raise ValueError(f'2D-periodic structures must be periodic in the x-y plane, got `{structure.pbc}`.')
             warnings.warn(
                 'This protocol was developed for fully periodic (i.e. 3D) systems. Use `overrides` to provide '
                 'any relevant keywords for handling aperiodicity, and proceed with caution.'
@@ -339,6 +338,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         """
         super().setup()
         self.ctx.inputs = AttributeDict(self.exposed_inputs(PwCalculation, 'pw'))
+        self.ctx.initial_parameters = AttributeDict(self.exposed_inputs(PwCalculation, 'pw'))
 
         self.ctx.inputs.parameters = self.ctx.inputs.parameters.get_dict()
         self.ctx.inputs.parameters.setdefault('CONTROL', {})
@@ -587,7 +587,41 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         return ProcessHandlerReport(True, self.exit_codes.ERROR_IONIC_CONVERGENCE_REACHED_EXCEPT_IN_FINAL_SCF)
 
     @process_handler(
-        priority=561,
+        priority=602,
+        exit_codes=[
+            PwCalculation.exit_codes.STOPPED_BY_MONITOR,
+        ],
+    )
+    def handle_electronic_convergence_stuck(self, calculation):
+        """Handle `STOPPED_BY_MONITOR` error.
+
+        This is needed when the scf convergence is stuck during a relax calculation, i.e. when the algorithm in
+        Quantum ESPRESSO tries to decrease the `conv_thr` during the ionic minimization, to ensure that forces are
+        small enough. To solve it, we restart by reducing the `IONS.upscale` parameter (by default, it is 100).
+        """
+        self.report(f'Handling {calculation.exit_status}<{calculation.exit_message}>')
+
+        if calculation.exit_message == 'Job appears stuck: accuracy has not improved in the last 5 occurrences.':
+            ions_namelist = self.ctx.inputs.parameters.get('IONS', {})
+            upscale = ions_namelist.get('upscale', 100)
+
+            if upscale > 1:
+                new_upscale = max(int(upscale * 0.3), 1)
+                ions_namelist['upscale'] = new_upscale
+                self.ctx.inputs.parameters['IONS'] = ions_namelist
+
+                action = f'reduced upscale from {upscale} to {new_upscale} and restarting from the last calculation'
+                self.set_restart_type(RestartType.FULL, calculation.outputs.remote_folder)
+            else:
+                return ProcessHandlerReport(True, self.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE)
+        else:
+            return ProcessHandlerReport(True, self.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE)
+
+        self.report_error_handled(calculation, action)
+        return ProcessHandlerReport(True)
+
+    @process_handler(
+        priority=601,
         exit_codes=[
             PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_FAILURE,
             PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_AND_FINAL_SCF_FAILURE,
@@ -596,16 +630,47 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
     def handle_relax_recoverable_ionic_convergence_bfgs_history_error(self, calculation):
         """Handle failure of the ionic minimization algorithm (BFGS).
 
-        When BFGS history fails, this can mean two things: the structure is close to the global minimum,
-        but the moves the algorithm wants to do are smaller than `trust_radius_min`, or the structure is
-        close to a local minimum (hard to detect). For the first, we restart with lowered trust_radius_min.
-        For the first case, one can lower the trust radius; for the second one, one can exploit a different
-        algorithm, e.g. `damp` (and `damp-w` for vc-relax).
+        When BFGS history fails, this can mean two things: the structure is close to the global minimum, but the
+        moves the algorithm wants to do are smaller than `trust_radius_min`, or the structure is close to a local
+        minimum (hard to detect). For the first case, one can lower the trust radius; for the second one, one can
+        exploit a different algorithm, e.g. `damp` (and `damp-w` for vc-relax). Additionally, in the case of a `relax`
+        calculation with few symmetries, the structure is rattled once (with a 0.01 Angstrom standard deviation) to
+        escape from a possible (hard) local minimum. A second occurrence of the same failure after the rattle is
+        considered unrecoverable.
         """
+        if not hasattr(self.ctx, 'rattled'):
+            self.ctx.rattled = False
+
         trust_radius_min = self.ctx.inputs.parameters['IONS'].get('trust_radius_min', qe_defaults.trust_radius_min)
         calculation_type = self.ctx.inputs.parameters['CONTROL'].get('calculation', 'relax')
 
         if calculation_type == 'relax':
+            symmetries = calculation.outputs.output_parameters.get_dict().get('symmetries', [])
+            if len(symmetries) < 5:
+                # Handle the case of a 'hard' local minimum by rattling the structure once, then a second
+                # occurrence is considered unrecoverable. Restore the original upscale value (i.e. from the
+                # initial input parameters, not from the possibly reduced value set by the handler dealing with
+                # the `electronic_convergence_stuck` error), since the structure is no longer close to the
+                # global minimum. Otherwise, the reduced upscale would make it impossible to reach convergence.
+                if not self.ctx.rattled:
+                    self.ctx.rattled = True
+                    atoms = calculation.outputs.output_structure.get_ase()
+                    atoms.rattle(stdev=0.01)
+                    self.ctx.inputs.structure = orm.StructureData(ase=atoms)
+                    self.ctx.inputs.parameters['IONS']['upscale'] = (
+                        self.ctx.initial_parameters['parameters'].get_dict().get('IONS', {}).get('upscale', 100)
+                    )
+                    action = (
+                        'bfgs history (ionic only) failure: rattling the structure once to escape from a '
+                        'possible (hard) local minimum.'
+                    )
+                else:
+                    return ProcessHandlerReport(True, self.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE)
+
+                self.set_restart_type(RestartType.FROM_CHARGE_DENSITY, calculation.outputs.remote_folder)
+                self.report_error_handled(calculation, action)
+                return ProcessHandlerReport(True)
+
             self.ctx.inputs.parameters['IONS']['ion_dynamics'] = 'damp'
             action = 'bfgs history (ionic only) failure: restarting with `damp` dynamics.'
 

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -17,7 +17,9 @@ from aiida.plugins import CalculationFactory, GroupFactory
 from aiida_quantumespresso.calculations.functions.create_kpoints_from_distance import (
     create_kpoints_from_distance,
 )
+from aiida_quantumespresso.calculations.functions.rattle_structure import rattle_structure
 from aiida_quantumespresso.common.types import ElectronicType, RestartType, SpinType
+from aiida_quantumespresso.tools.monitors.accuracy_stuck import ACCURACY_STUCK_MESSAGE_PREFIX
 from aiida_quantumespresso.utils.defaults.calculation import pw as qe_defaults
 
 from ..protocols.utils import ProtocolMixin
@@ -43,6 +45,9 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             'delta_factor_nbnd': 0.05,
             'delta_minimum_nbnd': 4,
             'delta_factor_trust_radius_min': 0.1,
+            'delta_factor_upscale': 0.3,
+            'rattle_stdev': 0.01,
+            'rattle_symmetry_threshold': 5,
         }
     )
 
@@ -338,7 +343,6 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         """
         super().setup()
         self.ctx.inputs = AttributeDict(self.exposed_inputs(PwCalculation, 'pw'))
-        self.ctx.initial_parameters = AttributeDict(self.exposed_inputs(PwCalculation, 'pw'))
 
         self.ctx.inputs.parameters = self.ctx.inputs.parameters.get_dict()
         self.ctx.inputs.parameters.setdefault('CONTROL', {})
@@ -599,24 +603,31 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         Quantum ESPRESSO tries to decrease the `conv_thr` during the ionic minimization, to ensure that forces are
         small enough. To solve it, we restart by reducing the `IONS.upscale` parameter (by default, it is 100).
         """
-        self.report(f'Handling {calculation.exit_status}<{calculation.exit_message}>')
+        if calculation.exit_message is None or not calculation.exit_message.startswith(ACCURACY_STUCK_MESSAGE_PREFIX):
+            # The exit code is shared by all monitors, so the message identifies the accuracy-stuck monitor. Any
+            # other message comes from an unrelated monitor: return `None` so the failure counts as unhandled.
+            return None
 
-        if calculation.exit_message == 'Job appears stuck: accuracy has not improved in the last 5 occurrences.':
+        calculation_type = self.ctx.inputs.parameters['CONTROL'].get('calculation', 'scf')
+
+        if calculation_type in ('relax', 'vc-relax'):
             ions_namelist = self.ctx.inputs.parameters.get('IONS', {})
-            upscale = ions_namelist.get('upscale', 100)
+            upscale = ions_namelist.get('upscale', qe_defaults.upscale)
 
-            if upscale > 1:
-                new_upscale = max(int(upscale * 0.3), 1)
-                ions_namelist['upscale'] = new_upscale
-                self.ctx.inputs.parameters['IONS'] = ions_namelist
-
-                action = f'reduced upscale from {upscale} to {new_upscale} and restarting from the last calculation'
-                self.set_restart_type(RestartType.FULL, calculation.outputs.remote_folder)
-            else:
+            if upscale <= 1:
+                self.report_error_handled(
+                    calculation, 'electronic convergence stuck but `upscale` already at its minimum, aborting...'
+                )
                 return ProcessHandlerReport(True, self.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE)
-        else:
-            return ProcessHandlerReport(True, self.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE)
 
+            new_upscale = max(int(upscale * self.defaults.delta_factor_upscale), 1)
+            ions_namelist['upscale'] = new_upscale
+            self.ctx.inputs.parameters['IONS'] = ions_namelist
+            action = f'reduced upscale from {upscale} to {new_upscale} and restarting from the last calculation'
+        else:
+            action = 'restarting from the last calculation'
+
+        self.set_restart_type(RestartType.FULL, calculation.outputs.remote_folder)
         self.report_error_handled(calculation, action)
         return ProcessHandlerReport(True)
 
@@ -645,8 +656,8 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         calculation_type = self.ctx.inputs.parameters['CONTROL'].get('calculation', 'relax')
 
         if calculation_type == 'relax':
-            symmetries = calculation.outputs.output_parameters.get_dict().get('symmetries', [])
-            if len(symmetries) < 5:
+            n_symmetries = calculation.outputs.output_parameters.get_dict().get('number_of_symmetries')
+            if n_symmetries is not None and n_symmetries < self.defaults.rattle_symmetry_threshold:
                 # Handle the case of a 'hard' local minimum by rattling the structure once, then a second
                 # occurrence is considered unrecoverable. Restore the original upscale value (i.e. from the
                 # initial input parameters, not from the possibly reduced value set by the handler dealing with
@@ -654,17 +665,20 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
                 # global minimum. Otherwise, the reduced upscale would make it impossible to reach convergence.
                 if not self.ctx.rattled:
                     self.ctx.rattled = True
-                    atoms = calculation.outputs.output_structure.get_ase()
-                    atoms.rattle(stdev=0.01)
-                    self.ctx.inputs.structure = orm.StructureData(ase=atoms)
+                    self.ctx.inputs.structure = rattle_structure(
+                        calculation.outputs.output_structure, orm.Float(self.defaults.rattle_stdev)
+                    )
                     self.ctx.inputs.parameters['IONS']['upscale'] = (
-                        self.ctx.initial_parameters['parameters'].get_dict().get('IONS', {}).get('upscale', 100)
+                        self.inputs.pw.parameters.get_dict().get('IONS', {}).get('upscale', qe_defaults.upscale)
                     )
                     action = (
                         'bfgs history (ionic only) failure: rattling the structure once to escape from a '
                         'possible (hard) local minimum.'
                     )
                 else:
+                    self.report_error_handled(
+                        calculation, 'bfgs history failure after the structure was already rattled once, aborting...'
+                    )
                     return ProcessHandlerReport(True, self.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE)
 
                 self.set_restart_type(RestartType.FROM_CHARGE_DENSITY, calculation.outputs.remote_folder)

--- a/tests/calculations/functions/test_rattle_structure.py
+++ b/tests/calculations/functions/test_rattle_structure.py
@@ -1,0 +1,32 @@
+"""Tests for the `rattle_structure` calculation function."""
+
+import numpy as np
+from aiida.orm import Float
+
+from aiida_quantumespresso.calculations.functions.rattle_structure import rattle_structure
+from aiida_quantumespresso.data.hubbard_structure import HubbardStructureData
+
+
+def test_rattle_structure(generate_structure):
+    """Test the `rattle_structure` calculation function with a plain ``StructureData``."""
+    structure = generate_structure('silicon')
+    rattled = rattle_structure(structure, Float(0.01))
+
+    assert rattled.cell == structure.cell
+    assert [site.kind_name for site in rattled.sites] == [site.kind_name for site in structure.sites]
+
+    positions = np.array([site.position for site in structure.sites])
+    rattled_positions = np.array([site.position for site in rattled.sites])
+    assert not np.allclose(positions, rattled_positions)
+    assert np.allclose(positions, rattled_positions, atol=0.1)
+
+
+def test_rattle_structure_hubbard(generate_structure):
+    """Test that rattling a ``HubbardStructureData`` preserves the node type and the Hubbard parameters."""
+    hubbard_structure = HubbardStructureData.from_structure(generate_structure('silicon'))
+    hubbard_structure.initialize_onsites_hubbard('Si', '3p', 5.0)
+
+    rattled = rattle_structure(hubbard_structure, Float(0.01))
+
+    assert isinstance(rattled, HubbardStructureData)
+    assert rattled.hubbard == hubbard_structure.hubbard

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -198,7 +198,7 @@ def test_handle_relax_recoverable_ionic_convergence_error(
     """Test `PwBaseWorkChain.handle_relax_recoverable_ionic_convergence_error`."""
     structure = generate_structure()
     remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
-    output_parameters = Dict({'symmetries': list(range(5))})
+    output_parameters = Dict({'number_of_symmetries': 5})
     process = generate_workchain_pw(
         pw_outputs={
             'output_structure': structure,
@@ -246,7 +246,7 @@ def test_handle_relax_recoverable_ionic_convergence_bfgs_history_error(
     """Test `PwBaseWorkChain.handle_relax_recoverable_ionic_convergence_bfgs_history_error`."""
     structure = generate_structure()
     remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
-    output_parameters = Dict({'symmetries': list(range(n_symmetries))})
+    output_parameters = Dict({'number_of_symmetries': n_symmetries})
     process = generate_workchain_pw(
         pw_outputs={
             'output_structure': structure,
@@ -265,7 +265,7 @@ def test_handle_relax_recoverable_ionic_convergence_bfgs_history_error(
     assert result.do_break
     assert result.exit_code.status == 0
 
-    if n_symmetries < 5:
+    if n_symmetries < PwBaseWorkChain.defaults.rattle_symmetry_threshold:
         # Few symmetries: the structure is rattled once and the original upscale is restored
         assert process.ctx.inputs.parameters['IONS']['ion_dynamics'] == 'bfgs'
         assert process.ctx.inputs.parameters['CONTROL']['restart_mode'] == 'from_scratch'
@@ -302,6 +302,66 @@ def test_handle_relax_recoverable_ionic_convergence_bfgs_history_error(
     assert result.exit_code.status == 0
     assert process.ctx.inputs.parameters['IONS']['ion_dynamics'] == 'damp'
     assert process.ctx.inputs.parameters['CELL']['cell_dynamics'] == 'damp-w'
+
+
+def test_handle_relax_recoverable_ionic_convergence_bfgs_history_error_after_rattle(
+    generate_workchain_pw,
+    generate_structure,
+    generate_remote_data,
+    fixture_localhost,
+):
+    """Test that a BFGS history failure with enough symmetries still switches to `damp` after a previous rattle."""
+    structure = generate_structure()
+    remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
+    output_parameters = Dict({'number_of_symmetries': PwBaseWorkChain.defaults.rattle_symmetry_threshold})
+    process = generate_workchain_pw(
+        pw_outputs={
+            'output_structure': structure,
+            'output_parameters': output_parameters,
+            'remote_folder': remote_data,
+        },
+        exit_code=PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_FAILURE,
+    )
+    process.setup()
+    process.ctx.rattled = True
+
+    process.ctx.inputs.parameters['CONTROL']['calculation'] = 'relax'
+    process.ctx.inputs.parameters.setdefault('IONS', {})['ion_dynamics'] = 'bfgs'
+    result = process.handle_relax_recoverable_ionic_convergence_bfgs_history_error(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert result.exit_code.status == 0
+    assert process.ctx.inputs.parameters['IONS']['ion_dynamics'] == 'damp'
+
+
+def test_handle_relax_recoverable_ionic_convergence_bfgs_history_error_no_symmetry_info(
+    generate_workchain_pw,
+    generate_structure,
+    generate_remote_data,
+    fixture_localhost,
+):
+    """Test that a BFGS history failure without symmetry information switches to `damp` instead of rattling."""
+    structure = generate_structure()
+    remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
+    output_parameters = Dict({})
+    process = generate_workchain_pw(
+        pw_outputs={
+            'output_structure': structure,
+            'output_parameters': output_parameters,
+            'remote_folder': remote_data,
+        },
+        exit_code=PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_FAILURE,
+    )
+    process.setup()
+
+    process.ctx.inputs.parameters['CONTROL']['calculation'] = 'relax'
+    process.ctx.inputs.parameters.setdefault('IONS', {})['ion_dynamics'] = 'bfgs'
+    result = process.handle_relax_recoverable_ionic_convergence_bfgs_history_error(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert result.exit_code.status == 0
+    assert process.ctx.inputs.parameters['IONS']['ion_dynamics'] == 'damp'
+    assert not process.ctx.rattled
 
 
 @pytest.mark.parametrize(
@@ -342,22 +402,40 @@ def test_handle_electronic_convergence_stuck(
     assert process.ctx.inputs.parent_folder == remote_data
 
 
-@pytest.mark.parametrize(
-    ('upscale', 'exit_message'),
-    [
-        (1, 'Job appears stuck: accuracy has not improved in the last 5 occurrences.'),
-        (100, 'Some other error message.'),
-        (100, None),
-    ],
-)
+def test_handle_electronic_convergence_stuck_scf(
+    generate_workchain_pw,
+    fixture_localhost,
+    generate_remote_data,
+):
+    """Test `PwBaseWorkChain.handle_electronic_convergence_stuck` for a non-ionic calculation."""
+    remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
+
+    process = generate_workchain_pw(
+        exit_code=PwCalculation.exit_codes.STOPPED_BY_MONITOR,
+        pw_outputs={'remote_folder': remote_data},
+    )
+    process.setup()
+
+    process.ctx.inputs.parameters['CONTROL']['calculation'] = 'scf'
+    calculation = process.ctx.children[-1]
+    # Use a non-default `min_repeats` to verify the handler matches the message prefix, not the exact message
+    calculation.set_exit_message('Job appears stuck: accuracy has not improved in the last 10 occurrences.')
+
+    result = process.handle_electronic_convergence_stuck(calculation)
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert result.exit_code.status == 0
+    assert process.ctx.inputs.parameters['CONTROL']['restart_mode'] == 'restart'
+    assert process.ctx.inputs.parent_folder == remote_data
+    assert 'IONS' not in process.ctx.inputs.parameters
+
+
 def test_handle_electronic_convergence_stuck_unrecoverable(
     generate_workchain_pw,
     fixture_localhost,
     generate_remote_data,
-    upscale,
-    exit_message,
 ):
-    """Test that `PwBaseWorkChain.handle_electronic_convergence_stuck` aborts when unrecoverable."""
+    """Test that `PwBaseWorkChain.handle_electronic_convergence_stuck` aborts when `upscale` is exhausted."""
     remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
 
     process = generate_workchain_pw(
@@ -367,15 +445,41 @@ def test_handle_electronic_convergence_stuck_unrecoverable(
     process.setup()
 
     process.ctx.inputs.parameters['CONTROL']['calculation'] = 'relax'
-    process.ctx.inputs.parameters.setdefault('IONS', {})['upscale'] = upscale
+    process.ctx.inputs.parameters.setdefault('IONS', {})['upscale'] = 1
     calculation = process.ctx.children[-1]
-    if exit_message is not None:
-        calculation.set_exit_message(exit_message)
+    calculation.set_exit_message('Job appears stuck: accuracy has not improved in the last 5 occurrences.')
 
     result = process.handle_electronic_convergence_stuck(calculation)
     assert isinstance(result, ProcessHandlerReport)
     assert result.do_break
     assert result.exit_code == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
+
+
+@pytest.mark.parametrize('exit_message', ['Some other error message.', None])
+def test_handle_electronic_convergence_stuck_unrelated_monitor(
+    generate_workchain_pw,
+    fixture_localhost,
+    generate_remote_data,
+    exit_message,
+):
+    """Test that `PwBaseWorkChain.handle_electronic_convergence_stuck` declines unrelated monitor messages."""
+    remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
+
+    process = generate_workchain_pw(
+        exit_code=PwCalculation.exit_codes.STOPPED_BY_MONITOR,
+        pw_outputs={'remote_folder': remote_data},
+    )
+    process.setup()
+
+    process.ctx.inputs.parameters['CONTROL']['calculation'] = 'relax'
+    calculation = process.ctx.children[-1]
+    if exit_message is not None:
+        calculation.set_exit_message(exit_message)
+
+    result = process.handle_electronic_convergence_stuck(calculation)
+    assert result is None
+    assert 'upscale' not in process.ctx.inputs.parameters.get('IONS', {})
+    assert 'parent_folder' not in process.ctx.inputs
 
 
 def test_handle_vcrelax_recoverable_fft_significant_volume_contraction_error(generate_workchain_pw, generate_structure):

--- a/tests/workflows/pw/test_base.py
+++ b/tests/workflows/pw/test_base.py
@@ -198,8 +198,13 @@ def test_handle_relax_recoverable_ionic_convergence_error(
     """Test `PwBaseWorkChain.handle_relax_recoverable_ionic_convergence_error`."""
     structure = generate_structure()
     remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
+    output_parameters = Dict({'symmetries': list(range(5))})
     process = generate_workchain_pw(
-        pw_outputs={'output_structure': structure, 'remote_folder': remote_data},
+        pw_outputs={
+            'output_structure': structure,
+            'output_parameters': output_parameters,
+            'remote_folder': remote_data,
+        },
         exit_code=exit_code,
     )
     process.setup()
@@ -223,30 +228,60 @@ def test_handle_relax_recoverable_ionic_convergence_error(
         PwCalculation.exit_codes.ERROR_IONIC_CYCLE_BFGS_HISTORY_AND_FINAL_SCF_FAILURE,
     ],
 )
+@pytest.mark.parametrize(
+    'n_symmetries',
+    [
+        0,
+        5,
+    ],
+)
 def test_handle_relax_recoverable_ionic_convergence_bfgs_history_error(
     generate_workchain_pw,
     generate_structure,
     generate_remote_data,
     fixture_localhost,
     exit_code,
+    n_symmetries,
 ):
     """Test `PwBaseWorkChain.handle_relax_recoverable_ionic_convergence_bfgs_history_error`."""
     structure = generate_structure()
     remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
+    output_parameters = Dict({'symmetries': list(range(n_symmetries))})
     process = generate_workchain_pw(
-        pw_outputs={'output_structure': structure, 'remote_folder': remote_data},
+        pw_outputs={
+            'output_structure': structure,
+            'output_parameters': output_parameters,
+            'remote_folder': remote_data,
+        },
         exit_code=exit_code,
     )
     process.setup()
 
-    # For `relax`, switch to `damp`
+    # For `relax`, switch to `damp` if there are many symmetries, rattle the structure once otherwise
     process.ctx.inputs.parameters['CONTROL']['calculation'] = 'relax'
     process.ctx.inputs.parameters.setdefault('IONS', {})['ion_dynamics'] = 'bfgs'
     result = process.handle_relax_recoverable_ionic_convergence_bfgs_history_error(process.ctx.children[-1])
     assert isinstance(result, ProcessHandlerReport)
     assert result.do_break
     assert result.exit_code.status == 0
-    assert process.ctx.inputs.parameters['IONS']['ion_dynamics'] == 'damp'
+
+    if n_symmetries < 5:
+        # Few symmetries: the structure is rattled once and the original upscale is restored
+        assert process.ctx.inputs.parameters['IONS']['ion_dynamics'] == 'bfgs'
+        assert process.ctx.inputs.parameters['CONTROL']['restart_mode'] == 'from_scratch'
+        assert process.ctx.inputs.parameters['ELECTRONS']['startingpot'] == 'file'
+        assert process.ctx.inputs.parameters['IONS']['upscale'] == 100
+        assert process.ctx.rattled
+        assert (
+            process.ctx.inputs.structure.get_ase().get_positions().tolist()
+            != structure.get_ase().get_positions().tolist()
+        )
+
+        # A second occurrence of the same failure is unrecoverable
+        result = process.handle_relax_recoverable_ionic_convergence_bfgs_history_error(process.ctx.children[-1])
+        assert result.exit_code == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
+    else:
+        assert process.ctx.inputs.parameters['IONS']['ion_dynamics'] == 'damp'
 
     # For `vc-relax`, try changing first the `trust_min_radius`
     process.ctx.inputs.parameters['CONTROL']['calculation'] = 'vc-relax'
@@ -267,6 +302,80 @@ def test_handle_relax_recoverable_ionic_convergence_bfgs_history_error(
     assert result.exit_code.status == 0
     assert process.ctx.inputs.parameters['IONS']['ion_dynamics'] == 'damp'
     assert process.ctx.inputs.parameters['CELL']['cell_dynamics'] == 'damp-w'
+
+
+@pytest.mark.parametrize(
+    ('upscale', 'expected'),
+    [
+        (100, 30),
+        (5, 1),
+        (2, 1),
+    ],
+)
+def test_handle_electronic_convergence_stuck(
+    generate_workchain_pw,
+    fixture_localhost,
+    generate_remote_data,
+    upscale,
+    expected,
+):
+    """Test `PwBaseWorkChain.handle_electronic_convergence_stuck`."""
+    remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
+
+    process = generate_workchain_pw(
+        exit_code=PwCalculation.exit_codes.STOPPED_BY_MONITOR,
+        pw_outputs={'remote_folder': remote_data},
+    )
+    process.setup()
+
+    process.ctx.inputs.parameters['CONTROL']['calculation'] = 'relax'
+    process.ctx.inputs.parameters.setdefault('IONS', {})['upscale'] = upscale
+    calculation = process.ctx.children[-1]
+    calculation.set_exit_message('Job appears stuck: accuracy has not improved in the last 5 occurrences.')
+
+    result = process.handle_electronic_convergence_stuck(calculation)
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert result.exit_code.status == 0
+    assert process.ctx.inputs.parameters['IONS']['upscale'] == expected
+    assert process.ctx.inputs.parameters['CONTROL']['restart_mode'] == 'restart'
+    assert process.ctx.inputs.parent_folder == remote_data
+
+
+@pytest.mark.parametrize(
+    ('upscale', 'exit_message'),
+    [
+        (1, 'Job appears stuck: accuracy has not improved in the last 5 occurrences.'),
+        (100, 'Some other error message.'),
+        (100, None),
+    ],
+)
+def test_handle_electronic_convergence_stuck_unrecoverable(
+    generate_workchain_pw,
+    fixture_localhost,
+    generate_remote_data,
+    upscale,
+    exit_message,
+):
+    """Test that `PwBaseWorkChain.handle_electronic_convergence_stuck` aborts when unrecoverable."""
+    remote_data = generate_remote_data(computer=fixture_localhost, remote_path='/path/to/remote')
+
+    process = generate_workchain_pw(
+        exit_code=PwCalculation.exit_codes.STOPPED_BY_MONITOR,
+        pw_outputs={'remote_folder': remote_data},
+    )
+    process.setup()
+
+    process.ctx.inputs.parameters['CONTROL']['calculation'] = 'relax'
+    process.ctx.inputs.parameters.setdefault('IONS', {})['upscale'] = upscale
+    calculation = process.ctx.children[-1]
+    if exit_message is not None:
+        calculation.set_exit_message(exit_message)
+
+    result = process.handle_electronic_convergence_stuck(calculation)
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert result.exit_code == PwBaseWorkChain.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
 
 
 def test_handle_vcrelax_recoverable_fft_significant_volume_contraction_error(generate_workchain_pw, generate_structure):


### PR DESCRIPTION
Ports the two error-handling improvements from aiida-qe-restart into PwBaseWorkChain, so both it and PwRelaxWorkChain benefit.

New handle_electronic_convergence_stuck (priority 602, STOPPED_BY_MONITOR): on stuck accuracy, reduce IONS.upscale by 70% (min 1) and restart from the last calculation; otherwise unrecoverable.
handle_relax_recoverable_ionic_convergence_bfgs_history_error (561 → 601): for relax with <5 symmetries, rattle the structure once (0.01 Å) to escape hard local minima and restore the original upscale; a second occurrence is unrecoverable. vc-relax unchanged.
Tests updated/added for both handlers.

Note: the accuracy_stuck monitor tooling is intentionally out of scope (separate PR on origin/monitor).