### PR TITLE
👌 Protocols: support pseudo families without recommended cutoffs

### DIFF
--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -216,15 +216,16 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         # Update the parameters based on the protocol inputs
         parameters = inputs['pw']['parameters']
 
+        system_overrides = (overrides or {}).get('pw', {}).get('parameters', {}).get('SYSTEM', {})
+        cutoffs_in_overrides = all(key in system_overrides for key in ('ecutwfc', 'ecutrho'))
+
         if overrides and 'pseudos' in overrides.get('pw', {}):
             pseudos = overrides['pw']['pseudos']
 
             if sorted(pseudos.keys()) != sorted(structure.get_kind_names()):
                 raise ValueError(f'`pseudos` override needs one value for each of the {len(structure.kinds)} kinds.')
 
-            system_overrides = overrides['pw'].get('parameters', {}).get('SYSTEM', {})
-
-            if not all(key in system_overrides for key in ('ecutwfc', 'ecutrho')):
+            if not cutoffs_in_overrides:
                 raise ValueError(
                     'When overriding the pseudo potentials, both `ecutwfc` and `ecutrho` cutoffs should be '
                     f'provided in the `overrides`: {overrides}'
@@ -244,15 +245,20 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
                     'install it.'
                 ) from exception
 
-            try:
-                parameters['SYSTEM']['ecutwfc'], parameters['SYSTEM']['ecutrho'] = (
-                    pseudo_family.get_recommended_cutoffs(structure=structure, unit='Ry')
-                )
-                pseudos = pseudo_family.get_pseudos(structure=structure)
-            except ValueError as exception:
-                raise ValueError(
-                    f'failed to obtain recommended cutoffs for pseudo family `{pseudo_family}`: {exception}'
-                ) from exception
+            # Families that do not define recommended cutoffs can still be used, as long as the `overrides` provide
+            # both cutoffs themselves, since these are applied further down and take precedence anyway.
+            if not cutoffs_in_overrides:
+                try:
+                    parameters['SYSTEM']['ecutwfc'], parameters['SYSTEM']['ecutrho'] = (
+                        pseudo_family.get_recommended_cutoffs(structure=structure, unit='Ry')
+                    )
+                except ValueError as exception:
+                    raise ValueError(
+                        f'failed to obtain recommended cutoffs for pseudo family `{pseudo_family}`: {exception} '
+                        'If the family does not define any, specify both `ecutwfc` and `ecutrho` in the `overrides`.'
+                    ) from exception
+
+            pseudos = pseudo_family.get_pseudos(structure=structure)
 
         parameters['CONTROL']['etot_conv_thr'] = natoms * meta_parameters['etot_conv_thr_per_atom']
         parameters['ELECTRONS']['conv_thr'] = natoms * meta_parameters['conv_thr_per_atom']

--- a/src/aiida_quantumespresso/workflows/pw/base.py
+++ b/src/aiida_quantumespresso/workflows/pw/base.py
@@ -13,6 +13,7 @@ from aiida.engine import (
     while_,
 )
 from aiida.plugins import CalculationFactory, GroupFactory
