### PR TITLE
🐛 Protocols: fix spurious warning for dynamic namespace overrides

### DIFF
--- a/src/aiida_quantumespresso/workflows/protocols/utils.py
+++ b/src/aiida_quantumespresso/workflows/protocols/utils.py
@@ -145,12 +145,28 @@ class ProtocolMixin:
         except (IndexError, TypeError):
             pass
 
+        # Sentinel key marking whether a namespace-dict below accepts arbitrary keys beyond its declared
+        # children (e.g. the dynamic ``monitors`` namespace). An `object()` is used rather than a string
+        # so it can never collide with an actual port or override name.
+        dynamic_marker = object()
+
         def port_namespace_to_dict(namespace: PortNamespace):
-            """Recursively convert a PortNamespace into a nested dict structure."""
-            return {
+            """Recursively convert a PortNamespace into a nested dict structure.
+
+            Each resulting dict carries a `dynamic_marker` entry recording whether the namespace is
+            genuinely open-ended (dynamic with no statically declared children, e.g. ``monitors`` or
+            ``pseudos``), so `recursive_key_check` can skip validating keys nested under it. Many
+            namespaces (e.g. `pw`, from ``expose_inputs``) are also `dynamic` for unrelated internal
+            reasons despite declaring a full, fixed set of children, so `dynamic` alone is not a
+            reliable signal: only an *empty* dynamic namespace unambiguously means "arbitrary keys are
+            expected here".
+            """
+            mapping = {
                 key: port_namespace_to_dict(port) if isinstance(port, PortNamespace) else None
                 for key, port in namespace.items()
             }
+            mapping[dynamic_marker] = namespace.dynamic and not mapping
+            return mapping
 
         def recursive_key_check(inputs_mapping: dict, overrides: dict, path=''):
             """Recursively check that all the provided keys in the `overrides` are in the `inputs_mapping`."""
@@ -158,7 +174,8 @@ class ProtocolMixin:
             for key, value in overrides.items():
                 full_key = f'{path}.{key}' if path else key
                 if key not in inputs_mapping:
-                    warnings.warn(f'Found unrecognised key in overrides: {full_key}')
+                    if not inputs_mapping.get(dynamic_marker, False):
+                        warnings.warn(f'Found unrecognised key in overrides: {full_key}')
                     continue
                 if isinstance(value, dict) and isinstance(inputs_mapping.get(key), dict):
                     recursive_key_check(inputs_mapping[key], value, full_key)

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -1,6 +1,6 @@
 """Tests for the ``PwBaseWorkChain.get_builder_from_protocol`` method."""
 
-from contextlib import nullcontext
+import warnings
 
 import pytest
 from aiida.engine import ProcessBuilder
@@ -304,9 +304,12 @@ def test_parallelization_overrides(fixture_code, generate_structure):
 def test_overrides_key_check(fixture_code, generate_structure, overrides, warning):
     """Test that the `get_builder_from_protocol()` method warns for erroneous keys in the `overrides`."""
 
-    context = pytest.warns(UserWarning) if warning else nullcontext()
+    context = pytest.warns(UserWarning) if warning else warnings.catch_warnings()
 
     with context:
+        if not warning:
+            warnings.simplefilter('error', UserWarning)
+
         PwBaseWorkChain.get_builder_from_protocol(
             fixture_code('quantumespresso.pw'),
             generate_structure('silicon'),

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -288,9 +288,14 @@ def test_parallelization_overrides(fixture_code, generate_structure):
         # CORRECT overrides for `Dict` node with incorrect keys
         # The key check should _not_ validate the inputs, that is the job of the port validator
         ({'pw': {'parameters': {'NON-EXISTENT': {'param': 1}}}}, None),
+        # CORRECT overrides for a key in a dynamic namespace with no declared children (`monitors`):
+        # its keys cannot be statically enumerated, so any key should be accepted. `pseudos` is the same
+        # shape (dynamic, no declared children) and is therefore covered by this same code path.
+        ({'pw': {'monitors': {'monitor1': {'entry_point': 'quantumespresso.accuracy_stuck'}}}}, None),
         # WRONG overrides with typo
         ({'clean_wokdir': True}, UserWarning),
-        # WRONG overrides with process input at incorrect level
+        # WRONG overrides with process input at incorrect level: `pw` is also a dynamic namespace, but
+        # (unlike `monitors`) has declared children, so an undeclared key here must still warn
         ({'pw': {'options': {}}}, UserWarning),
         # WRONG overrides with protocol input at incorrect level
         ({'pw': {'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'}}, UserWarning),


### PR DESCRIPTION
The validation of overrides emits warnings for dynamic namespaces with undeclared children, such as `monitors` or `pseudos` in case of the `PwBaseWorkChain`.

This PR fixes this behavior but still emits warnings for dynamic namespaces with declared children.

Script to reproduce the issue (on main one will still see the warnings but this branch should fix it):

```python

from aiida import orm
from aiida_quantumespresso.workflows.pw.base import PwBaseWorkChain

pseudo_fam = orm.load_group('SSSP/1.3/PBEsol/efficiency')

code = orm.load_code('YOUR CODE')

structure = orm.StructureData(cell=[[2.7, 2.7, 0], [0, 2.7, 2.7], [2.7, 0, 2.7]])
structure.append_atom(position=(0, 0, 0), symbols='Si')
structure.append_atom(position=(1.35, 1.35, 1.35), symbols='Si')

pseudos = pseudo_fam.get_pseudos(structure=structure)

overrides = {
    'pw': {
        'monitors': {'monitor1': {'entry_point': 'quantumespresso.accuracy_stuck'}},
        'pseudos': pseudos,
        'parameters': {
            'SYSTEM': {
                'ecutwfc': 30,
                'ecutrho': 240,
            },
        }
    },
}

builder = PwBaseWorkChain.get_builder_from_protocol(code, structure, overrides=overrides)

```

