### PR TITLE
🐛 `PhCalculation`: fix `KeyError` on restart

### DIFF
--- a/src/aiida_quantumespresso/calculations/ph.py
+++ b/src/aiida_quantumespresso/calculations/ph.py
@@ -256,6 +256,9 @@ class PhCalculation(CalcJob):
         if not restart_flag:  # if it is a restart, it will be copied over
             folder.get_subfolder(self._FOLDER_DYNAMICAL_MATRIX, create=True)
 
+        # Determine this before writing the input file, since the namelists are popped from `parameters` there
+        electron_phonon = parameters['INPUTPH'].get('electron_phonon', None)
+
         with folder.open(self.metadata.options.input_filename, 'w') as infile:
             for namelist_name in namelists_toprint:
                 infile.write(f'&{namelist_name}\n')
@@ -329,7 +332,7 @@ class PhCalculation(CalcJob):
                         self._FOLDER_DYNAMICAL_MATRIX,
                     )
                 )
-                if parameters['INPUTPH'].get('electron_phonon', None) is not None:
+                if electron_phonon is not None:
                     remote_symlink_list.append(
                         (
                             parent_folder.computer.uuid,
@@ -353,7 +356,7 @@ class PhCalculation(CalcJob):
                         '.',
                     )
                 )
-                if parameters['INPUTPH'].get('electron_phonon', None) is not None:
+                if electron_phonon is not None:
                     remote_copy_list.append(
                         (
                             parent_folder.computer.uuid,

--- a/tests/calculations/test_ph.py
+++ b/tests/calculations/test_ph.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from aiida import orm
 from aiida.common import datastructures
 from aiida.plugins import CalculationFactory
@@ -69,6 +70,42 @@ def test_ph_initialization_only(fixture_sandbox, generate_inputs_ph, generate_ca
     inputs['settings'] = orm.Dict({'only_initialization': True})
     generate_calc_job(fixture_sandbox, entry_point_name, inputs)
     assert (Path(fixture_sandbox.abspath) / f'{PhCalculation._PREFIX}.EXIT').exists()
+
+
+@pytest.mark.parametrize('symlink', (True, False))
+@pytest.mark.parametrize('electron_phonon', (None, 'interpolated'))
+def test_ph_restart(
+    fixture_sandbox,
+    fixture_localhost,
+    generate_inputs_ph,
+    generate_calc_job,
+    generate_remote_data,
+    tmp_path,
+    symlink,
+    electron_phonon,
+):
+    """Test a ``PhCalculation`` that restarts from the ``parent_folder`` of another ``PhCalculation``.
+
+    The ``elph_dir`` folder should only be copied or symlinked if ``electron_phonon`` is set in the ``INPUTPH``
+    namelist.
+    """
+    entry_point_name = 'quantumespresso.ph'
+
+    inputs = generate_inputs_ph()
+    inputs['parent_folder'] = generate_remote_data(fixture_localhost, str(tmp_path), entry_point_name)
+    inputs['settings'] = orm.Dict({'parent_folder_symlink': symlink})
+
+    parameters = {'INPUTPH': {}}
+    if electron_phonon is not None:
+        parameters['INPUTPH']['electron_phonon'] = electron_phonon
+    inputs['parameters'] = orm.Dict(parameters)
+
+    calc_info = generate_calc_job(fixture_sandbox, entry_point_name, inputs)
+
+    remote_list = calc_info.remote_symlink_list if symlink else calc_info.remote_copy_list
+    targets = [target for _, _, target in remote_list]
+
+    assert (PhCalculation._FOLDER_ELECTRON_PHONON in targets) is (electron_phonon is not None)
 
 
 def test_serialize_builder(generate_inputs_ph, data_regression, serialize_builder):


### PR DESCRIPTION
Fixes #1212

When restarting from the `parent_folder` of another `PhCalculation`, the `elph_dir` folder is only copied or symlinked if the `electron_phonon` key is set in the `INPUTPH` namelist. This condition was evaluated on `parameters` after the input file had already been written, at which point the dictionary is empty: the namelists are popped from it while writing, and the check that immediately follows guarantees nothing is left over. Since `INPUTPH` is a compulsory namelist it is always popped, so _every_ restart raised a `KeyError`, in both the symlink and copy branches, whether or not `electron_phonon` was set.