+from aiida_pseudo.groups.mixins import RecommendedCutoffMixin
 
 from aiida_quantumespresso.calculations.functions.create_kpoints_from_distance import (
     create_kpoints_from_distance,
@@ -25,9 +26,7 @@ from aiida_quantumespresso.utils.defaults.calculation import pw as qe_defaults
 from ..protocols.utils import ProtocolMixin
 
 PwCalculation = CalculationFactory('quantumespresso.pw')
-SsspFamily = GroupFactory('pseudo.family.sssp')
-PseudoDojoFamily = GroupFactory('pseudo.family.pseudo_dojo')
-CutoffsPseudoPotentialFamily = GroupFactory('pseudo.family.cutoffs')
+PseudoPotentialFamily = GroupFactory('pseudo.family')
 
 
 class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
@@ -233,12 +232,9 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
 
         else:
             try:
-                pseudo_set = (
-                    PseudoDojoFamily,
-                    SsspFamily,
-                    CutoffsPseudoPotentialFamily,
+                pseudo_family = (
+                    orm.QueryBuilder().append(PseudoPotentialFamily, filters={'label': pseudo_family}).one()[0]
                 )
-                pseudo_family = orm.QueryBuilder().append(pseudo_set, filters={'label': pseudo_family}).one()[0]
             except exceptions.NotExistent as exception:
                 raise ValueError(
                     f'required pseudo family `{pseudo_family}` is not installed. Please use `aiida-pseudo install` to'
@@ -248,6 +244,12 @@ class PwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             # Families that do not define recommended cutoffs can still be used, as long as the `overrides` provide
             # both cutoffs themselves, since these are applied further down and take precedence anyway.
             if not cutoffs_in_overrides:
+                if not isinstance(pseudo_family, RecommendedCutoffMixin):
+                    raise ValueError(
+                        f'pseudo family `{pseudo_family}` cannot recommend cutoffs. Provide both `ecutwfc` and '
+                        '`ecutrho` in the `overrides`, or use a family that recommends them.'
+                    )
+
                 try:
                     parameters['SYSTEM']['ecutwfc'], parameters['SYSTEM']['ecutrho'] = (
                         pseudo_family.get_recommended_cutoffs(structure=structure, unit='Ry')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,25 @@ def pseudo_family(generate_upf_data):
     return family
 
 
+@pytest.fixture(scope='session')
+def pseudo_family_without_cutoffs(generate_upf_data):
+    """Create a silicon pseudo potential family for which no recommended cutoffs are defined."""
+    from aiida_pseudo.data.pseudo.upf import UpfData
+    from aiida_pseudo.groups.family import CutoffsPseudoPotentialFamily
+
+    label = 'custom/no-cutoffs'
+    upf = generate_upf_data('Si')
+
+    with tempfile.TemporaryDirectory() as directory:
+        dirpath = pathlib.Path(directory)
+
+        with open(dirpath / 'Si.upf', 'w+b') as handle, upf.open(mode='rb') as source:
+            handle.write(source.read())
+            handle.flush()
+
+        return CutoffsPseudoPotentialFamily.create_from_folder(dirpath, label, pseudo_type=UpfData)
+
+
 @pytest.fixture
 def generate_calc_job():
     """Fixture to construct a new `CalcJob` instance and call `prepare_for_submission` for testing `CalcJob` classes.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,22 +173,30 @@ def pseudo_family(generate_upf_data):
 
 
 @pytest.fixture(scope='session')
-def pseudo_family_without_cutoffs(generate_upf_data):
-    """Create a silicon pseudo potential family for which no recommended cutoffs are defined."""
-    from aiida_pseudo.data.pseudo.upf import UpfData
-    from aiida_pseudo.groups.family import CutoffsPseudoPotentialFamily
+def pseudo_families_without_cutoffs(generate_upf_data):
+    """Create the silicon pseudo potential families that recommend no cutoffs, keyed on their class name.
 
-    label = 'custom/no-cutoffs'
+    A ``CutoffsPseudoPotentialFamily`` can recommend cutoffs but has none set here. A ``PseudoPotentialFamily``, the
+    class that ``aiida-pseudo install family`` installs by default, cannot recommend them at all.
+    """
+    from aiida_pseudo.data.pseudo.upf import UpfData
+    from aiida_pseudo.groups.family import CutoffsPseudoPotentialFamily, PseudoPotentialFamily
+
+    families = {}
     upf = generate_upf_data('Si')
 
-    with tempfile.TemporaryDirectory() as directory:
-        dirpath = pathlib.Path(directory)
+    for family_type in (PseudoPotentialFamily, CutoffsPseudoPotentialFamily):
+        with tempfile.TemporaryDirectory() as directory:
+            dirpath = pathlib.Path(directory)
 
-        with open(dirpath / 'Si.upf', 'w+b') as handle, upf.open(mode='rb') as source:
-            handle.write(source.read())
-            handle.flush()
+            with open(dirpath / 'Si.upf', 'w+b') as handle, upf.open(mode='rb') as source:
+                handle.write(source.read())
+                handle.flush()
 
-        return CutoffsPseudoPotentialFamily.create_from_folder(dirpath, label, pseudo_type=UpfData)
+            label = f'custom/{family_type.__name__}'
+            families[family_type.__name__] = family_type.create_from_folder(dirpath, label, pseudo_type=UpfData)
+
+    return families
 
 
 @pytest.fixture

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -444,40 +444,43 @@ def test_pseudos_family_structure_fail(fixture_code, generate_structure):
     assert 'recommended cutoffs' not in str(exception.value)
 
 
-def test_pseudo_family_without_cutoffs(fixture_code, generate_structure, pseudo_family_without_cutoffs):
+@pytest.mark.parametrize('family_type', ('PseudoPotentialFamily', 'CutoffsPseudoPotentialFamily'))
+def test_pseudo_family_without_cutoffs(fixture_code, generate_structure, pseudo_families_without_cutoffs, family_type):
     """Test a ``pseudo_family`` without recommended cutoffs, where the cutoffs are specified in the ``overrides``."""
     code = fixture_code('quantumespresso.pw')
     structure = generate_structure('silicon')
+    family = pseudo_families_without_cutoffs[family_type]
 
     builder = PwBaseWorkChain.get_builder_from_protocol(
         code,
         structure,
         overrides={
-            'pseudo_family': pseudo_family_without_cutoffs.label,
+            'pseudo_family': family.label,
             'pw': {'parameters': {'SYSTEM': {'ecutwfc': 30.0, 'ecutrho': 240.0}}},
         },
     )
     parameters = builder.pw.parameters.get_dict()
 
-    assert builder.pw.pseudos['Si'].uuid == pseudo_family_without_cutoffs.get_pseudo(element='Si').uuid
+    assert builder.pw.pseudos['Si'].uuid == family.get_pseudo(element='Si').uuid
     assert parameters['SYSTEM']['ecutwfc'] == 30.0
     assert parameters['SYSTEM']['ecutrho'] == 240.0
 
 
+@pytest.mark.parametrize('family_type', ('PseudoPotentialFamily', 'CutoffsPseudoPotentialFamily'))
 @pytest.mark.parametrize('system_overrides', ({}, {'ecutwfc': 30.0}, {'ecutrho': 240.0}))
 def test_pseudo_family_without_cutoffs_fail(
-    fixture_code, generate_structure, pseudo_family_without_cutoffs, system_overrides
+    fixture_code, generate_structure, pseudo_families_without_cutoffs, system_overrides, family_type
 ):
     """Test a ``pseudo_family`` without recommended cutoffs fails if the ``overrides`` do not specify both cutoffs."""
     code = fixture_code('quantumespresso.pw')
     structure = generate_structure('silicon')
 
-    with pytest.raises(ValueError, match=r'specify both `ecutwfc` and `ecutrho` in the `overrides`'):
+    with pytest.raises(ValueError, match=r'both `ecutwfc` and `ecutrho` in the `overrides`'):
         PwBaseWorkChain.get_builder_from_protocol(
             code,
             structure,
             overrides={
-                'pseudo_family': pseudo_family_without_cutoffs.label,
+                'pseudo_family': pseudo_families_without_cutoffs[family_type].label,
                 'pw': {'parameters': {'SYSTEM': system_overrides}},
             },
         )

--- a/tests/workflows/protocols/pw/test_base.py
+++ b/tests/workflows/protocols/pw/test_base.py
@@ -182,6 +182,21 @@ def test_overrides_pseudo_family(fixture_code, generate_structure):
     assert parameters['SYSTEM']['ecutrho'] == 400.0
 
 
+def test_overrides_cutoffs(fixture_code, generate_structure):
+    """Test cutoffs in the ``overrides`` take precedence over those recommended by the ``pseudo_family``."""
+    code = fixture_code('quantumespresso.pw')
+    structure = generate_structure('silicon')
+
+    # The default family recommends 30 Ry and 240 Ry, see ``test_default``
+    overrides = {'pw': {'parameters': {'SYSTEM': {'ecutwfc': 45.0, 'ecutrho': 180.0}}}}
+
+    builder = PwBaseWorkChain.get_builder_from_protocol(code, structure, overrides=overrides)
+    parameters = builder.pw.parameters.get_dict()
+    assert parameters['SYSTEM']['ecutwfc'] == 45.0
+    assert parameters['SYSTEM']['ecutrho'] == 180.0
+    assert 'Si' in builder.pw.pseudos
+
+
 def test_magnetization_overrides(fixture_code, generate_structure):
     """Test magnetization ``overrides`` for the ``PwBaseWorkChain.get_builder_from_protocol`` method."""
     code = fixture_code('quantumespresso.pw')
@@ -416,6 +431,55 @@ def test_pseudos_family_structure_fail(fixture_code, generate_structure):
         PwBaseWorkChain.get_builder_from_protocol(
             code,
             structure,
+        )
+
+    # If the cutoffs are specified in the ``overrides``, the family is only asked for the pseudo potentials
+    with pytest.raises(ValueError, match=r'does not contain pseudo for element `U`') as exception:
+        PwBaseWorkChain.get_builder_from_protocol(
+            code,
+            structure,
+            overrides={'pw': {'parameters': {'SYSTEM': {'ecutwfc': 30.0, 'ecutrho': 240.0}}}},
+        )
+
+    assert 'recommended cutoffs' not in str(exception.value)
+
+
+def test_pseudo_family_without_cutoffs(fixture_code, generate_structure, pseudo_family_without_cutoffs):
+    """Test a ``pseudo_family`` without recommended cutoffs, where the cutoffs are specified in the ``overrides``."""
+    code = fixture_code('quantumespresso.pw')
+    structure = generate_structure('silicon')
+
+    builder = PwBaseWorkChain.get_builder_from_protocol(
+        code,
+        structure,
+        overrides={
+            'pseudo_family': pseudo_family_without_cutoffs.label,
+            'pw': {'parameters': {'SYSTEM': {'ecutwfc': 30.0, 'ecutrho': 240.0}}},
+        },
+    )
+    parameters = builder.pw.parameters.get_dict()
+
+    assert builder.pw.pseudos['Si'].uuid == pseudo_family_without_cutoffs.get_pseudo(element='Si').uuid
+    assert parameters['SYSTEM']['ecutwfc'] == 30.0
+    assert parameters['SYSTEM']['ecutrho'] == 240.0
+
+
+@pytest.mark.parametrize('system_overrides', ({}, {'ecutwfc': 30.0}, {'ecutrho': 240.0}))
+def test_pseudo_family_without_cutoffs_fail(
+    fixture_code, generate_structure, pseudo_family_without_cutoffs, system_overrides
+):
+    """Test a ``pseudo_family`` without recommended cutoffs fails if the ``overrides`` do not specify both cutoffs."""
+    code = fixture_code('quantumespresso.pw')
+    structure = generate_structure('silicon')
+
+    with pytest.raises(ValueError, match=r'specify both `ecutwfc` and `ecutrho` in the `overrides`'):
+        PwBaseWorkChain.get_builder_from_protocol(
+            code,
+            structure,
+            overrides={
+                'pseudo_family': pseudo_family_without_cutoffs.label,
+                'pw': {'parameters': {'SYSTEM': system_overrides}},
+            },
         )
 
 


### PR DESCRIPTION
### Summary

This PR allows non-SSSP/PseudoDojo pseudo families to be used with the builders.

`aiida-pseudo install family <folder> <label>` installs a family the builders then refuse:

```
ValueError: required pseudo family `MyPseudos/local` is not installed.
Please use `aiida-pseudo install` toinstall it.
```

It is installed. `PwBaseWorkChain.get_builder_from_protocol` looks only for the family classes that can recommend cutoffs, and asks for those cutoffs before fetching the pseudos, so a family without them cannot be used at all — even when the `overrides` already give both (which take precedence anyway). A `CutoffsPseudoPotentialFamily` whose stringency is never set fails the same way, with `no default stringency has been defined`.

### Changes
**First commit.** The recommended cutoffs are requested only when the `overrides` do not already define both; the pseudos are fetched either way. The error still fires when nothing provides them, now naming the alternative.

**Second commit.** The query now names the base class rather than the three cutoff-recommending subclasses, and the capability is checked where the cutoffs are needed (`isinstance(..., RecommendedCutoffMixin)`):

```
ValueError: pseudo family `PseudoPotentialFamily<MyPseudos/local>` cannot recommend cutoffs.
Provide both `ecutwfc` and `ecutrho` in the `overrides`, or use a family that recommends them.
```

The old query's line was not "families whose cutoffs track the protocol": `get_recommended_cutoffs` is called with no stringency, and only `stringent` varies the family — by naming a different one, which a cutoffs family follows no better than a plain one.

### A question for the maintainers
Is the intent that `get_builder_from_protocol` always returns a builder with cutoffs set — so a plain family plus override cutoffs is legitimate, as implemented — or that only cutoff-recommending families are supported at all, in which case the right fix is just a clearer error and no widening? I have taken the first; the second commit can be dropped on its own.

### Notes
- this adds the first direct `aiida_pseudo` import to `src/` (entry points cover group classes, not mixins)
- this drops the now-unused module-level `SsspFamily` / `PseudoDojoFamily` / `CutoffsPseudoPotentialFamily` names from `workflows/pw/base.py`. Say if you would rather keep them.
- #931 proposes improving the neighbouring "not installed" error. This does not reword it, but it does stop it firing for families that are installed.