### PR TITLE
🐛 Protocols: fix silently dropped `overrides` in `get_builder_from_protocol`

### DIFF
--- a/src/aiida_quantumespresso/cli/workflows/pw/bands.py
+++ b/src/aiida_quantumespresso/cli/workflows/pw/bands.py
@@ -84,7 +84,7 @@ def launch_workflow(
             'hubbard_file': hubbard_file,
         },
     }
-    overrides = {'relax': base_overrides, 'scf': base_overrides, 'bands': base_overrides}
+    overrides = {'scf': base_overrides, 'bands': base_overrides}
     builder = PwBandsWorkChain.get_builder_from_protocol(code, structure, overrides=overrides)
 
     launch.launch_process(builder, daemon)

--- a/src/aiida_quantumespresso/cli/workflows/pw/bands.py
+++ b/src/aiida_quantumespresso/cli/workflows/pw/bands.py
@@ -75,7 +75,6 @@ def launch_workflow(
         raise click.BadParameter(str(exception))
 
     base_overrides = {
-        'clean_workdir': clean_workdir,
         'pseudo_family': pseudo_family.label,
         'kpoints_distance': kpoints_distance,
         'pw': {
@@ -84,7 +83,8 @@ def launch_workflow(
             'hubbard_file': hubbard_file,
         },
     }
-    overrides = {'scf': base_overrides, 'bands': base_overrides}
+    # `clean_workdir` is excluded from the exposed `scf`/`bands` namespaces, so it has to be set at the root.
+    overrides = {'clean_workdir': clean_workdir, 'scf': base_overrides, 'bands': base_overrides}
     builder = PwBandsWorkChain.get_builder_from_protocol(code, structure, overrides=overrides)
 
     launch.launch_process(builder, daemon)

--- a/src/aiida_quantumespresso/cli/workflows/pw/relax.py
+++ b/src/aiida_quantumespresso/cli/workflows/pw/relax.py
@@ -83,7 +83,6 @@ def launch_workflow(
         raise click.BadParameter(str(exception)) from exception
 
     base_overrides = {
-        'clean_workdir': clean_workdir,
         'pseudo_family': pseudo_family.label,
         'pw': {
             'parameters': parameters,
@@ -91,7 +90,10 @@ def launch_workflow(
             'hubbard_file': hubbard_file,
         },
     }
+    # `clean_workdir` is excluded from the exposed `base_relax`/`base_init_relax` namespaces, so it has to be set at
+    # the root.
     overrides = {
+        'clean_workdir': clean_workdir,
         'base_init_relax': base_overrides,
         'base_relax': base_overrides,
     }

--- a/src/aiida_quantumespresso/workflows/neb/base.py
+++ b/src/aiida_quantumespresso/workflows/neb/base.py
@@ -130,19 +130,28 @@ class NebBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             options=options,
             **kargs,
         )
-        builder = cls.get_builder()
-        builder.neb.code = code
-        builder.neb.images = images
-        builder.neb.pw.pseudos = pw_base.pw.pseudos
-        builder.neb.pw.parameters = pw_base.pw.parameters
-        builder.neb.metadata.options = pw_base.pw.metadata.options
+        inputs = {
+            'neb': {
+                'code': code,
+                'images': images,
+                'pw': {
+                    'pseudos': pw_base.pw.pseudos,
+                    'parameters': pw_base.pw.parameters,
+                },
+                'metadata': {'options': pw_base.pw.metadata.options},
+            },
+            'kpoints_force_parity': pw_base['kpoints_force_parity'],
+            'max_iterations': pw_base['max_iterations'],
+        }
 
         if 'kpoints' in pw_base:
-            builder.kpoints = pw_base['kpoints']
+            inputs['kpoints'] = pw_base['kpoints']
         else:
-            builder.kpoints_distance = orm.Float(pw_base['kpoints_distance'])
-        builder.kpoints_force_parity = orm.Bool(pw_base['kpoints_force_parity'])
-        builder.max_iterations = orm.Int(pw_base['max_iterations'])
+            inputs['kpoints_distance'] = pw_base['kpoints_distance']
+
+        builder = cls.get_builder()
+        builder._update(inputs)
+
         return builder
 
     def setup(self):

--- a/src/aiida_quantumespresso/workflows/neb/base.py
+++ b/src/aiida_quantumespresso/workflows/neb/base.py
@@ -150,7 +150,7 @@ class NebBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             inputs['kpoints_distance'] = pw_base['kpoints_distance']
 
         builder = cls.get_builder()
-        builder._update(inputs)
+        builder._merge(inputs)
 
         return builder
 

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -363,8 +363,11 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         nscf['pw']['parameters']['SYSTEM'].pop('degauss', None)
         nscf.pop('clean_workdir', None)
 
-        metadata_dos = inputs.get('dos', {}).get('metadata', {'options': {}})
-        metadata_projwfc = inputs.get('projwfc', {}).get('metadata', {'options': {}})
+        dos_inputs = inputs.setdefault('dos', {})
+        projwfc_inputs = inputs.setdefault('projwfc', {})
+
+        metadata_dos = dos_inputs.setdefault('metadata', {'options': {}})
+        metadata_projwfc = projwfc_inputs.setdefault('metadata', {'options': {}})
 
         if options:
             metadata_dos['options'] = recursive_merge(metadata_dos['options'], options)
@@ -375,21 +378,20 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
             metadata_projwfc['options'], projwfc_code.computer.scheduler_type
         )
 
+        dos_inputs['code'] = dos_code
+        dos_inputs['metadata'] = metadata_dos
+        projwfc_inputs['code'] = projwfc_code
+        projwfc_inputs['metadata'] = metadata_projwfc
+
+        # `scf`/`nscf` are already fully constructed builders, so assign them directly rather than merging as dicts.
+        inputs.pop('scf', None)
+        inputs.pop('nscf', None)
+
         builder = cls.get_builder()
         builder.structure = structure
-        builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
         builder.scf = scf
         builder.nscf = nscf
-        builder.dos.code = dos_code
-        builder.dos.parameters = orm.Dict(inputs.get('dos', {}).get('parameters'))
-        builder.dos.metadata = metadata_dos
-        if inputs.get('dos', {}).get('settings'):
-            builder.dos.settings = orm.Dict(inputs['dos']['settings'])
-        builder.projwfc.code = projwfc_code
-        builder.projwfc.parameters = orm.Dict(inputs.get('projwfc', {}).get('parameters'))
-        builder.projwfc.metadata = metadata_projwfc
-        if inputs.get('projwfc', {}).get('settings'):
-            builder.projwfc.settings = orm.Dict(inputs['projwfc']['settings'])
+        builder._update(inputs)
 
         return builder
 

--- a/src/aiida_quantumespresso/workflows/pdos.py
+++ b/src/aiida_quantumespresso/workflows/pdos.py
@@ -391,7 +391,7 @@ class PdosWorkChain(ProtocolMixin, WorkChain):
         builder.structure = structure
         builder.scf = scf
         builder.nscf = nscf
-        builder._update(inputs)
+        builder._merge(inputs)
 
         return builder
 

--- a/src/aiida_quantumespresso/workflows/ph/base.py
+++ b/src/aiida_quantumespresso/workflows/ph/base.py
@@ -162,26 +162,21 @@ class PhBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
 
         metadata['options'] = cls.set_default_resources(metadata['options'], code.computer.scheduler_type)
 
-        builder = cls.get_builder()
-        builder.ph['code'] = code
+        inputs['ph']['code'] = code
         if parent_folder is not None:
-            builder.ph['parent_folder'] = parent_folder
-        builder.ph['parameters'] = orm.Dict(inputs['ph']['parameters'])
-        builder.ph['metadata'] = metadata
-        if 'settings' in inputs['ph']:
-            builder.ph['settings'] = orm.Dict(inputs['ph']['settings'])
-        builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
+            inputs['ph']['parent_folder'] = parent_folder
+        inputs['ph']['metadata'] = metadata
 
         if 'qpoints' in inputs:
-            qpoints_mesh = inputs['qpoints']
+            qpoints_mesh = inputs.pop('qpoints')
             qpoints = orm.KpointsData()
             qpoints.set_kpoints_mesh(qpoints_mesh)
-            builder.qpoints = qpoints
-        else:
-            builder.qpoints_distance = orm.Float(inputs['qpoints_distance'])
-            builder.qpoints_force_parity = orm.Bool(inputs['qpoints_force_parity'])
+            inputs['qpoints'] = qpoints
+            inputs.pop('qpoints_distance', None)
+            inputs.pop('qpoints_force_parity', None)
 
-        builder.max_iterations = orm.Int(inputs['max_iterations'])
+        builder = cls.get_builder()
+        builder._update(inputs)
 
         return builder
 

--- a/src/aiida_quantumespresso/workflows/ph/base.py
+++ b/src/aiida_quantumespresso/workflows/ph/base.py
@@ -176,7 +176,7 @@ class PhBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             inputs.pop('qpoints_force_parity', None)
 
         builder = cls.get_builder()
-        builder._update(inputs)
+        builder._merge(inputs)
 
         return builder
 

--- a/src/aiida_quantumespresso/workflows/protocols/utils.py
+++ b/src/aiida_quantumespresso/workflows/protocols/utils.py
@@ -1,14 +1,11 @@
 """Utilities to manipulate the workflow input protocols."""
 
 import copy
-import inspect
 import pathlib
-import warnings
 from typing import Optional, Union
 
 import yaml
 from aiida.orm import StructureData
-from aiida.engine import WorkChain
 from plumpy import PortNamespace
 
 from aiida_quantumespresso.common.types import SpinType
@@ -128,40 +125,45 @@ class ProtocolMixin:
     def _validate_override_keys(cls, overrides):
         """Validate that override keys match either the process spec or protocol inputs.
 
-        Recursively checks the `overrides` dictionary against the input port namespace of the work chain, extended
-        with protocol inputs, and emits warnings for any unrecognised keys.
+        Recursively checks the `overrides` dictionary against the input port namespace of the `WorkChain`, extended
+        with protocol inputs, and raises for any unrecognised keys.
+
+        :raises ValueError: if the `overrides` contain a key that corresponds neither to an input port nor to a
+            protocol input of the `WorkChain`.
         """
-        # Avoid duplicate warnings when calling `get_builder_from_protocol` within another `get_builder_from_protocol`
-        try:
-            caller_frame = inspect.stack(context=0)[3]  # Check the frame where `get_builder_from_protocol` is called
-            caller_class = caller_frame.frame.f_locals.get('cls')
-            # Skip the validation when
-            if (
-                caller_frame.function == 'get_builder_from_protocol'  # It is a parent `get_builder_from_protocol` call
-                and caller_class not in (None, cls)  # The caller is a different class
-                and issubclass(caller_class, WorkChain)  # The caller is a WorkChain
-            ):
-                return
-        except (IndexError, TypeError):
-            pass
+
+        def has_undeclared_keys(port) -> bool:
+            """Return whether the keys of the `port` are not declared by the spec, but provided by the caller.
+
+            This is the case for a dynamic namespace that declares no ports of its own, such as `pw.pseudos`, whose
+            keys are the kind names of the structure, or `pw.monitors`. Note that a dynamic namespace that _does_
+            declare ports, such as `pw`, is still validated against those, since a key that is not among them is
+            virtually always a mistake rather than an intentional addition.
+            """
+            return isinstance(port, PortNamespace) and port.dynamic and len(port) == 0
 
         def port_namespace_to_dict(namespace: PortNamespace):
             """Recursively convert a PortNamespace into a nested dict structure."""
             return {
-                key: port_namespace_to_dict(port) if isinstance(port, PortNamespace) else None
+                key: port_namespace_to_dict(port)
+                if isinstance(port, PortNamespace) and not has_undeclared_keys(port)
+                else None
                 for key, port in namespace.items()
             }
 
         def recursive_key_check(inputs_mapping: dict, overrides: dict, path=''):
-            """Recursively check that all the provided keys in the `overrides` are in the `inputs_mapping`."""
+            """Recursively collect the keys of the `overrides` that are not in the `inputs_mapping`."""
+            unrecognised = []
 
             for key, value in overrides.items():
                 full_key = f'{path}.{key}' if path else key
                 if key not in inputs_mapping:
-                    warnings.warn(f'Found unrecognised key in overrides: {full_key}')
+                    unrecognised.append(full_key)
                     continue
                 if isinstance(value, dict) and isinstance(inputs_mapping.get(key), dict):
-                    recursive_key_check(inputs_mapping[key], value, full_key)
+                    unrecognised.extend(recursive_key_check(inputs_mapping[key], value, full_key))
+
+            return unrecognised
 
         meta_inputs_schema = cls._load_protocol_file().get('meta_inputs_schema')
 
@@ -171,7 +173,14 @@ class ProtocolMixin:
         # Full protocol schema = meta inputs + process inputs
         inputs_mapping = recursive_merge(meta_inputs_schema, port_namespace_to_dict(cls.spec().inputs))
 
-        recursive_key_check(inputs_mapping, overrides)
+        unrecognised = recursive_key_check(inputs_mapping, overrides)
+
+        if unrecognised:
+            formatted = ', '.join(f'`{key}`' for key in unrecognised)
+            raise ValueError(
+                f'Found unrecognised key(s) in the `overrides` of `{cls.__name__}`: {formatted}. Note that the '
+                '`overrides` have to mirror the nesting of the input port namespace of the `WorkChain`.'
+            )
 
 
 def recursive_merge(left: dict, right: dict) -> dict:

--- a/src/aiida_quantumespresso/workflows/pw/bands.py
+++ b/src/aiida_quantumespresso/workflows/pw/bands.py
@@ -172,16 +172,21 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
         bands.pop('kpoints_distance', None)
         bands.pop('kpoints_force_parity', None)
 
+        # `scf`/`bands` are already fully constructed builders, so assign them directly rather than merging as dicts.
+        inputs.pop('scf', None)
+        inputs.pop('bands', None)
+
+        # `bands_kpoints` and `bands_kpoints_distance` are mutually exclusive: only pass on the one that should be used.
+        if 'bands_kpoints' in inputs:
+            inputs.pop('bands_kpoints_distance', None)
+        else:
+            inputs.pop('bands_kpoints', None)
+
         builder = cls.get_builder()
         builder.structure = structure
         builder.scf = scf
         builder.bands = bands
-        builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
-        builder.nbands_factor = orm.Float(inputs['nbands_factor'])
-        if 'bands_kpoints' in inputs:
-            builder.bands_kpoints = inputs['bands_kpoints']
-        else:
-            builder.bands_kpoints_distance = orm.Float(inputs['bands_kpoints_distance'])
+        builder._update(inputs)
 
         return builder
 

--- a/src/aiida_quantumespresso/workflows/pw/bands.py
+++ b/src/aiida_quantumespresso/workflows/pw/bands.py
@@ -186,7 +186,7 @@ class PwBandsWorkChain(ProtocolMixin, WorkChain):
         builder.structure = structure
         builder.scf = scf
         builder.bands = bands
-        builder._update(inputs)
+        builder._merge(inputs)
 
         return builder
 

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -312,23 +312,20 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
 
         metadata['options'] = cls.set_default_resources(metadata['options'], code.computer.scheduler_type)
 
-        builder = cls.get_builder()
-        builder.pw['code'] = code
-        builder.pw['pseudos'] = pseudos
-        builder.pw['structure'] = structure
-        builder.pw['parameters'] = orm.Dict(parameters)
-        builder.pw['metadata'] = metadata
-        if 'settings' in inputs['pw']:
-            builder.pw['settings'] = orm.Dict(inputs['pw']['settings'])
-        if 'parallelization' in inputs['pw']:
-            builder.pw['parallelization'] = orm.Dict(inputs['pw']['parallelization'])
-        builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
+        inputs['pw']['code'] = code
+        inputs['pw']['structure'] = structure
+        inputs['pw']['pseudos'] = pseudos
+        inputs['pw']['parameters'] = parameters
+        inputs['pw']['metadata'] = metadata
+
+        # `kpoints` and `kpoints_distance` are mutually exclusive: only pass on the one that should be used.
         if 'kpoints' in inputs:
-            builder.kpoints = inputs['kpoints']
+            inputs.pop('kpoints_distance', None)
         else:
-            builder.kpoints_distance = orm.Float(inputs['kpoints_distance'])
-        builder.kpoints_force_parity = orm.Bool(inputs['kpoints_force_parity'])
-        builder.max_iterations = orm.Int(inputs['max_iterations'])
+            inputs.pop('kpoints', None)
+
+        builder = cls.get_builder()
+        builder._update(inputs)
 
         return builder
 

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -325,7 +325,7 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             inputs.pop('kpoints', None)
 
         builder = cls.get_builder()
-        builder._update(inputs)
+        builder._merge(inputs)
 
         return builder
 

--- a/src/aiida_quantumespresso/workflows/pw/relax.py
+++ b/src/aiida_quantumespresso/workflows/pw/relax.py
@@ -190,13 +190,16 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
                         f'Structures with periodic boundary conditions `{structure.pbc}` are not supported.'
                     )
 
+        # `base_relax`/`base_init_relax` are already fully constructed builders, so assign them directly rather than
+        # merging as dicts.
+        inputs.pop('base_relax', None)
+        inputs.pop('base_init_relax', None)
+
         builder = cls.get_builder()
         builder.base_relax = base_relax
         builder.base_init_relax = base_init_relax
         builder.structure = structure
-        builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
-        builder.max_meta_convergence_iterations = orm.Int(inputs['max_meta_convergence_iterations'])
-        builder.meta_convergence = orm.Bool(inputs['meta_convergence'])
+        builder._update(inputs)
 
         return builder
 

--- a/src/aiida_quantumespresso/workflows/pw/relax.py
+++ b/src/aiida_quantumespresso/workflows/pw/relax.py
@@ -199,7 +199,7 @@ class PwRelaxWorkChain(ProtocolMixin, WorkChain):
         builder.base_relax = base_relax
         builder.base_init_relax = base_init_relax
         builder.structure = structure
-        builder._update(inputs)
+        builder._merge(inputs)
 
         return builder
 

--- a/tests/workflows/protocols/neb/test_base.py
+++ b/tests/workflows/protocols/neb/test_base.py
@@ -1,0 +1,67 @@
+"""Tests for the ``NebBaseWorkChain.get_builder_from_protocol`` method."""
+
+import pytest
+from aiida.engine import ProcessBuilder
+
+from aiida_quantumespresso.workflows.neb.base import NebBaseWorkChain
+
+pytestmark = pytest.mark.usefixtures('pseudo_family')
+
+
+def test_get_available_protocols():
+    """Test ``NebBaseWorkChain.get_available_protocols``."""
+    protocols = NebBaseWorkChain.get_available_protocols()
+    assert sorted(protocols.keys()) == ['balanced', 'fast', 'stringent']
+    assert all('description' in protocol for protocol in protocols.values())
+
+
+def test_get_default_protocol():
+    """Test ``NebBaseWorkChain.get_default_protocol``."""
+    assert NebBaseWorkChain.get_default_protocol() == 'balanced'
+
+
+def test_default(fixture_code, generate_trajectory):
+    """Test ``NebBaseWorkChain.get_builder_from_protocol`` for the default protocol."""
+    code = fixture_code('quantumespresso.neb')
+    images = generate_trajectory()
+    builder = NebBaseWorkChain.get_builder_from_protocol(code, images)
+
+    assert isinstance(builder, ProcessBuilder)
+    assert builder.neb.code == code
+    assert builder.neb.images == images
+    assert sorted(builder.neb.pw.pseudos.keys()) == sorted(images.get_step_structure(-1).get_kind_names())
+    assert 'SYSTEM' in builder.neb.pw.parameters.get_dict()
+    assert builder.neb.metadata.options['resources']['num_machines'] == 1
+
+
+def test_overrides_forwarded_to_pw_base(fixture_code, generate_trajectory):
+    """Test that ``overrides`` understood by the ``PwBaseWorkChain`` take effect on the builder.
+
+    Note that ``NebBaseWorkChain`` forwards the ``overrides`` to ``PwBaseWorkChain.get_builder_from_protocol`` and then
+    transfers a fixed selection of the resulting inputs onto its own builder. Consequently only overrides that are
+    understood by the ``PwBaseWorkChain`` spec take effect here; ``NebBaseWorkChain`` specific inputs, such as
+    ``neb.parameters`` or ``handler_overrides``, cannot currently be set through the ``overrides``.
+    """
+    code = fixture_code('quantumespresso.neb')
+    images = generate_trajectory()
+    overrides = {
+        'max_iterations': 3,
+        'pw': {'parameters': {'SYSTEM': {'ecutwfc': 42.0}}},
+    }
+    builder = NebBaseWorkChain.get_builder_from_protocol(code, images, overrides=overrides)
+
+    assert builder.max_iterations == 3
+    assert builder.neb.pw.parameters['SYSTEM']['ecutwfc'] == 42.0
+
+
+def test_options(fixture_code, generate_trajectory):
+    """Test specifying ``options`` for the ``get_builder_from_protocol()`` method."""
+    code = fixture_code('quantumespresso.neb')
+    images = generate_trajectory()
+
+    queue_name = 'super-fast'
+    options = {'queue_name': queue_name, 'withmpi': False}
+    builder = NebBaseWorkChain.get_builder_from_protocol(code, images, options=options)
+
+    assert builder.neb.metadata.options['queue_name'] == queue_name
+    assert builder.neb.metadata.options['withmpi'] is False

--- a/tests/workflows/protocols/ph/test_base.py
+++ b/tests/workflows/protocols/ph/test_base.py
@@ -103,3 +103,22 @@ def test_parent_folder(fixture_code, generate_remote_data, fixture_localhost, fi
     builder = PhBaseWorkChain.get_builder_from_protocol(code, parent_folder=remote_folder)
 
     assert builder.ph.parent_folder == remote_folder
+
+
+def test_overrides_merged(fixture_code):
+    """Test that ``overrides`` are merged onto the builder, also for dict-valued ports.
+
+    A dict-valued input port such as ``handler_overrides`` is not a namespace, so it has to be serialised to a ``Dict``
+    rather than being recursed into. This pins that these overrides land instead of being dropped or raising.
+    """
+    code = fixture_code('quantumespresso.ph')
+    overrides = {
+        'handler_overrides': {'handle_out_of_walltime': {'enabled': False}},
+        'max_iterations': 3,
+        'ph': {'settings': {'cmdline': ['-nk', '4']}},
+    }
+    builder = PhBaseWorkChain.get_builder_from_protocol(code, overrides=overrides)
+
+    assert builder.handler_overrides.get_dict() == {'handle_out_of_walltime': {'enabled': False}}
+    assert builder.max_iterations == 3
+    assert builder.ph.settings.get_dict() == {'cmdline': ['-nk', '4']}

--- a/tests/workflows/protocols/pw/test_bands.py
+++ b/tests/workflows/protocols/pw/test_bands.py
@@ -97,3 +97,25 @@ def test_options(fixture_code, generate_structure):
         builder.bands.pw.metadata,
     ):
         assert subspace['options']['queue_name'] == queue_name, subspace
+
+
+def test_overrides_merged(fixture_code, generate_structure):
+    """Test that ``overrides`` are merged onto the builder, also for dict-valued ports.
+
+    A dict-valued input port such as ``scf.handler_overrides`` is not a namespace, so it has to be serialised to a
+    ``Dict`` rather than being recursed into. This pins that these overrides land instead of being dropped or raising.
+    """
+    code = fixture_code('quantumespresso.pw')
+    structure = generate_structure('silicon')
+    overrides = {
+        'nbands_factor': 5.0,
+        'clean_workdir': True,
+        'scf': {'handler_overrides': {'handle_out_of_walltime': {'enabled': False}}},
+        'bands': {'pw': {'settings': {'cmdline': ['-nk', '4']}}},
+    }
+    builder = PwBandsWorkChain.get_builder_from_protocol(code, structure, overrides=overrides)
+
+    assert builder.nbands_factor == 5.0
+    assert builder.clean_workdir
+    assert builder.scf.handler_overrides.get_dict() == {'handle_out_of_walltime': {'enabled': False}}
+    assert builder.bands.pw.settings.get_dict() == {'cmdline': ['-nk', '4']}

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -288,11 +288,10 @@ def test_parallelization_overrides(fixture_code, generate_structure):
         # CORRECT overrides for `Dict` node with incorrect keys
         # The key check should _not_ validate the inputs, that is the job of the port validator
         ({'pw': {'parameters': {'NON-EXISTENT': {'param': 1}}}}, None),
-        # WRONG overrides with typo
-        ({'clean_wokdir': True}, UserWarning),
-        # WRONG overrides with process input at incorrect level
+        # WRONG overrides with process input at incorrect level, nested inside the dynamic `pw` namespace: the
+        # namespace itself cannot reject unknown keys, so this is only caught with a warning.
         ({'pw': {'options': {}}}, UserWarning),
-        # WRONG overrides with protocol input at incorrect level
+        # WRONG overrides with protocol input at incorrect level, same reasoning as above.
         ({'pw': {'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'}}, UserWarning),
     ],
 )
