### PR TITLE
🐛 `setup codes`: use POSIX `command -v` to locate executables

### DIFF
--- a/docs/source/get_started/installation.md
+++ b/docs/source/get_started/installation.md
@@ -43,7 +43,7 @@ $ aiida-quantumespresso setup codes localhost pw.x projwfc.x dos.x
 
 :::{important}
 
-The command will look for the executables in your `PATH` using the `which` UNIX command.
+The command will look for the executables in your `PATH` using the `command -v` shell builtin.
 This can fail, or you may wish to specify a different executable.
 In this case, have a look at the dropdown below.
 
@@ -52,7 +52,7 @@ In this case, have a look at the dropdown below.
 You can find out the absolute path to e.g. the first `pw.x` executable in the `PATH` using:
 
 ```console
-which pw.x
+command -v pw.x
 ```
 
 If this returns nothing or a Quantum ESPRESSO version you don't want to run, you have a few options:

--- a/src/aiida_quantumespresso/tools/setup.py
+++ b/src/aiida_quantumespresso/tools/setup.py
@@ -84,7 +84,8 @@ def get_executable_paths(
     """Return a mapping from executable names to absolute paths on the given computer.
 
     If `directory` is provided, each path is constructed as `directory`/`executable`.
-    Otherwise, the `prepend_text` is combined with `which` to locate executables in the PATH.
+    Otherwise, the `prepend_text` is combined with `command -v` to locate executables in the PATH. The POSIX-compliant
+    `command -v` is used instead of `which`, since the latter is not guaranteed to be available on all systems.
     """
     executable_paths = {}
 
@@ -93,22 +94,30 @@ def get_executable_paths(
             if directory is None:
                 combined_prepend_text = f'{computer.get_prepend_text()}\n{prepend_text}'
                 return_value, stdout, stderr = transport.exec_command_wait(
-                    command=f'. /dev/stdin > /dev/null && which {executable}', stdin=combined_prepend_text
+                    command=f'. /dev/stdin > /dev/null && command -v {executable}', stdin=combined_prepend_text
                 )
 
-                if return_value != 0 or not stdout.strip():
+                resolved_path = PurePosixPath(stdout.strip())
+
+                if return_value != 0 or not stdout.strip() or not resolved_path.is_absolute():
                     msg = f'Failed to determine the path of executable<{executable}> on computer<{computer.label}>.\n'
                     if stderr:
                         msg += f'Error: {stderr}'
                     elif not stdout.strip():
-                        msg += 'Error: the `which` command returned an empty output.\n'
+                        msg += 'Error: the `command -v` command returned an empty output.\n'
+                    else:
+                        # Unlike `which`, `command -v` also resolves shell functions and aliases, returning their name
+                        # instead of a path. A relative entry in the `PATH` equally yields a relative path. Since
+                        # `orm.InstalledCode` skips its existence check for non-absolute paths, such a code would be
+                        # stored successfully but only fail once a calculation is submitted.
+                        msg += f'Error: the `command -v` command did not return an absolute path: {stdout.strip()}\n'
                     msg += (
                         '\nDouble-check the `prepend_text` and executables and/or specify the full path with the '
                         '`directory` input.'
                     )
                     raise FileNotFoundError(msg)
 
-                executable_paths[executable] = PurePosixPath(stdout.strip()).as_posix()
+                executable_paths[executable] = resolved_path.as_posix()
             else:
                 directory = PurePosixPath(directory)
 

--- a/tests/tools/test_code_setup.py
+++ b/tests/tools/test_code_setup.py
@@ -15,7 +15,7 @@ def create_pw_executable(tmp_path):
         executable_path = tmp_path / subdir / 'pw.x'
         executable_path.parent.mkdir(parents=True, exist_ok=True)
         executable_path.touch()
-        executable_path.chmod(0o755)  # Needs to be executable for `which` to find it
+        executable_path.chmod(0o755)  # Needs to be executable for `command -v` to find it
         return executable_path
 
     return _factory
@@ -27,17 +27,17 @@ def create_pw_executable(tmp_path):
         ('export PATH={path}:$PATH', None, ''),
         ('echo lala\nexport PATH={path}:$PATH', None, ''),
         ('# Comment\nexport PATH={path}:$PATH', None, ''),
-        ('', FileNotFoundError, 'Error: the `which` command returned an empty output.'),
+        ('', FileNotFoundError, 'Error: the `command -v` command returned an empty output.'),
         (
             'echo lala',
             FileNotFoundError,
-            'Error: the `which` command returned an empty output.',
+            'Error: the `command -v` command returned an empty output.',
         ),
         ('expoat PATH={path}:$PATH', FileNotFoundError, 'expoat: command not found'),
         (
             'export PATH={path}WRONG:$PATH',
             FileNotFoundError,
-            'Error: the `which` command returned an empty output.',
+            'Error: the `command -v` command returned an empty output.',
         ),
     ],
 )
@@ -69,6 +69,24 @@ def test_get_executable_paths_with_quoted_path(create_pw_executable, fixture_loc
         prepend_text=prepend_text,
     )
     assert result == {pw_executable.name: pw_executable.as_posix()}
+
+
+def test_get_executable_paths_not_absolute(create_pw_executable, fixture_localhost):
+    """Tests that the `get_executable_paths` function rejects a result that is not an absolute path.
+
+    In contrast to `which`, `command -v` also resolves shell functions and aliases, for which it returns the name
+    instead of a path. Such a code would be stored successfully but only fail once a calculation is submitted.
+    """
+    pw_executable = create_pw_executable()
+    # Define a shell function that shadows the executable, even though the latter can be found in the `PATH`
+    prepend_text = f'export PATH={pw_executable.parent.as_posix()}:$PATH\n{pw_executable.name}() {{ echo mock; }}'
+
+    with pytest.raises(FileNotFoundError, match=f'did not return an absolute path: {pw_executable.name}'):
+        get_executable_paths(
+            executable_tuple=(pw_executable.name,),
+            computer=fixture_localhost,
+            prepend_text=prepend_text,
+        )
 
 
 def test_get_executable_paths_directory(create_pw_executable, fixture_localhost):


### PR DESCRIPTION
Fixes #1254

The executables are located by running `which`, which is not specified by POSIX and ships as a separate package, so it is not guaranteed to be installed. On Arch Linux, for example, zsh users typically don't have it, and the `bash` shell used by the transport fails with `which: command not found`.

Here we switch to `command -v`, a POSIX-mandated shell builtin that is available in any conformant shell and returns the same absolute path for executables found via the `PATH`, so existing setups are unaffected. Since `command -v` also resolves shell functions and aliases, we additionally reject results that are not absolute, as `orm.InstalledCode` would otherwise store them as a seemingly valid code that only fails on submission.