@@ -306,6 +305,20 @@ def test_overrides_key_check(fixture_code, generate_structure, overrides, warnin
             fixture_code('quantumespresso.pw'),
             generate_structure('silicon'),
             overrides=overrides,
+        )
+
+
+def test_overrides_key_check_raises(fixture_code, generate_structure):
+    """Test that a typo in a top-level override key raises, instead of being silently ignored.
+
+    Unlike keys nested inside a dynamic namespace (see ``test_overrides_key_check``), the work chain's own root
+    namespace is not dynamic, so the builder itself rejects an unknown top-level key.
+    """
+    with pytest.warns(UserWarning), pytest.raises(AttributeError):
+        PwBaseWorkChain.get_builder_from_protocol(
+            fixture_code('quantumespresso.pw'),
+            generate_structure('silicon'),
+            overrides={'clean_wokdir': True},
         )
 
 

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -1,9 +1,10 @@
 """Tests for the ``PwBaseWorkChain.get_builder_from_protocol`` method."""
 
-from contextlib import nullcontext
+import re
 
 import pytest
 from aiida.engine import ProcessBuilder
+from aiida.orm import Dict
 
 from aiida_quantumespresso.common.types import ElectronicType, SpinType
 from aiida_quantumespresso.workflows.pw.base import PwBaseWorkChain
@@ -273,34 +274,53 @@ def test_parallelization_overrides(fixture_code, generate_structure):
 
 
 @pytest.mark.parametrize(
-    ('overrides', 'warning'),
+    'overrides',
     [
         # CORRECT overrides for top-level process input
-        ({'clean_workdir': True}, None),
+        {'clean_workdir': True},
         # CORRECT overrides for top-level protocol input
-        ({'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'}, None),
+        {'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'},
         # CORRECT overrides for nested process input
-        ({'pw': {'metadata': {'options': {'withmpi': False}}}}, None),
+        {'pw': {'metadata': {'options': {'withmpi': False}}}},
         # CORRECT overrides for nested protocol input
-        ({'meta_parameters': {'conv_thr_per_atom': 0.2}}, None),
+        {'meta_parameters': {'conv_thr_per_atom': 0.2}},
         # CORRECT overrides for `Dict` node with correct keys
-        ({'pw': {'parameters': {'CONTROL': {'calculation': 'relax'}}}}, None),
+        {'pw': {'parameters': {'CONTROL': {'calculation': 'relax'}}}},
         # CORRECT overrides for `Dict` node with incorrect keys
         # The key check should _not_ validate the inputs, that is the job of the port validator
-        ({'pw': {'parameters': {'NON-EXISTENT': {'param': 1}}}}, None),
-        # WRONG overrides with process input at incorrect level, nested inside the dynamic `pw` namespace: the
-        # namespace itself cannot reject unknown keys, so this is only caught with a warning.
-        ({'pw': {'options': {}}}, UserWarning),
-        # WRONG overrides with protocol input at incorrect level, same reasoning as above.
-        ({'pw': {'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'}}, UserWarning),
+        {'pw': {'parameters': {'NON-EXISTENT': {'param': 1}}}},
     ],
 )
-def test_overrides_key_check(fixture_code, generate_structure, overrides, warning):
-    """Test that the `get_builder_from_protocol()` method warns for erroneous keys in the `overrides`."""
+def test_overrides_key_check(fixture_code, generate_structure, overrides):
+    """Test that the `get_builder_from_protocol()` method accepts valid keys in the `overrides`."""
+    PwBaseWorkChain.get_builder_from_protocol(
+        fixture_code('quantumespresso.pw'),
+        generate_structure('silicon'),
+        overrides=overrides,
+    )
 
-    context = pytest.warns(UserWarning) if warning else nullcontext()
 
-    with context:
+@pytest.mark.parametrize(
+    ('overrides', 'match'),
+    [
+        # WRONG overrides with typo at the (non-dynamic) root level.
+        ({'clean_wokdir': True}, '`clean_wokdir`'),
+        # WRONG overrides with process input at incorrect level, nested inside the dynamic `pw` namespace. The
+        # namespace itself cannot reject unknown keys, so this can only be caught by the key check.
+        ({'pw': {'options': {}}}, '`pw.options`'),
+        # WRONG overrides with protocol input at incorrect level, same reasoning as above.
+        ({'pw': {'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'}}, '`pw.pseudo_family`'),
+        # Multiple unrecognised keys are reported in a single error.
+        ({'clean_wokdir': True, 'pw': {'options': {}}}, '`clean_wokdir`, `pw.options`'),
+    ],
+)
+def test_overrides_key_check_raises(fixture_code, generate_structure, overrides, match):
+    """Test that an unrecognised key in the `overrides` raises, instead of being silently ignored.
+
+    This holds regardless of whether the enclosing namespace is dynamic: a key nested inside the dynamic ``pw``
+    namespace would otherwise be accepted by the builder and only fail at submission with a cryptic type error.
+    """
+    with pytest.raises(ValueError, match=re.escape(match)):
         PwBaseWorkChain.get_builder_from_protocol(
             fixture_code('quantumespresso.pw'),
             generate_structure('silicon'),
@@ -308,18 +328,21 @@ def test_overrides_key_check(fixture_code, generate_structure, overrides, warnin
         )
 
 
-def test_overrides_key_check_raises(fixture_code, generate_structure):
-    """Test that a typo in a top-level override key raises, instead of being silently ignored.
+def test_monitors_overrides(fixture_code, generate_structure):
+    """Test specifying ``pw.monitors`` ``overrides`` for the ``get_builder_from_protocol()`` method.
 
-    Unlike keys nested inside a dynamic namespace (see ``test_overrides_key_check``), the work chain's own root
-    namespace is not dynamic, so the builder itself rejects an unknown top-level key.
+    The ``pw.monitors`` namespace is dynamic and declares no ports of its own, so its keys are chosen by the caller
+    and cannot be validated by the key check. This pins that such keys land on the builder rather than being
+    rejected as unrecognised.
     """
-    with pytest.warns(UserWarning), pytest.raises(AttributeError):
-        PwBaseWorkChain.get_builder_from_protocol(
-            fixture_code('quantumespresso.pw'),
-            generate_structure('silicon'),
-            overrides={'clean_wokdir': True},
-        )
+    monitors = {'accuracy_stuck': Dict({'entry_point': 'quantumespresso.accuracy_stuck'})}
+    builder = PwBaseWorkChain.get_builder_from_protocol(
+        fixture_code('quantumespresso.pw'),
+        generate_structure('silicon'),
+        overrides={'pw': {'monitors': monitors}},
+    )
+
+    assert builder.pw.monitors['accuracy_stuck'].get_dict() == {'entry_point': 'quantumespresso.accuracy_stuck'}
 
 
 def test_pseudos_overrides(fixture_code, generate_structure, generate_upf_data):

--- a/tests/workflows/protocols/pw/test_relax.py
+++ b/tests/workflows/protocols/pw/test_relax.py
@@ -163,12 +163,9 @@ def test_pbc_cell(fixture_code, generate_structure, struc_name, cell_dofree):
         ({'base_relax': {'kpoints_force_parity': True}}, None),
         # CORRECT overrides for nested protocol input
         ({'base_relax': {'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'}}, None),
-        # WRONG overrides with typo
-        ({'clean_wokdir': True}, UserWarning),
-        # WRONG overrides with process input at incorrect level
+        # WRONG overrides with process input at incorrect level, nested inside the dynamic `base_relax` namespace:
+        # the namespace itself cannot reject unknown keys, so this is only caught with a warning.
         ({'base_relax': {'clean_workdir': True}}, UserWarning),
-        # WRONG overrides with protocol input at incorrect level
-        ({'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'}, UserWarning),
     ],
 )
 def test_overrides_key_check(fixture_code, generate_structure, overrides, warning):
@@ -177,6 +174,29 @@ def test_overrides_key_check(fixture_code, generate_structure, overrides, warnin
     context = pytest.warns(UserWarning) if warning else nullcontext()
 
     with context:
+        PwRelaxWorkChain.get_builder_from_protocol(
+            fixture_code('quantumespresso.pw'),
+            generate_structure('silicon'),
+            overrides=overrides,
+        )
+
+
+@pytest.mark.parametrize(
+    'overrides',
+    [
+        # WRONG overrides with typo at the (non-dynamic) root level.
+        {'clean_wokdir': True},
+        # WRONG overrides with protocol input at the (non-dynamic) root level.
+        {'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'},
+    ],
+)
+def test_overrides_key_check_raises(fixture_code, generate_structure, overrides):
+    """Test that a typo in a top-level override key raises, instead of being silently ignored.
+
+    Unlike keys nested inside a dynamic namespace (see ``test_overrides_key_check``), the work chain's own root
+    namespace is not dynamic, so the builder itself rejects an unknown top-level key.
+    """
+    with pytest.warns(UserWarning), pytest.raises(AttributeError):
         PwRelaxWorkChain.get_builder_from_protocol(
             fixture_code('quantumespresso.pw'),
             generate_structure('silicon'),

--- a/tests/workflows/protocols/pw/test_relax.py
+++ b/tests/workflows/protocols/pw/test_relax.py
@@ -1,6 +1,6 @@
 """Tests for the ``PwRelaxWorkChain.get_builder_from_protocol`` method."""
 
-from contextlib import nullcontext
+import re
 
 import pytest
 from aiida.engine import ProcessBuilder
@@ -155,48 +155,44 @@ def test_pbc_cell(fixture_code, generate_structure, struc_name, cell_dofree):
 
 
 @pytest.mark.parametrize(
-    ('overrides', 'warning'),
+    'overrides',
     [
         # CORRECT overrides for top-level process input
-        ({'clean_workdir': True}, None),
+        {'clean_workdir': True},
         # CORRECT overrides for nested process input
-        ({'base_relax': {'kpoints_force_parity': True}}, None),
+        {'base_relax': {'kpoints_force_parity': True}},
         # CORRECT overrides for nested protocol input
-        ({'base_relax': {'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'}}, None),
-        # WRONG overrides with process input at incorrect level, nested inside the dynamic `base_relax` namespace:
-        # the namespace itself cannot reject unknown keys, so this is only caught with a warning.
-        ({'base_relax': {'clean_workdir': True}}, UserWarning),
+        {'base_relax': {'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'}},
     ],
 )
-def test_overrides_key_check(fixture_code, generate_structure, overrides, warning):
-    """Test that the `get_builder_from_protocol()` method warns for erroneous keys in the `overrides`."""
-
-    context = pytest.warns(UserWarning) if warning else nullcontext()
-
-    with context:
-        PwRelaxWorkChain.get_builder_from_protocol(
-            fixture_code('quantumespresso.pw'),
-            generate_structure('silicon'),
-            overrides=overrides,
-        )
+def test_overrides_key_check(fixture_code, generate_structure, overrides):
+    """Test that the `get_builder_from_protocol()` method accepts valid keys in the `overrides`."""
+    PwRelaxWorkChain.get_builder_from_protocol(
+        fixture_code('quantumespresso.pw'),
+        generate_structure('silicon'),
+        overrides=overrides,
+    )
 
 
 @pytest.mark.parametrize(
-    'overrides',
+    ('overrides', 'match'),
     [
         # WRONG overrides with typo at the (non-dynamic) root level.
-        {'clean_wokdir': True},
+        ({'clean_wokdir': True}, '`clean_wokdir`'),
         # WRONG overrides with protocol input at the (non-dynamic) root level.
-        {'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'},
+        ({'pseudo_family': 'SSSP/1.3/PBEsol/efficiency'}, '`pseudo_family`'),
+        # WRONG overrides with process input at incorrect level, nested inside the dynamic `base_relax` namespace.
+        # The namespace itself cannot reject unknown keys, so this can only be caught by the key check.
+        ({'base_relax': {'clean_workdir': True}}, '`base_relax.clean_workdir`'),
     ],
 )
-def test_overrides_key_check_raises(fixture_code, generate_structure, overrides):
-    """Test that a typo in a top-level override key raises, instead of being silently ignored.
+def test_overrides_key_check_raises(fixture_code, generate_structure, overrides, match):
+    """Test that an unrecognised key in the `overrides` raises, instead of being silently ignored.
 
-    Unlike keys nested inside a dynamic namespace (see ``test_overrides_key_check``), the work chain's own root
-    namespace is not dynamic, so the builder itself rejects an unknown top-level key.
+    This holds regardless of whether the enclosing namespace is dynamic: a key nested inside the dynamic
+    ``base_relax`` namespace would otherwise be accepted by the builder and only fail at submission.
     """
-    with pytest.warns(UserWarning), pytest.raises(AttributeError):
+    with pytest.raises(ValueError, match=re.escape(match)):
         PwRelaxWorkChain.get_builder_from_protocol(
             fixture_code('quantumespresso.pw'),
             generate_structure('silicon'),

--- a/tests/workflows/protocols/test_pdos.py
+++ b/tests/workflows/protocols/test_pdos.py
@@ -102,3 +102,25 @@ def test_settings_overrides(get_pdos_generator_inputs):
 
     assert builder.dos.settings.get_dict() == {'CMDLINE': ['-npool', '4']}
     assert builder.projwfc.settings.get_dict() == {'CMDLINE': ['-npool', '4']}
+
+
+def test_overrides_merged(get_pdos_generator_inputs):
+    """Test that ``overrides`` are merged onto the builder, also for dict-valued ports.
+
+    A dict-valued input port such as ``scf.handler_overrides`` is not a namespace, so it has to be serialised to a
+    ``Dict`` rather than being recursed into. This pins that these overrides land instead of being dropped or raising.
+    """
+    overrides = {
+        'nbands_factor': 3.0,
+        'clean_workdir': True,
+        'scf': {'handler_overrides': {'handle_out_of_walltime': {'enabled': False}}},
+        'dos': {'settings': {'cmdline': ['-nk', '4']}},
+        'projwfc': {'parameters': {'PROJWFC': {'deltae': 0.02}}},
+    }
+    builder = PdosWorkChain.get_builder_from_protocol(**get_pdos_generator_inputs, overrides=overrides)
+
+    assert builder.nbands_factor == 3.0
+    assert builder.clean_workdir
+    assert builder.scf.handler_overrides.get_dict() == {'handle_out_of_walltime': {'enabled': False}}
+    assert builder.dos.settings.get_dict() == {'cmdline': ['-nk', '4']}
+    assert builder.projwfc.parameters['PROJWFC']['deltae'] == 0.02


### PR DESCRIPTION
`get_builder_from_protocol()` built each work chain's inputs by manually copying a hardcoded whitelist of fields onto the builder, wrapping each in its AiiDA type by hand. Any `overrides` key not in that whitelist (e.g. `monitors`) was silently ignored instead of being applied or raising an error.

- Replace the manual per-field copying with `builder._update(inputs)` in `PwBaseWorkChain`, `PhBaseWorkChain`, `PdosWorkChain`, `PwBandsWorkChain`, `PwRelaxWorkChain` and `NebBaseWorkChain`. This existing `ProcessBuilderNamespace` method already does everything the manual code was doing by hand: it merges a plain dict onto the builder, applies the default `to_aiida_type` serializer per port, and raises `AttributeError` for unknown keys at a non-dynamic level.
- A typo'd or misplaced key at a work chain's root namespace now raises instead of being dropped. Keys nested inside a dynamic namespace (e.g. `pw`, `base_relax`) still can only be caught with the existing `UserWarning` from `_validate_override_keys`, since dynamic namespaces accept arbitrary keys by design — this soft check is unchanged and keeps working exactly as introduced in #1136.
- While this changes the behavior, i.e., failing for top level keys, I'd still say that it's fine. I also had a version just emitting a warning and ignoring those keys, but I found it unnecessarily complicated. In the end, an error is only raised for top level keys and if a user tries to manually set them on the builder, it will anyway fail. Also, in #1102 we introduced a new raising behavior that was included in a minor release, so I think that we could accept this change and properly document it in the CHANGELOG.

If there are other opinions, especially in favour of checking those top level keys and dropping them with a warning, instead of raising, we can of course adjust it